### PR TITLE
Sql console improvements v3

### DIFF
--- a/src/components/db-console/active-tabs.tsx
+++ b/src/components/db-console/active-tabs.tsx
@@ -11,23 +11,49 @@ import {
 	TabsTrigger,
 } from "@health-samurai/react-components";
 import { generateId } from "../../utils";
+import { DEFAULT_TIMEOUT_SEC } from "./utils";
 
 export type SqlTabId = string;
+
+export interface SqlTabSettings {
+	rowLimit: number | null;
+	timeoutSec: number | null;
+	autocommit: boolean;
+	readOnly: boolean;
+	asyncMode: boolean;
+}
 
 export interface SqlTab {
 	id: SqlTabId;
 	query: string;
 	selected?: boolean;
+	// Per-tab execution settings. Optional for backward compat with tabs
+	// persisted before settings moved onto the tab; read via tabSettings()
+	// which fills in DEFAULT_SQL_TAB_SETTINGS for missing keys.
+	settings?: Partial<SqlTabSettings>;
 }
 
 const DEFAULT_QUERY = "select * from patient";
 
 export const DEFAULT_SQL_TAB_ID: SqlTabId = "sql-tab-default";
 
+export const DEFAULT_SQL_TAB_SETTINGS: SqlTabSettings = {
+	rowLimit: 10,
+	timeoutSec: DEFAULT_TIMEOUT_SEC,
+	autocommit: true,
+	readOnly: false,
+	asyncMode: false,
+};
+
+export function tabSettings(tab: SqlTab | undefined): SqlTabSettings {
+	return { ...DEFAULT_SQL_TAB_SETTINGS, ...(tab?.settings ?? {}) };
+}
+
 export const DEFAULT_SQL_TAB: SqlTab = {
 	id: DEFAULT_SQL_TAB_ID,
 	query: DEFAULT_QUERY,
 	selected: true,
+	settings: DEFAULT_SQL_TAB_SETTINGS,
 };
 
 export function addSqlTab(
@@ -38,6 +64,7 @@ export function addSqlTab(
 		id: generateId(),
 		query: DEFAULT_QUERY,
 		selected: true,
+		settings: DEFAULT_SQL_TAB_SETTINGS,
 	};
 	setTabs([...tabs.map((t) => ({ ...t, selected: false })), newTab]);
 	return newTab;

--- a/src/components/db-console/result-content.tsx
+++ b/src/components/db-console/result-content.tsx
@@ -381,7 +381,7 @@ export function LimitDropdown({
 					variant="link"
 					className="text-text-secondary bg-bg-tertiary rounded-full px-2.5 h-6"
 				>
-					<span className="text-text-tertiary uppercase">Limit</span>
+					<span className="text-text-tertiary uppercase">Fetch size</span>
 					<span className="text-text-secondary">
 						{rowLimit === null ? "No limit" : rowLimit}
 					</span>

--- a/src/components/db-console/result-content.tsx
+++ b/src/components/db-console/result-content.tsx
@@ -28,7 +28,7 @@ import {
 import type React from "react";
 import { useCallback, useMemo, useState } from "react";
 import type { QueryResultItem } from "../../webmcp/db-console-context";
-import { LIMIT_PRESETS } from "./utils";
+import { LIMIT_PRESETS, TIMEOUT_PRESETS } from "./utils";
 
 // ── JSON highlighting ──
 
@@ -397,6 +397,80 @@ export function LimitDropdown({
 				))}
 			</DropdownMenuContent>
 		</DropdownMenu>
+	);
+}
+
+export function TimeoutDropdown({
+	timeoutSec,
+	onTimeoutChange,
+}: {
+	timeoutSec: number | null;
+	onTimeoutChange: (timeout: number | null) => void;
+}) {
+	const currentLabel = useMemo(() => {
+		const preset = TIMEOUT_PRESETS.find((p) => p.value === timeoutSec);
+		if (preset) return preset.label;
+		return timeoutSec === null ? "No timeout" : `${timeoutSec}s`;
+	}, [timeoutSec]);
+
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<Button
+					variant="link"
+					className="text-text-secondary bg-bg-tertiary rounded-full px-2.5 h-6"
+				>
+					<span className="text-text-tertiary uppercase">Timeout</span>
+					<span className="text-text-secondary">{currentLabel}</span>
+					<ChevronDown className="size-3 text-text-tertiary" />
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="start">
+				{TIMEOUT_PRESETS.map((option) => (
+					<DropdownMenuItem
+						key={option.label}
+						onSelect={() => onTimeoutChange(option.value)}
+					>
+						{option.label}
+						{option.value === timeoutSec && (
+							<Check className="ml-auto size-4" />
+						)}
+					</DropdownMenuItem>
+				))}
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}
+
+export function AutocommitToggle({
+	autocommit,
+	onAutocommitChange,
+}: {
+	autocommit: boolean;
+	onAutocommitChange: (next: boolean) => void;
+}) {
+	return (
+		<Tooltip delayDuration={300}>
+			<TooltipTrigger asChild>
+				<Button
+					variant="link"
+					className={`rounded-full px-2.5 h-6 ${
+						autocommit
+							? "text-text-link bg-bg-tertiary"
+							: "text-text-secondary bg-bg-tertiary"
+					}`}
+					onClick={() => onAutocommitChange(!autocommit)}
+				>
+					<span className="text-text-tertiary uppercase">Tx</span>
+					<span>{autocommit ? "Autocommit" : "Transaction"}</span>
+				</Button>
+			</TooltipTrigger>
+			<TooltipContent side="bottom">
+				{autocommit
+					? "Each statement commits immediately. Required for VACUUM, CREATE INDEX CONCURRENTLY."
+					: "Wrap the whole script in a single transaction."}
+			</TooltipContent>
+		</Tooltip>
 	);
 }
 

--- a/src/components/db-console/result-content.tsx
+++ b/src/components/db-console/result-content.tsx
@@ -474,6 +474,38 @@ export function AutocommitToggle({
 	);
 }
 
+export function ReadOnlyToggle({
+	readOnly,
+	onReadOnlyChange,
+}: {
+	readOnly: boolean;
+	onReadOnlyChange: (next: boolean) => void;
+}) {
+	return (
+		<Tooltip delayDuration={300}>
+			<TooltipTrigger asChild>
+				<Button
+					variant="link"
+					className={`rounded-full px-2.5 h-6 ${
+						readOnly
+							? "text-text-link bg-bg-tertiary"
+							: "text-text-secondary bg-bg-tertiary"
+					}`}
+					onClick={() => onReadOnlyChange(!readOnly)}
+				>
+					<span className="text-text-tertiary uppercase">RO</span>
+					<span>{readOnly ? "Read-only" : "Read-write"}</span>
+				</Button>
+			</TooltipTrigger>
+			<TooltipContent side="bottom">
+				{readOnly
+					? "Writes and DDL rejected by the server."
+					: "Statements can modify data and schema."}
+			</TooltipContent>
+		</Tooltip>
+	);
+}
+
 export function ExportDropdown({
 	results,
 	disabled,

--- a/src/components/db-console/result-content.tsx
+++ b/src/components/db-console/result-content.tsx
@@ -506,6 +506,38 @@ export function ReadOnlyToggle({
 	);
 }
 
+export function AsyncToggle({
+	async,
+	onAsyncChange,
+}: {
+	async: boolean;
+	onAsyncChange: (next: boolean) => void;
+}) {
+	return (
+		<Tooltip delayDuration={300}>
+			<TooltipTrigger asChild>
+				<Button
+					variant="link"
+					className={`rounded-full px-2.5 h-6 ${
+						async
+							? "text-text-link bg-bg-tertiary"
+							: "text-text-secondary bg-bg-tertiary"
+					}`}
+					onClick={() => onAsyncChange(!async)}
+				>
+					<span className="text-text-tertiary uppercase">Mode</span>
+					<span>{async ? "Background" : "Foreground"}</span>
+				</Button>
+			</TooltipTrigger>
+			<TooltipContent side="bottom">
+				{async
+					? "Query runs server-side; UI polls for status. Closing the tab does not stop it."
+					: "Query runs synchronously; closing the tab aborts it."}
+			</TooltipContent>
+		</Tooltip>
+	);
+}
+
 export function ExportDropdown({
 	results,
 	disabled,

--- a/src/components/db-console/result-content.tsx
+++ b/src/components/db-console/result-content.tsx
@@ -250,6 +250,9 @@ function QueryResult({
 }) {
 	const rows = result.result ?? [];
 	const columns = extractColumns(rows);
+	const isExplain =
+		columns.length === 1 && columns[0]?.toLowerCase() === "query plan";
+	const explainColumn = isExplain ? columns[0] : undefined;
 
 	if (result.error) {
 		return (
@@ -285,6 +288,12 @@ function QueryResult({
 						<div className="text-lg mb-2">No results</div>
 						<div className="text-sm">Query returned no rows</div>
 					</div>
+				</div>
+			) : isExplain && explainColumn ? (
+				<div className="flex-1 overflow-auto min-h-0 p-4">
+					<pre className="typo-code whitespace-pre text-text-primary">
+						{rows.map((row) => String(row[explainColumn] ?? "")).join("\n")}
+					</pre>
 				</div>
 			) : viewMode === "list" ? (
 				<div className="flex-1 overflow-auto min-h-0 divide-y divide-border-secondary">

--- a/src/components/db-console/result-panel.tsx
+++ b/src/components/db-console/result-panel.tsx
@@ -18,6 +18,7 @@ import { ExportDropdown, ResultContent } from "./result-content";
 export function ResultPanel({
 	results,
 	error,
+	asyncStarted,
 	isLoading,
 	onRun,
 	onCancel,
@@ -28,6 +29,7 @@ export function ResultPanel({
 }: {
 	results: QueryResultItem[] | null;
 	error: string | null;
+	asyncStarted?: { operationId: string; startedAt: number };
 	isLoading: boolean;
 	onRun: () => void;
 	onCancel: () => void;
@@ -135,16 +137,29 @@ export function ResultPanel({
 					</Tooltip>
 				</div>
 			</div>
-			{!collapsed && (
-				<ResultContent
-					results={results}
-					error={error}
-					isLoading={isLoading}
-					onRun={onRun}
-					onCancel={onCancel}
-					viewMode={viewMode}
-				/>
-			)}
+			{!collapsed &&
+				(asyncStarted ? (
+					<div className="flex-1 flex items-center justify-center bg-bg-secondary">
+						<div className="text-center px-6 py-8">
+							<div className="typo-label text-text-primary mb-2">
+								Query started in background
+							</div>
+							<div className="typo-body-xs text-text-secondary">
+								Operation ID:{" "}
+								<span className="typo-code">{asyncStarted.operationId}</span>
+							</div>
+						</div>
+					</div>
+				) : (
+					<ResultContent
+						results={results}
+						error={error}
+						isLoading={isLoading}
+						onRun={onRun}
+						onCancel={onCancel}
+						viewMode={viewMode}
+					/>
+				))}
 		</div>
 	);
 }

--- a/src/components/db-console/tables-view.tsx
+++ b/src/components/db-console/tables-view.tsx
@@ -93,7 +93,7 @@ export function psqlRequest<T = Record<string, unknown>>(
 	return client
 		.rawRequest({
 			method: "POST",
-			url: "/$notebook-psql",
+			url: "/$psql",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({ query }),
 		})

--- a/src/components/db-console/utils.ts
+++ b/src/components/db-console/utils.ts
@@ -11,13 +11,6 @@ export type FunctionsMap = Record<string, FunctionEntry[]>;
 
 export const LIMIT_PRESETS = [10, 100, 1000];
 
-export function splitSqlStatements(query: string): string[] {
-	return query
-		.split(/\n----\n/)
-		.map((s) => s.trim())
-		.filter(Boolean);
-}
-
 export function isAidboxError(
 	err: unknown,
 ): err is { response: { text(): Promise<string> } } {

--- a/src/components/db-console/utils.ts
+++ b/src/components/db-console/utils.ts
@@ -11,6 +11,17 @@ export type FunctionsMap = Record<string, FunctionEntry[]>;
 
 export const LIMIT_PRESETS = [10, 100, 1000];
 
+export const TIMEOUT_PRESETS: { value: number | null; label: string }[] = [
+	{ value: 5, label: "5s" },
+	{ value: 30, label: "30s" },
+	{ value: 60, label: "1m" },
+	{ value: 300, label: "5m" },
+	{ value: 900, label: "15m" },
+	{ value: null, label: "No timeout" },
+];
+
+export const DEFAULT_TIMEOUT_SEC = 60;
+
 export function isAidboxError(
 	err: unknown,
 ): err is { response: { text(): Promise<string> } } {

--- a/src/layout/sidebar.tsx
+++ b/src/layout/sidebar.tsx
@@ -59,7 +59,7 @@ const mainMenuItems: {
 		url: "/db-console",
 		title: "SQL console",
 		link: (
-			<Link to="/db-console">
+			<Link to="/db-console" search={{ query: undefined }}>
 				<Database />
 				SQL console
 			</Link>

--- a/src/routes/db-console.tsx
+++ b/src/routes/db-console.tsx
@@ -136,40 +136,6 @@ async function kickOffAsync(
 	return id;
 }
 
-type AsyncStatus =
-	| { status: "in-progress" }
-	| { status: "completed"; result: unknown }
-	| { status: "failed"; error: string }
-	| { status: "not-found" };
-
-async function fetchAsyncStatus(
-	baseUrl: string,
-	operationId: string,
-	signal: AbortSignal,
-): Promise<AsyncStatus> {
-	const response = await fetch(
-		`${baseUrl}/$psql/operations/${encodeURIComponent(operationId)}`,
-		{
-			method: "GET",
-			headers: { Accept: "application/json" },
-			credentials: "include",
-			signal,
-		},
-	);
-	if (response.status === 404) return { status: "not-found" };
-	return (await response.json()) as AsyncStatus;
-}
-
-async function cancelAsync(
-	baseUrl: string,
-	operationId: string,
-): Promise<void> {
-	await fetch(
-		`${baseUrl}/$psql/operations/${encodeURIComponent(operationId)}`,
-		{ method: "DELETE", credentials: "include" },
-	);
-}
-
 const TABLES_QUERY = `SELECT table_schema, table_name, table_type FROM information_schema.tables WHERE table_schema NOT IN ('pg_catalog', 'information_schema', 'pgagent') AND table_type IN ('BASE TABLE', 'VIEW') ORDER BY table_schema, table_name`;
 
 const FUNCTIONS_QUERY = `SELECT n.nspname AS function_schema, p.proname AS function_name, pg_get_function_identity_arguments(p.oid) AS arguments, CASE p.prokind WHEN 'f' THEN 'function' WHEN 'p' THEN 'procedure' WHEN 'a' THEN 'aggregate' WHEN 'w' THEN 'window' END AS function_type, t.typname AS return_type FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace JOIN pg_type t ON t.oid = p.prorettype WHERE n.nspname NOT IN ('pg_catalog', 'information_schema', 'pgagent') ORDER BY n.nspname, p.proname`;
@@ -187,6 +153,9 @@ export const Route = createFileRoute("/db-console")({
 type TabResultData = {
 	results: QueryResultItem[] | null;
 	error: string | null;
+	// Fire-and-forget async: set once on kick-off, shown as a one-shot
+	// confirmation. No polling, no result surfacing.
+	asyncStarted?: { operationId: string; startedAt: number };
 };
 
 /** Extract a human-readable error message from a caught error. */
@@ -363,6 +332,7 @@ function DbConsolePage() {
 	const currentResult = tabResults.get(selectedTab?.id ?? "");
 	const results = currentResult?.results ?? null;
 	const error = currentResult?.error ?? null;
+	const asyncStarted = currentResult?.asyncStarted;
 
 	const queryRef = useRef(query);
 	queryRef.current = query;
@@ -387,9 +357,7 @@ function DbConsolePage() {
 
 	const cancelledTabRef = useRef<string | null>(null);
 	const runningQueryIdRef = useRef<string | null>(null);
-	const runningOperationIdRef = useRef<string | null>(null);
 	const abortControllerRef = useRef<AbortController | null>(null);
-	const pollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
 	const handleQueryChange = useCallback(
 		(value: string) => {
@@ -408,60 +376,6 @@ function DbConsolePage() {
 		});
 	}, []);
 
-	const stopPolling = useCallback(() => {
-		if (pollTimeoutRef.current !== null) {
-			clearTimeout(pollTimeoutRef.current);
-			pollTimeoutRef.current = null;
-		}
-	}, []);
-
-	const pollAsync = useCallback(
-		(tabId: string, operationId: string, queryToSave: string) => {
-			const baseUrl = client.getBaseUrl();
-			const tick = async () => {
-				if (cancelledTabRef.current === tabId) return;
-				try {
-					const status = await fetchAsyncStatus(
-						baseUrl,
-						operationId,
-						new AbortController().signal,
-					);
-					if (cancelledTabRef.current === tabId) return;
-					if (status.status === "in-progress") {
-						pollTimeoutRef.current = setTimeout(tick, 1000);
-						return;
-					}
-					stopPolling();
-					runningOperationIdRef.current = null;
-					setIsLoading(false);
-					if (status.status === "completed") {
-						const items = transformToQueryResultItems(
-							status.result as Parameters<
-								typeof transformToQueryResultItems
-							>[0],
-						);
-						if (!items.some((item) => item.error)) {
-							saveSqlHistory(queryToSave, queryClient, client);
-						}
-						updateTabResult(tabId, { results: items, error: null });
-					} else if (status.status === "failed") {
-						updateTabResult(tabId, { results: null, error: status.error });
-					} else {
-						updateTabResult(tabId, {
-							results: null,
-							error: "Async operation not found",
-						});
-					}
-				} catch {
-					// transient network error — keep polling
-					pollTimeoutRef.current = setTimeout(tick, 1000);
-				}
-			};
-			tick();
-		},
-		[client, queryClient, stopPolling, updateTabResult],
-	);
-
 	const executeQuery = useCallback(
 		async (overrideQuery?: string) => {
 			if (overrideQuery !== undefined) {
@@ -477,14 +391,12 @@ function DbConsolePage() {
 			}
 
 			abortControllerRef.current?.abort();
-			stopPolling();
 			const controller = new AbortController();
 			abortControllerRef.current = controller;
 
 			const queryId = generateId();
 			cancelledTabRef.current = null;
 			runningQueryIdRef.current = queryId;
-			runningOperationIdRef.current = null;
 			setIsLoading(true);
 			const queryToSave = queryRef.current;
 			updateTabResult(tabId, { results: null, error: null });
@@ -500,6 +412,8 @@ function DbConsolePage() {
 				const baseUrl = client.getBaseUrl();
 
 				if (asyncModeRef.current) {
+					// Fire-and-forget: kick off, confirm, don't poll. Results
+					// live on the server; background jobs execute on their own.
 					const operationId = await kickOffAsync(
 						baseUrl,
 						rawQuery,
@@ -508,8 +422,12 @@ function DbConsolePage() {
 						runOpts,
 					);
 					if (cancelledTabRef.current === tabId) return;
-					runningOperationIdRef.current = operationId;
-					pollAsync(tabId, operationId, queryToSave);
+					saveSqlHistory(queryToSave, queryClient, client);
+					updateTabResult(tabId, {
+						results: null,
+						error: null,
+						asyncStarted: { operationId, startedAt: Date.now() },
+					});
 					return;
 				}
 
@@ -536,19 +454,12 @@ function DbConsolePage() {
 				updateTabResult(tabId, { results: null, error: errorMsg });
 			} finally {
 				runningQueryIdRef.current = null;
-				if (!asyncModeRef.current && cancelledTabRef.current !== tabId) {
+				if (cancelledTabRef.current !== tabId) {
 					setIsLoading(false);
 				}
 			}
 		},
-		[
-			client,
-			queryClient,
-			handleQueryChange,
-			updateTabResult,
-			pollAsync,
-			stopPolling,
-		],
+		[client, queryClient, handleQueryChange, updateTabResult],
 	);
 
 	const cancelQuery = useCallback(async () => {
@@ -557,32 +468,26 @@ function DbConsolePage() {
 
 		abortControllerRef.current?.abort();
 		abortControllerRef.current = null;
-		stopPolling();
 
 		const queryId = runningQueryIdRef.current;
-		const operationId = runningOperationIdRef.current;
 		cancelledTabRef.current = tabId;
 		runningQueryIdRef.current = null;
-		runningOperationIdRef.current = null;
 		setIsLoading(false);
 		updateTabResult(tabId, { results: null, error: "Query cancelled" });
 
-		const baseUrl = client.getBaseUrl();
-		try {
-			if (operationId) {
-				await cancelAsync(baseUrl, operationId);
-			} else if (queryId) {
+		if (queryId) {
+			try {
 				await client.rawRequest({
 					method: "POST",
 					url: "/$psql-cancel",
 					headers: { "Content-Type": "application/json" },
 					body: JSON.stringify({ "query-id": queryId }),
 				});
+			} catch {
+				// best-effort cancel
 			}
-		} catch {
-			// best-effort cancel
 		}
-	}, [client, stopPolling, updateTabResult]);
+	}, [client, updateTabResult]);
 
 	const { data: historyData } = useSqlHistory();
 
@@ -1023,7 +928,7 @@ function DbConsolePage() {
 								</div>
 							</ResizablePanel>
 
-							{(results || error || isLoading) && (
+							{(results || error || asyncStarted || isLoading) && (
 								<>
 									<ResizableHandle />
 
@@ -1040,6 +945,7 @@ function DbConsolePage() {
 											key={selectedTab?.id}
 											results={results}
 											error={error}
+											asyncStarted={asyncStarted}
 											isLoading={isLoading}
 											onRun={executeQuery}
 											onCancel={cancelQuery}

--- a/src/routes/db-console.tsx
+++ b/src/routes/db-console.tsx
@@ -1,4 +1,4 @@
-import { indentWithTab } from "@codemirror/commands";
+import { indentLess, insertTab } from "@codemirror/commands";
 import { Prec } from "@codemirror/state";
 import { type EditorView, keymap } from "@codemirror/view";
 import {
@@ -645,7 +645,9 @@ function DbConsolePage() {
 							return true;
 						},
 					},
-					indentWithTab,
+					// Tab inserts a literal tab at the cursor (or indents the
+					// selection if multi-line). Shift-Tab unindents.
+					{ key: "Tab", run: insertTab, shift: indentLess },
 				]),
 			),
 		],

--- a/src/routes/db-console.tsx
+++ b/src/routes/db-console.tsx
@@ -966,10 +966,13 @@ function DbConsolePage() {
 												autocommit={autocommit}
 												onAutocommitChange={setAutocommit}
 											/>
-											<ReadOnlyToggle
-												readOnly={readOnly}
-												onReadOnlyChange={setReadOnly}
-											/>
+											{/* Read-only toggle hidden — keep state wired so behavior stays on the default (read-write). Re-enable when product decides to expose it. */}
+											{false && (
+												<ReadOnlyToggle
+													readOnly={readOnly}
+													onReadOnlyChange={setReadOnly}
+												/>
+											)}
 											<AsyncToggle
 												async={asyncMode}
 												onAsyncChange={setAsyncMode}

--- a/src/routes/db-console.tsx
+++ b/src/routes/db-console.tsx
@@ -309,7 +309,7 @@ function DbConsolePage() {
 	});
 	const [autocommit, setAutocommit] = useLocalStorage<boolean>({
 		key: "db-console-autocommit",
-		defaultValue: false,
+		defaultValue: true,
 		getInitialValueInEffect: false,
 	});
 	const [readOnly, setReadOnly] = useLocalStorage<boolean>({

--- a/src/routes/db-console.tsx
+++ b/src/routes/db-console.tsx
@@ -178,6 +178,10 @@ export const Route = createFileRoute("/db-console")({
 	component: DbConsolePage,
 	staticData: { title: TITLE },
 	loader: () => ({ breadCrumb: TITLE }),
+	// Accept `?query=...` so legacy /ui/db?query=... links preload SQL.
+	validateSearch: (search: Record<string, unknown>) => ({
+		query: typeof search.query === "string" ? search.query : undefined,
+	}),
 });
 
 type TabResultData = {
@@ -258,6 +262,7 @@ function DbConsolePage() {
 	const queryClient = useQueryClient();
 	const { schemas, functions } = useDbConsoleData();
 	const vimMode = useVimMode();
+	const search = Route.useSearch();
 
 	const sqlConfig = useMemo<SqlConfig>(
 		() => ({
@@ -273,6 +278,28 @@ function DbConsolePage() {
 		defaultValue: [DEFAULT_SQL_TAB],
 		getInitialValueInEffect: false,
 	});
+
+	// If the page was opened via /u/db-console?query=..., preload a tab with
+	// that SQL. Keeps legacy /ui/db?query=... links working after redirect.
+	const appliedQueryRef = useRef(false);
+	useEffect(() => {
+		if (appliedQueryRef.current) return;
+		const incoming = search.query;
+		if (!incoming) return;
+		appliedQueryRef.current = true;
+		setTabs((prev) => {
+			const existing = prev.find((t) => t.query === incoming);
+			if (existing) {
+				return prev.map((t) => ({ ...t, selected: t.id === existing.id }));
+			}
+			const newTab: SqlTab = {
+				id: generateId(),
+				query: incoming,
+				selected: true,
+			};
+			return [...prev.map((t) => ({ ...t, selected: false })), newTab];
+		});
+	}, [search.query, setTabs]);
 	const [leftMenuOpen, setLeftMenuOpen] = useLocalStorage<boolean>({
 		key: "db-console-left-menu-open",
 		defaultValue: true,

--- a/src/routes/db-console.tsx
+++ b/src/routes/db-console.tsx
@@ -32,7 +32,11 @@ import {
 	SqlLeftMenuContext,
 	SqlLeftMenuToggle,
 } from "../components/db-console/left-menu";
-import { LimitDropdown } from "../components/db-console/result-content";
+import {
+	AutocommitToggle,
+	LimitDropdown,
+	TimeoutDropdown,
+} from "../components/db-console/result-content";
 import { ResultPanel } from "../components/db-console/result-panel";
 import {
 	extractIndexType,
@@ -42,6 +46,7 @@ import {
 	transformToQueryResultItems,
 } from "../components/db-console/tables-view";
 import {
+	DEFAULT_TIMEOUT_SEC,
 	type FunctionsMap,
 	isAidboxError,
 	type SchemaMap,
@@ -62,15 +67,20 @@ async function fetchBlock(
 	block: string,
 	limit: number | null,
 	signal: AbortSignal,
+	opts: { autocommit: boolean; timeoutSec: number | null },
 ): Promise<QueryResultItem[]> {
 	const body: { query: string; limit?: number } = { query: block };
 	if (limit !== null) body.limit = limit;
+	const headers: Record<string, string> = {
+		"Content-Type": "application/json",
+		Accept: "application/json",
+	};
+	if (opts.autocommit) headers["X-Aidbox-Sql-Autocommit"] = "true";
+	if (opts.timeoutSec !== null)
+		headers["X-Aidbox-Sql-Timeout"] = String(opts.timeoutSec);
 	const response = await fetch(`${baseUrl}/$notebook-psql`, {
 		method: "POST",
-		headers: {
-			"Content-Type": "application/json",
-			Accept: "application/json",
-		},
+		headers,
 		credentials: "include",
 		body: JSON.stringify(body),
 		signal,
@@ -214,6 +224,16 @@ function DbConsolePage() {
 		defaultValue: 10,
 		getInitialValueInEffect: false,
 	});
+	const [timeoutSec, setTimeoutSec] = useLocalStorage<number | null>({
+		key: "db-console-timeout-sec",
+		defaultValue: DEFAULT_TIMEOUT_SEC,
+		getInitialValueInEffect: false,
+	});
+	const [autocommit, setAutocommit] = useLocalStorage<boolean>({
+		key: "db-console-autocommit",
+		defaultValue: false,
+		getInitialValueInEffect: false,
+	});
 	const leftPanelRef = useRef<ImperativePanelHandle>(null);
 	const resultPanelRef = useRef<ImperativePanelHandle>(null);
 	const initialLeftMenuOpen = useRef(leftMenuOpen);
@@ -237,6 +257,12 @@ function DbConsolePage() {
 
 	const rowLimitRef = useRef(rowLimit);
 	rowLimitRef.current = rowLimit;
+
+	const timeoutRef = useRef(timeoutSec);
+	timeoutRef.current = timeoutSec;
+
+	const autocommitRef = useRef(autocommit);
+	autocommitRef.current = autocommit;
 
 	const cancelledTabRef = useRef<string | null>(null);
 	const runningQueryRef = useRef<string | null>(null);
@@ -290,6 +316,10 @@ function DbConsolePage() {
 					rawQuery,
 					rowLimitRef.current,
 					controller.signal,
+					{
+						autocommit: autocommitRef.current,
+						timeoutSec: timeoutRef.current,
+					},
 				);
 
 				if (cancelledTabRef.current === tabId) return;
@@ -740,10 +770,18 @@ function DbConsolePage() {
 												</Tooltip>
 											)}
 										</div>
-										<div>
+										<div className="flex items-center gap-2">
 											<LimitDropdown
 												rowLimit={rowLimit}
 												onRowLimitChange={setRowLimit}
+											/>
+											<TimeoutDropdown
+												timeoutSec={timeoutSec}
+												onTimeoutChange={setTimeoutSec}
+											/>
+											<AutocommitToggle
+												autocommit={autocommit}
+												onAutocommitChange={setAutocommit}
 											/>
 										</div>
 									</div>

--- a/src/routes/db-console.tsx
+++ b/src/routes/db-console.tsx
@@ -45,7 +45,6 @@ import {
 	type FunctionsMap,
 	isAidboxError,
 	type SchemaMap,
-	splitSqlStatements,
 } from "../components/db-console/utils";
 import { useLocalStorage } from "../hooks";
 import { useVimMode } from "../shared/vim-mode";
@@ -286,20 +285,14 @@ function DbConsolePage() {
 
 			try {
 				const baseUrl = client.getBaseUrl();
-				const blocks = splitSqlStatements(rawQuery);
-				const allItems: QueryResultItem[] = [];
+				const allItems = await fetchBlock(
+					baseUrl,
+					rawQuery,
+					rowLimitRef.current,
+					controller.signal,
+				);
 
-				for (const block of blocks) {
-					if (cancelledTabRef.current === tabId) return;
-					allItems.push(
-						...(await fetchBlock(
-							baseUrl,
-							block,
-							rowLimitRef.current,
-							controller.signal,
-						)),
-					);
-				}
+				if (cancelledTabRef.current === tabId) return;
 
 				if (!allItems.some((item) => item.error)) {
 					saveSqlHistory(queryToSave, queryClient, client);

--- a/src/routes/db-console.tsx
+++ b/src/routes/db-console.tsx
@@ -4,9 +4,12 @@ import { type EditorView, keymap } from "@codemirror/view";
 import {
 	Button,
 	CodeEditor,
+	Label,
 	Popover,
 	PopoverContent,
 	PopoverTrigger,
+	RadioGroup,
+	RadioGroupItem,
 	ResizableHandle,
 	ResizablePanel,
 	ResizablePanelGroup,
@@ -36,13 +39,7 @@ import {
 	SqlLeftMenuContext,
 	SqlLeftMenuToggle,
 } from "../components/db-console/left-menu";
-import {
-	AsyncToggle,
-	AutocommitToggle,
-	LimitDropdown,
-	ReadOnlyToggle,
-	TimeoutDropdown,
-} from "../components/db-console/result-content";
+import { LimitDropdown } from "../components/db-console/result-content";
 import { ResultPanel } from "../components/db-console/result-panel";
 import {
 	extractIndexType,
@@ -56,6 +53,7 @@ import {
 	type FunctionsMap,
 	isAidboxError,
 	type SchemaMap,
+	TIMEOUT_PRESETS,
 } from "../components/db-console/utils";
 import { useLocalStorage } from "../hooks";
 import { useVimMode } from "../shared/vim-mode";
@@ -318,7 +316,10 @@ function DbConsolePage() {
 		defaultValue: true,
 		getInitialValueInEffect: false,
 	});
-	const [readOnly, setReadOnly] = useLocalStorage<boolean>({
+	// Read-only mode state is wired through to the backend headers but the UI
+	// toggle is hidden for now — see Hide read-only toggle commit. Value stays
+	// at the default (false / read-write).
+	const [readOnly, _setReadOnly] = useLocalStorage<boolean>({
 		key: "db-console-read-only",
 		defaultValue: false,
 		getInitialValueInEffect: false,
@@ -936,27 +937,118 @@ function DbConsolePage() {
 												</Tooltip>
 												<PopoverContent
 													align="start"
-													className="w-auto p-3 flex flex-col gap-2"
+													className="w-72 p-0 divide-y divide-border-secondary"
 												>
-													<TimeoutDropdown
-														timeoutSec={timeoutSec}
-														onTimeoutChange={setTimeoutSec}
-													/>
-													<AutocommitToggle
-														autocommit={autocommit}
-														onAutocommitChange={setAutocommit}
-													/>
-													{/* Read-only toggle hidden — keep state wired so behavior stays on the default (read-write). Re-enable when product decides to expose it. */}
-													{false && (
-														<ReadOnlyToggle
-															readOnly={readOnly}
-															onReadOnlyChange={setReadOnly}
-														/>
-													)}
-													<AsyncToggle
-														async={asyncMode}
-														onAsyncChange={setAsyncMode}
-													/>
+													<section className="p-4 space-y-2">
+														<Label className="typo-label-xs text-text-tertiary uppercase">
+															Timeout
+														</Label>
+														<RadioGroup
+															value={
+																timeoutSec === null
+																	? "none"
+																	: String(timeoutSec)
+															}
+															onValueChange={(v) =>
+																setTimeoutSec(v === "none" ? null : Number(v))
+															}
+															className="gap-1.5"
+														>
+															{TIMEOUT_PRESETS.map((p) => {
+																const val =
+																	p.value === null ? "none" : String(p.value);
+																return (
+																	<Label
+																		key={val}
+																		className="flex items-center gap-2 text-sm cursor-pointer"
+																	>
+																		<RadioGroupItem value={val} />
+																		{p.label}
+																	</Label>
+																);
+															})}
+														</RadioGroup>
+													</section>
+
+													<section className="p-4 space-y-2">
+														<Label className="typo-label-xs text-text-tertiary uppercase">
+															Transaction mode
+														</Label>
+														<RadioGroup
+															value={autocommit ? "autocommit" : "transaction"}
+															onValueChange={(v) =>
+																setAutocommit(v === "autocommit")
+															}
+															className="gap-1.5"
+														>
+															<Label className="flex items-start gap-2 text-sm cursor-pointer">
+																<RadioGroupItem
+																	value="autocommit"
+																	className="mt-0.5"
+																/>
+																<div>
+																	<div>Autocommit</div>
+																	<div className="text-xs text-text-secondary">
+																		Each statement commits immediately. Required
+																		for VACUUM, CREATE INDEX CONCURRENTLY.
+																	</div>
+																</div>
+															</Label>
+															<Label className="flex items-start gap-2 text-sm cursor-pointer">
+																<RadioGroupItem
+																	value="transaction"
+																	className="mt-0.5"
+																/>
+																<div>
+																	<div>Transaction</div>
+																	<div className="text-xs text-text-secondary">
+																		Wrap the whole script in a single
+																		transaction.
+																	</div>
+																</div>
+															</Label>
+														</RadioGroup>
+													</section>
+
+													<section className="p-4 space-y-2">
+														<Label className="typo-label-xs text-text-tertiary uppercase">
+															Execution
+														</Label>
+														<RadioGroup
+															value={asyncMode ? "background" : "foreground"}
+															onValueChange={(v) =>
+																setAsyncMode(v === "background")
+															}
+															className="gap-1.5"
+														>
+															<Label className="flex items-start gap-2 text-sm cursor-pointer">
+																<RadioGroupItem
+																	value="foreground"
+																	className="mt-0.5"
+																/>
+																<div>
+																	<div>Foreground</div>
+																	<div className="text-xs text-text-secondary">
+																		Run synchronously; closing the tab aborts
+																		it.
+																	</div>
+																</div>
+															</Label>
+															<Label className="flex items-start gap-2 text-sm cursor-pointer">
+																<RadioGroupItem
+																	value="background"
+																	className="mt-0.5"
+																/>
+																<div>
+																	<div>Background</div>
+																	<div className="text-xs text-text-secondary">
+																		Fire-and-forget on the server. No result
+																		returned to the UI.
+																	</div>
+																</div>
+															</Label>
+														</RadioGroup>
+													</section>
 												</PopoverContent>
 											</Popover>
 										</div>

--- a/src/routes/db-console.tsx
+++ b/src/routes/db-console.tsx
@@ -1,3 +1,4 @@
+import { indentWithTab } from "@codemirror/commands";
 import { Prec } from "@codemirror/state";
 import { type EditorView, keymap } from "@codemirror/view";
 import {
@@ -674,6 +675,7 @@ function DbConsolePage() {
 							return true;
 						},
 					},
+					indentWithTab,
 				]),
 			),
 		],

--- a/src/routes/db-console.tsx
+++ b/src/routes/db-console.tsx
@@ -1,6 +1,6 @@
 import { indentLess, insertTab } from "@codemirror/commands";
 import { Prec } from "@codemirror/state";
-import { type EditorView, keymap } from "@codemirror/view";
+import { type Command, type EditorView, keymap } from "@codemirror/view";
 import {
 	Button,
 	CodeEditor,
@@ -69,6 +69,25 @@ import type {
 import { useWebMCPSql } from "../webmcp/sql";
 
 const TITLE = "SQL console";
+
+/**
+ * Shift-Tab handler that de-indents only when the cursor is in the leading
+ * whitespace of the current line (or the line is empty / whitespace-only).
+ * Outdenting from the middle of a token is rarely what users want, so consume
+ * the keystroke as a no-op in that case. Multi-line selections always de-indent.
+ */
+const smartIndentLess: Command = (view) => {
+	const { state } = view;
+	const sel = state.selection.main;
+	if (!sel.empty) return indentLess(view);
+	const line = state.doc.lineAt(sel.head);
+	const firstNonWs = line.text.search(/\S/);
+	const cursorCol = sel.head - line.from;
+	if (firstNonWs === -1 || cursorCol <= firstNonWs) {
+		return indentLess(view);
+	}
+	return true;
+};
 
 type SqlRunOpts = {
 	autocommit: boolean;
@@ -646,8 +665,11 @@ function DbConsolePage() {
 						},
 					},
 					// Tab inserts a literal tab at the cursor (or indents the
-					// selection if multi-line). Shift-Tab unindents.
-					{ key: "Tab", run: insertTab, shift: indentLess },
+					// selection if multi-line). Shift-Tab de-indents the line
+					// only when the cursor sits in its leading whitespace
+					// (logical start of the line) — otherwise it's a no-op so
+					// users mid-token don't accidentally outdent.
+					{ key: "Tab", run: insertTab, shift: smartIndentLess },
 				]),
 			),
 		],

--- a/src/routes/db-console.tsx
+++ b/src/routes/db-console.tsx
@@ -35,6 +35,7 @@ import {
 import {
 	AutocommitToggle,
 	LimitDropdown,
+	ReadOnlyToggle,
 	TimeoutDropdown,
 } from "../components/db-console/result-content";
 import { ResultPanel } from "../components/db-console/result-panel";
@@ -67,7 +68,11 @@ async function fetchBlock(
 	block: string,
 	limit: number | null,
 	signal: AbortSignal,
-	opts: { autocommit: boolean; timeoutSec: number | null },
+	opts: {
+		autocommit: boolean;
+		timeoutSec: number | null;
+		readOnly: boolean;
+	},
 ): Promise<QueryResultItem[]> {
 	const body: { query: string; limit?: number } = { query: block };
 	if (limit !== null) body.limit = limit;
@@ -78,6 +83,7 @@ async function fetchBlock(
 	if (opts.autocommit) headers["X-Aidbox-Sql-Autocommit"] = "true";
 	if (opts.timeoutSec !== null)
 		headers["X-Aidbox-Sql-Timeout"] = String(opts.timeoutSec);
+	if (opts.readOnly) headers["X-Aidbox-Sql-Read-Only"] = "true";
 	const response = await fetch(`${baseUrl}/$notebook-psql`, {
 		method: "POST",
 		headers,
@@ -234,6 +240,11 @@ function DbConsolePage() {
 		defaultValue: false,
 		getInitialValueInEffect: false,
 	});
+	const [readOnly, setReadOnly] = useLocalStorage<boolean>({
+		key: "db-console-read-only",
+		defaultValue: false,
+		getInitialValueInEffect: false,
+	});
 	const leftPanelRef = useRef<ImperativePanelHandle>(null);
 	const resultPanelRef = useRef<ImperativePanelHandle>(null);
 	const initialLeftMenuOpen = useRef(leftMenuOpen);
@@ -263,6 +274,9 @@ function DbConsolePage() {
 
 	const autocommitRef = useRef(autocommit);
 	autocommitRef.current = autocommit;
+
+	const readOnlyRef = useRef(readOnly);
+	readOnlyRef.current = readOnly;
 
 	const cancelledTabRef = useRef<string | null>(null);
 	const runningQueryRef = useRef<string | null>(null);
@@ -319,6 +333,7 @@ function DbConsolePage() {
 					{
 						autocommit: autocommitRef.current,
 						timeoutSec: timeoutRef.current,
+						readOnly: readOnlyRef.current,
 					},
 				);
 
@@ -782,6 +797,10 @@ function DbConsolePage() {
 											<AutocommitToggle
 												autocommit={autocommit}
 												onAutocommitChange={setAutocommit}
+											/>
+											<ReadOnlyToggle
+												readOnly={readOnly}
+												onReadOnlyChange={setReadOnly}
 											/>
 										</div>
 									</div>

--- a/src/routes/db-console.tsx
+++ b/src/routes/db-console.tsx
@@ -4,12 +4,16 @@ import { type EditorView, keymap } from "@codemirror/view";
 import {
 	Button,
 	CodeEditor,
-	Label,
-	Popover,
-	PopoverContent,
-	PopoverTrigger,
-	RadioGroup,
-	RadioGroupItem,
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuLabel,
+	DropdownMenuRadioGroup,
+	DropdownMenuRadioItem,
+	DropdownMenuSeparator,
+	DropdownMenuSub,
+	DropdownMenuSubContent,
+	DropdownMenuSubTrigger,
+	DropdownMenuTrigger,
 	ResizableHandle,
 	ResizablePanel,
 	ResizablePanelGroup,
@@ -919,138 +923,99 @@ function DbConsolePage() {
 												rowLimit={rowLimit}
 												onRowLimitChange={setRowLimit}
 											/>
-											<Popover>
+											<DropdownMenu>
 												<Tooltip delayDuration={300}>
 													<TooltipTrigger asChild>
-														<PopoverTrigger asChild>
+														<DropdownMenuTrigger asChild>
 															<Button
 																variant="link"
 																className="text-text-secondary bg-bg-tertiary rounded-full px-2 h-6"
 															>
 																<Settings2 className="size-3.5" />
 															</Button>
-														</PopoverTrigger>
+														</DropdownMenuTrigger>
 													</TooltipTrigger>
 													<TooltipContent side="bottom">
 														SQL execution settings
 													</TooltipContent>
 												</Tooltip>
-												<PopoverContent
-													align="start"
-													className="w-72 p-0 divide-y divide-border-secondary"
-												>
-													<section className="p-4 space-y-2">
-														<Label className="typo-label-xs text-text-tertiary uppercase">
-															Timeout
-														</Label>
-														<RadioGroup
-															value={
-																timeoutSec === null
-																	? "none"
-																	: String(timeoutSec)
-															}
-															onValueChange={(v) =>
-																setTimeoutSec(v === "none" ? null : Number(v))
-															}
-															className="gap-1.5"
-														>
-															{TIMEOUT_PRESETS.map((p) => {
-																const val =
-																	p.value === null ? "none" : String(p.value);
-																return (
-																	<Label
-																		key={val}
-																		className="flex items-center gap-2 text-sm cursor-pointer"
-																	>
-																		<RadioGroupItem value={val} />
-																		{p.label}
-																	</Label>
-																);
-															})}
-														</RadioGroup>
-													</section>
+												<DropdownMenuContent align="start" className="w-56">
+													<DropdownMenuSub>
+														<DropdownMenuSubTrigger>
+															<span className="flex-1">Timeout</span>
+															<span className="text-text-tertiary">
+																{TIMEOUT_PRESETS.find(
+																	(p) => p.value === timeoutSec,
+																)?.label ??
+																	(timeoutSec === null
+																		? "No timeout"
+																		: `${timeoutSec}s`)}
+															</span>
+														</DropdownMenuSubTrigger>
+														<DropdownMenuSubContent>
+															<DropdownMenuRadioGroup
+																value={
+																	timeoutSec === null
+																		? "none"
+																		: String(timeoutSec)
+																}
+																onValueChange={(v) =>
+																	setTimeoutSec(v === "none" ? null : Number(v))
+																}
+															>
+																{TIMEOUT_PRESETS.map((p) => {
+																	const val =
+																		p.value === null ? "none" : String(p.value);
+																	return (
+																		<DropdownMenuRadioItem
+																			key={val}
+																			value={val}
+																		>
+																			{p.label}
+																		</DropdownMenuRadioItem>
+																	);
+																})}
+															</DropdownMenuRadioGroup>
+														</DropdownMenuSubContent>
+													</DropdownMenuSub>
 
-													<section className="p-4 space-y-2">
-														<Label className="typo-label-xs text-text-tertiary uppercase">
-															Transaction mode
-														</Label>
-														<RadioGroup
-															value={autocommit ? "autocommit" : "transaction"}
-															onValueChange={(v) =>
-																setAutocommit(v === "autocommit")
-															}
-															className="gap-1.5"
-														>
-															<Label className="flex items-start gap-2 text-sm cursor-pointer">
-																<RadioGroupItem
-																	value="autocommit"
-																	className="mt-0.5"
-																/>
-																<div>
-																	<div>Autocommit</div>
-																	<div className="text-xs text-text-secondary">
-																		Each statement commits immediately. Required
-																		for VACUUM, CREATE INDEX CONCURRENTLY.
-																	</div>
-																</div>
-															</Label>
-															<Label className="flex items-start gap-2 text-sm cursor-pointer">
-																<RadioGroupItem
-																	value="transaction"
-																	className="mt-0.5"
-																/>
-																<div>
-																	<div>Transaction</div>
-																	<div className="text-xs text-text-secondary">
-																		Wrap the whole script in a single
-																		transaction.
-																	</div>
-																</div>
-															</Label>
-														</RadioGroup>
-													</section>
+													<DropdownMenuSeparator />
+													<DropdownMenuLabel className="typo-label-xs text-text-tertiary uppercase">
+														Transaction mode
+													</DropdownMenuLabel>
+													<DropdownMenuRadioGroup
+														value={autocommit ? "autocommit" : "transaction"}
+														onValueChange={(v) =>
+															setAutocommit(v === "autocommit")
+														}
+													>
+														<DropdownMenuRadioItem value="autocommit">
+															Autocommit
+														</DropdownMenuRadioItem>
+														<DropdownMenuRadioItem value="transaction">
+															Transaction
+														</DropdownMenuRadioItem>
+													</DropdownMenuRadioGroup>
 
-													<section className="p-4 space-y-2">
-														<Label className="typo-label-xs text-text-tertiary uppercase">
-															Execution
-														</Label>
-														<RadioGroup
-															value={asyncMode ? "background" : "foreground"}
-															onValueChange={(v) =>
-																setAsyncMode(v === "background")
-															}
-															className="gap-1.5"
-														>
-															<Label className="flex items-start gap-2 text-sm cursor-pointer">
-																<RadioGroupItem
-																	value="foreground"
-																	className="mt-0.5"
-																/>
-																<div>
-																	<div>Foreground</div>
-																	<div className="text-xs text-text-secondary">
-																		Run synchronously; closing the tab aborts
-																		it.
-																	</div>
-																</div>
-															</Label>
-															<Label className="flex items-start gap-2 text-sm cursor-pointer">
-																<RadioGroupItem
-																	value="background"
-																	className="mt-0.5"
-																/>
-																<div>
-																	<div>Background</div>
-																	<div className="text-xs text-text-secondary">
-																		Fire-and-forget on the server. No result
-																		returned to the UI.
-																	</div>
-																</div>
-															</Label>
-														</RadioGroup>
-													</section>
-												</PopoverContent>
-											</Popover>
+													<DropdownMenuSeparator />
+													<DropdownMenuLabel className="typo-label-xs text-text-tertiary uppercase">
+														Execution
+													</DropdownMenuLabel>
+													<DropdownMenuRadioGroup
+														value={asyncMode ? "background" : "foreground"}
+														onValueChange={(v) =>
+															setAsyncMode(v === "background")
+														}
+													>
+														<DropdownMenuRadioItem value="foreground">
+															Foreground
+														</DropdownMenuRadioItem>
+														<DropdownMenuRadioItem value="background">
+															Background
+														</DropdownMenuRadioItem>
+													</DropdownMenuRadioGroup>
+												</DropdownMenuContent>
+											</DropdownMenu>
 										</div>
 									</div>
 									<div className="flex-1 min-h-0">

--- a/src/routes/db-console.tsx
+++ b/src/routes/db-console.tsx
@@ -1,4 +1,5 @@
 import { indentLess, insertTab } from "@codemirror/commands";
+import { indentUnit } from "@codemirror/language";
 import { Prec } from "@codemirror/state";
 import { type Command, type EditorView, keymap } from "@codemirror/view";
 import {
@@ -635,6 +636,10 @@ function DbConsolePage() {
 
 	const sqlEditorExtensions = useMemo(
 		() => [
+			// Use a literal tab as the indent unit so indentMore / indentLess
+			// (multi-line Tab and Shift-Tab) work in tabs, matching what
+			// insertTab does for single-cursor Tab.
+			indentUnit.of("\t"),
 			Prec.highest(
 				keymap.of([
 					{

--- a/src/routes/db-console.tsx
+++ b/src/routes/db-console.tsx
@@ -283,7 +283,14 @@ function DbConsolePage() {
 	const [tabResults, setTabResults] = useState<Map<string, TabResultData>>(
 		() => new Map(),
 	);
-	const [isLoading, setIsLoading] = useState(false);
+	// Per-tab running state: keyed on tabId so switching tabs preserves
+	// the other tab's in-flight query and its STOP button.
+	type RunningState = { queryId: string; controller: AbortController };
+	const [runningTabs, setRunningTabs] = useState<Map<string, RunningState>>(
+		() => new Map(),
+	);
+	const selectedTabId = selectedTab?.id;
+	const isLoading = !!(selectedTabId && runningTabs.has(selectedTabId));
 	const [showStop, setShowStop] = useState(false);
 	useEffect(() => {
 		if (!isLoading) {
@@ -355,9 +362,33 @@ function DbConsolePage() {
 	const asyncModeRef = useRef(asyncMode);
 	asyncModeRef.current = asyncMode;
 
-	const cancelledTabRef = useRef<string | null>(null);
-	const runningQueryIdRef = useRef<string | null>(null);
-	const abortControllerRef = useRef<AbortController | null>(null);
+	const runningTabsRef = useRef(runningTabs);
+	runningTabsRef.current = runningTabs;
+
+	const startRunning = useCallback(
+		(tabId: string, queryId: string, controller: AbortController) => {
+			setRunningTabs((prev) => {
+				// Abort any previous run on the same tab so we don't leak it.
+				const previous = prev.get(tabId);
+				if (previous) previous.controller.abort();
+				const next = new Map(prev);
+				next.set(tabId, { queryId, controller });
+				return next;
+			});
+		},
+		[],
+	);
+
+	const clearRunning = useCallback((tabId: string, queryId: string) => {
+		setRunningTabs((prev) => {
+			// Only clear if the entry still matches this run — otherwise a
+			// newer run on the same tab is already registered.
+			if (prev.get(tabId)?.queryId !== queryId) return prev;
+			const next = new Map(prev);
+			next.delete(tabId);
+			return next;
+		});
+	}, []);
 
 	const handleQueryChange = useCallback(
 		(value: string) => {
@@ -390,14 +421,9 @@ function DbConsolePage() {
 				return;
 			}
 
-			abortControllerRef.current?.abort();
-			const controller = new AbortController();
-			abortControllerRef.current = controller;
-
 			const queryId = generateId();
-			cancelledTabRef.current = null;
-			runningQueryIdRef.current = queryId;
-			setIsLoading(true);
+			const controller = new AbortController();
+			startRunning(tabId, queryId, controller);
 			const queryToSave = queryRef.current;
 			updateTabResult(tabId, { results: null, error: null });
 
@@ -421,7 +447,7 @@ function DbConsolePage() {
 						controller.signal,
 						runOpts,
 					);
-					if (cancelledTabRef.current === tabId) return;
+					if (controller.signal.aborted) return;
 					saveSqlHistory(queryToSave, queryClient, client);
 					updateTabResult(tabId, {
 						results: null,
@@ -439,7 +465,7 @@ function DbConsolePage() {
 					runOpts,
 				);
 
-				if (cancelledTabRef.current === tabId) return;
+				if (controller.signal.aborted) return;
 
 				if (!allItems.some((item) => item.error)) {
 					saveSqlHistory(queryToSave, queryClient, client);
@@ -447,47 +473,46 @@ function DbConsolePage() {
 
 				updateTabResult(tabId, { results: allItems, error: null });
 			} catch (err) {
-				if (cancelledTabRef.current === tabId) return;
+				if (controller.signal.aborted) return;
 				if (err instanceof DOMException && err.name === "AbortError") return;
 
 				const errorMsg = await extractErrorMessage(err);
 				updateTabResult(tabId, { results: null, error: errorMsg });
 			} finally {
-				runningQueryIdRef.current = null;
-				if (cancelledTabRef.current !== tabId) {
-					setIsLoading(false);
-				}
+				clearRunning(tabId, queryId);
 			}
 		},
-		[client, queryClient, handleQueryChange, updateTabResult],
+		[
+			client,
+			queryClient,
+			handleQueryChange,
+			updateTabResult,
+			startRunning,
+			clearRunning,
+		],
 	);
 
 	const cancelQuery = useCallback(async () => {
 		const tabId = selectedTabRef.current?.id;
 		if (!tabId) return;
+		const running = runningTabsRef.current.get(tabId);
+		if (!running) return;
 
-		abortControllerRef.current?.abort();
-		abortControllerRef.current = null;
-
-		const queryId = runningQueryIdRef.current;
-		cancelledTabRef.current = tabId;
-		runningQueryIdRef.current = null;
-		setIsLoading(false);
+		running.controller.abort();
+		clearRunning(tabId, running.queryId);
 		updateTabResult(tabId, { results: null, error: "Query cancelled" });
 
-		if (queryId) {
-			try {
-				await client.rawRequest({
-					method: "POST",
-					url: "/$psql-cancel",
-					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ "query-id": queryId }),
-				});
-			} catch {
-				// best-effort cancel
-			}
+		try {
+			await client.rawRequest({
+				method: "POST",
+				url: "/$psql-cancel",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ "query-id": running.queryId }),
+			});
+		} catch {
+			// best-effort cancel
 		}
-	}, [client, updateTabResult]);
+	}, [client, updateTabResult, clearRunning]);
 
 	const { data: historyData } = useSqlHistory();
 

--- a/src/routes/db-console.tsx
+++ b/src/routes/db-console.tsx
@@ -72,6 +72,7 @@ async function fetchBlock(
 		autocommit: boolean;
 		timeoutSec: number | null;
 		readOnly: boolean;
+		queryId: string;
 	},
 ): Promise<QueryResultItem[]> {
 	const body: { query: string; limit?: number } = { query: block };
@@ -79,6 +80,7 @@ async function fetchBlock(
 	const headers: Record<string, string> = {
 		"Content-Type": "application/json",
 		Accept: "application/json",
+		"X-Aidbox-Sql-Query-Id": opts.queryId,
 	};
 	if (opts.autocommit) headers["X-Aidbox-Sql-Autocommit"] = "true";
 	if (opts.timeoutSec !== null)
@@ -279,7 +281,7 @@ function DbConsolePage() {
 	readOnlyRef.current = readOnly;
 
 	const cancelledTabRef = useRef<string | null>(null);
-	const runningQueryRef = useRef<string | null>(null);
+	const runningQueryIdRef = useRef<string | null>(null);
 	const abortControllerRef = useRef<AbortController | null>(null);
 
 	const handleQueryChange = useCallback(
@@ -317,8 +319,9 @@ function DbConsolePage() {
 			const controller = new AbortController();
 			abortControllerRef.current = controller;
 
+			const queryId = generateId();
 			cancelledTabRef.current = null;
-			runningQueryRef.current = queryRef.current;
+			runningQueryIdRef.current = queryId;
 			setIsLoading(true);
 			const queryToSave = queryRef.current;
 			updateTabResult(tabId, { results: null, error: null });
@@ -334,6 +337,7 @@ function DbConsolePage() {
 						autocommit: autocommitRef.current,
 						timeoutSec: timeoutRef.current,
 						readOnly: readOnlyRef.current,
+						queryId,
 					},
 				);
 
@@ -351,10 +355,10 @@ function DbConsolePage() {
 				const errorMsg = await extractErrorMessage(err);
 				updateTabResult(tabId, { results: null, error: errorMsg });
 			} finally {
+				runningQueryIdRef.current = null;
 				if (cancelledTabRef.current !== tabId) {
 					setIsLoading(false);
 				}
-				runningQueryRef.current = null;
 			}
 		},
 		[client, queryClient, handleQueryChange, updateTabResult],
@@ -367,22 +371,19 @@ function DbConsolePage() {
 		abortControllerRef.current?.abort();
 		abortControllerRef.current = null;
 
-		const queryText = runningQueryRef.current;
+		const queryId = runningQueryIdRef.current;
 		cancelledTabRef.current = tabId;
-		runningQueryRef.current = null;
+		runningQueryIdRef.current = null;
 		setIsLoading(false);
 		updateTabResult(tabId, { results: null, error: "Query cancelled" });
 
-		if (queryText) {
+		if (queryId) {
 			try {
-				const escaped = queryText.slice(0, 200).replace(/'/g, "''");
 				await client.rawRequest({
 					method: "POST",
-					url: "/$notebook-psql",
+					url: "/$psql-cancel",
 					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({
-						query: `SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE state = 'active' AND query LIKE '%${escaped}%' AND pid != pg_backend_pid()`,
-					}),
+					body: JSON.stringify({ "query-id": queryId }),
 				});
 			} catch {
 				// best-effort cancel

--- a/src/routes/db-console.tsx
+++ b/src/routes/db-console.tsx
@@ -33,6 +33,7 @@ import {
 	SqlLeftMenuToggle,
 } from "../components/db-console/left-menu";
 import {
+	AsyncToggle,
 	AutocommitToggle,
 	LimitDropdown,
 	ReadOnlyToggle,
@@ -63,20 +64,14 @@ import { useWebMCPSql } from "../webmcp/sql";
 
 const TITLE = "SQL console";
 
-async function fetchBlock(
-	baseUrl: string,
-	block: string,
-	limit: number | null,
-	signal: AbortSignal,
-	opts: {
-		autocommit: boolean;
-		timeoutSec: number | null;
-		readOnly: boolean;
-		queryId: string;
-	},
-): Promise<QueryResultItem[]> {
-	const body: { query: string; limit?: number } = { query: block };
-	if (limit !== null) body.limit = limit;
+type SqlRunOpts = {
+	autocommit: boolean;
+	timeoutSec: number | null;
+	readOnly: boolean;
+	queryId: string;
+};
+
+function buildSqlHeaders(opts: SqlRunOpts): Record<string, string> {
 	const headers: Record<string, string> = {
 		"Content-Type": "application/json",
 		Accept: "application/json",
@@ -86,6 +81,43 @@ async function fetchBlock(
 	if (opts.timeoutSec !== null)
 		headers["X-Aidbox-Sql-Timeout"] = String(opts.timeoutSec);
 	if (opts.readOnly) headers["X-Aidbox-Sql-Read-Only"] = "true";
+	return headers;
+}
+
+async function fetchBlock(
+	baseUrl: string,
+	block: string,
+	limit: number | null,
+	signal: AbortSignal,
+	opts: SqlRunOpts,
+): Promise<QueryResultItem[]> {
+	const body: { query: string; limit?: number } = { query: block };
+	if (limit !== null) body.limit = limit;
+	const response = await fetch(`${baseUrl}/$notebook-psql`, {
+		method: "POST",
+		headers: buildSqlHeaders(opts),
+		credentials: "include",
+		body: JSON.stringify(body),
+		signal,
+	});
+	if (!response.ok) {
+		const text = await response.text();
+		throw new Error(`HTTP ${response.status}: ${text}`);
+	}
+	return transformToQueryResultItems(await response.json());
+}
+
+async function kickOffAsync(
+	baseUrl: string,
+	block: string,
+	limit: number | null,
+	signal: AbortSignal,
+	opts: SqlRunOpts,
+): Promise<string> {
+	const body: { query: string; limit?: number } = { query: block };
+	if (limit !== null) body.limit = limit;
+	const headers = buildSqlHeaders(opts);
+	headers["X-Aidbox-Sql-Async"] = "true";
 	const response = await fetch(`${baseUrl}/$notebook-psql`, {
 		method: "POST",
 		headers,
@@ -97,7 +129,44 @@ async function fetchBlock(
 		const text = await response.text();
 		throw new Error(`HTTP ${response.status}: ${text}`);
 	}
-	return transformToQueryResultItems(await response.json());
+	const json = (await response.json()) as { "operation-id"?: string };
+	const id = json["operation-id"];
+	if (!id) throw new Error("Missing operation-id in async kick-off response");
+	return id;
+}
+
+type AsyncStatus =
+	| { status: "in-progress" }
+	| { status: "completed"; result: unknown }
+	| { status: "failed"; error: string }
+	| { status: "not-found" };
+
+async function fetchAsyncStatus(
+	baseUrl: string,
+	operationId: string,
+	signal: AbortSignal,
+): Promise<AsyncStatus> {
+	const response = await fetch(
+		`${baseUrl}/$psql/operations/${encodeURIComponent(operationId)}`,
+		{
+			method: "GET",
+			headers: { Accept: "application/json" },
+			credentials: "include",
+			signal,
+		},
+	);
+	if (response.status === 404) return { status: "not-found" };
+	return (await response.json()) as AsyncStatus;
+}
+
+async function cancelAsync(
+	baseUrl: string,
+	operationId: string,
+): Promise<void> {
+	await fetch(
+		`${baseUrl}/$psql/operations/${encodeURIComponent(operationId)}`,
+		{ method: "DELETE", credentials: "include" },
+	);
 }
 
 const TABLES_QUERY = `SELECT table_schema, table_name, table_type FROM information_schema.tables WHERE table_schema NOT IN ('pg_catalog', 'information_schema', 'pgagent') AND table_type IN ('BASE TABLE', 'VIEW') ORDER BY table_schema, table_name`;
@@ -247,6 +316,11 @@ function DbConsolePage() {
 		defaultValue: false,
 		getInitialValueInEffect: false,
 	});
+	const [asyncMode, setAsyncMode] = useLocalStorage<boolean>({
+		key: "db-console-async-mode",
+		defaultValue: false,
+		getInitialValueInEffect: false,
+	});
 	const leftPanelRef = useRef<ImperativePanelHandle>(null);
 	const resultPanelRef = useRef<ImperativePanelHandle>(null);
 	const initialLeftMenuOpen = useRef(leftMenuOpen);
@@ -280,9 +354,14 @@ function DbConsolePage() {
 	const readOnlyRef = useRef(readOnly);
 	readOnlyRef.current = readOnly;
 
+	const asyncModeRef = useRef(asyncMode);
+	asyncModeRef.current = asyncMode;
+
 	const cancelledTabRef = useRef<string | null>(null);
 	const runningQueryIdRef = useRef<string | null>(null);
+	const runningOperationIdRef = useRef<string | null>(null);
 	const abortControllerRef = useRef<AbortController | null>(null);
+	const pollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
 	const handleQueryChange = useCallback(
 		(value: string) => {
@@ -301,6 +380,60 @@ function DbConsolePage() {
 		});
 	}, []);
 
+	const stopPolling = useCallback(() => {
+		if (pollTimeoutRef.current !== null) {
+			clearTimeout(pollTimeoutRef.current);
+			pollTimeoutRef.current = null;
+		}
+	}, []);
+
+	const pollAsync = useCallback(
+		(tabId: string, operationId: string, queryToSave: string) => {
+			const baseUrl = client.getBaseUrl();
+			const tick = async () => {
+				if (cancelledTabRef.current === tabId) return;
+				try {
+					const status = await fetchAsyncStatus(
+						baseUrl,
+						operationId,
+						new AbortController().signal,
+					);
+					if (cancelledTabRef.current === tabId) return;
+					if (status.status === "in-progress") {
+						pollTimeoutRef.current = setTimeout(tick, 1000);
+						return;
+					}
+					stopPolling();
+					runningOperationIdRef.current = null;
+					setIsLoading(false);
+					if (status.status === "completed") {
+						const items = transformToQueryResultItems(
+							status.result as Parameters<
+								typeof transformToQueryResultItems
+							>[0],
+						);
+						if (!items.some((item) => item.error)) {
+							saveSqlHistory(queryToSave, queryClient, client);
+						}
+						updateTabResult(tabId, { results: items, error: null });
+					} else if (status.status === "failed") {
+						updateTabResult(tabId, { results: null, error: status.error });
+					} else {
+						updateTabResult(tabId, {
+							results: null,
+							error: "Async operation not found",
+						});
+					}
+				} catch {
+					// transient network error — keep polling
+					pollTimeoutRef.current = setTimeout(tick, 1000);
+				}
+			};
+			tick();
+		},
+		[client, queryClient, stopPolling, updateTabResult],
+	);
+
 	const executeQuery = useCallback(
 		async (overrideQuery?: string) => {
 			if (overrideQuery !== undefined) {
@@ -316,29 +449,48 @@ function DbConsolePage() {
 			}
 
 			abortControllerRef.current?.abort();
+			stopPolling();
 			const controller = new AbortController();
 			abortControllerRef.current = controller;
 
 			const queryId = generateId();
 			cancelledTabRef.current = null;
 			runningQueryIdRef.current = queryId;
+			runningOperationIdRef.current = null;
 			setIsLoading(true);
 			const queryToSave = queryRef.current;
 			updateTabResult(tabId, { results: null, error: null });
 
+			const runOpts: SqlRunOpts = {
+				autocommit: autocommitRef.current,
+				timeoutSec: timeoutRef.current,
+				readOnly: readOnlyRef.current,
+				queryId,
+			};
+
 			try {
 				const baseUrl = client.getBaseUrl();
+
+				if (asyncModeRef.current) {
+					const operationId = await kickOffAsync(
+						baseUrl,
+						rawQuery,
+						rowLimitRef.current,
+						controller.signal,
+						runOpts,
+					);
+					if (cancelledTabRef.current === tabId) return;
+					runningOperationIdRef.current = operationId;
+					pollAsync(tabId, operationId, queryToSave);
+					return;
+				}
+
 				const allItems = await fetchBlock(
 					baseUrl,
 					rawQuery,
 					rowLimitRef.current,
 					controller.signal,
-					{
-						autocommit: autocommitRef.current,
-						timeoutSec: timeoutRef.current,
-						readOnly: readOnlyRef.current,
-						queryId,
-					},
+					runOpts,
 				);
 
 				if (cancelledTabRef.current === tabId) return;
@@ -356,12 +508,19 @@ function DbConsolePage() {
 				updateTabResult(tabId, { results: null, error: errorMsg });
 			} finally {
 				runningQueryIdRef.current = null;
-				if (cancelledTabRef.current !== tabId) {
+				if (!asyncModeRef.current && cancelledTabRef.current !== tabId) {
 					setIsLoading(false);
 				}
 			}
 		},
-		[client, queryClient, handleQueryChange, updateTabResult],
+		[
+			client,
+			queryClient,
+			handleQueryChange,
+			updateTabResult,
+			pollAsync,
+			stopPolling,
+		],
 	);
 
 	const cancelQuery = useCallback(async () => {
@@ -370,26 +529,32 @@ function DbConsolePage() {
 
 		abortControllerRef.current?.abort();
 		abortControllerRef.current = null;
+		stopPolling();
 
 		const queryId = runningQueryIdRef.current;
+		const operationId = runningOperationIdRef.current;
 		cancelledTabRef.current = tabId;
 		runningQueryIdRef.current = null;
+		runningOperationIdRef.current = null;
 		setIsLoading(false);
 		updateTabResult(tabId, { results: null, error: "Query cancelled" });
 
-		if (queryId) {
-			try {
+		const baseUrl = client.getBaseUrl();
+		try {
+			if (operationId) {
+				await cancelAsync(baseUrl, operationId);
+			} else if (queryId) {
 				await client.rawRequest({
 					method: "POST",
 					url: "/$psql-cancel",
 					headers: { "Content-Type": "application/json" },
 					body: JSON.stringify({ "query-id": queryId }),
 				});
-			} catch {
-				// best-effort cancel
 			}
+		} catch {
+			// best-effort cancel
 		}
-	}, [client, updateTabResult]);
+	}, [client, stopPolling, updateTabResult]);
 
 	const { data: historyData } = useSqlHistory();
 
@@ -802,6 +967,10 @@ function DbConsolePage() {
 											<ReadOnlyToggle
 												readOnly={readOnly}
 												onReadOnlyChange={setReadOnly}
+											/>
+											<AsyncToggle
+												async={asyncMode}
+												onAsyncChange={setAsyncMode}
 											/>
 										</div>
 									</div>

--- a/src/routes/db-console.tsx
+++ b/src/routes/db-console.tsx
@@ -36,6 +36,8 @@ import {
 	forceSelectedTab,
 	SqlActiveTabs,
 	type SqlTab,
+	type SqlTabSettings,
+	tabSettings,
 } from "../components/db-console/active-tabs";
 import {
 	SqlLeftMenu,
@@ -52,7 +54,6 @@ import {
 	transformToQueryResultItems,
 } from "../components/db-console/tables-view";
 import {
-	DEFAULT_TIMEOUT_SEC,
 	type FunctionsMap,
 	isAidboxError,
 	type SchemaMap,
@@ -304,34 +305,39 @@ function DbConsolePage() {
 		const timer = setTimeout(() => setShowStop(true), 100);
 		return () => clearTimeout(timer);
 	}, [isLoading]);
-	const [rowLimit, setRowLimit] = useLocalStorage<number | null>({
-		key: "db-console-row-limit",
-		defaultValue: 10,
-		getInitialValueInEffect: false,
-	});
-	const [timeoutSec, setTimeoutSec] = useLocalStorage<number | null>({
-		key: "db-console-timeout-sec",
-		defaultValue: DEFAULT_TIMEOUT_SEC,
-		getInitialValueInEffect: false,
-	});
-	const [autocommit, setAutocommit] = useLocalStorage<boolean>({
-		key: "db-console-autocommit",
-		defaultValue: true,
-		getInitialValueInEffect: false,
-	});
-	// Read-only mode state is wired through to the backend headers but the UI
-	// toggle is hidden for now — see Hide read-only toggle commit. Value stays
-	// at the default (false / read-write).
-	const [readOnly, _setReadOnly] = useLocalStorage<boolean>({
-		key: "db-console-read-only",
-		defaultValue: false,
-		getInitialValueInEffect: false,
-	});
-	const [asyncMode, setAsyncMode] = useLocalStorage<boolean>({
-		key: "db-console-async-mode",
-		defaultValue: false,
-		getInitialValueInEffect: false,
-	});
+	// Settings live on the selected tab (SqlTabSettings). Switching tabs or
+	// creating a new tab does not leak settings across tabs; new tabs start
+	// with DEFAULT_SQL_TAB_SETTINGS.
+	const { rowLimit, timeoutSec, autocommit, readOnly, asyncMode } =
+		tabSettings(selectedTab);
+
+	const updateSelectedTabSettings = useCallback(
+		(patch: Partial<SqlTabSettings>) => {
+			setTabs((prev) =>
+				prev.map((t) =>
+					t.selected ? { ...t, settings: { ...tabSettings(t), ...patch } } : t,
+				),
+			);
+		},
+		[setTabs],
+	);
+
+	const setRowLimit = useCallback(
+		(v: number | null) => updateSelectedTabSettings({ rowLimit: v }),
+		[updateSelectedTabSettings],
+	);
+	const setTimeoutSec = useCallback(
+		(v: number | null) => updateSelectedTabSettings({ timeoutSec: v }),
+		[updateSelectedTabSettings],
+	);
+	const setAutocommit = useCallback(
+		(v: boolean) => updateSelectedTabSettings({ autocommit: v }),
+		[updateSelectedTabSettings],
+	);
+	const setAsyncMode = useCallback(
+		(v: boolean) => updateSelectedTabSettings({ asyncMode: v }),
+		[updateSelectedTabSettings],
+	);
 	const leftPanelRef = useRef<ImperativePanelHandle>(null);
 	const resultPanelRef = useRef<ImperativePanelHandle>(null);
 	const initialLeftMenuOpen = useRef(leftMenuOpen);

--- a/src/routes/db-console.tsx
+++ b/src/routes/db-console.tsx
@@ -99,7 +99,7 @@ async function fetchBlock(
 ): Promise<QueryResultItem[]> {
 	const body: { query: string; limit?: number } = { query: block };
 	if (limit !== null) body.limit = limit;
-	const response = await fetch(`${baseUrl}/$notebook-psql`, {
+	const response = await fetch(`${baseUrl}/$psql`, {
 		method: "POST",
 		headers: buildSqlHeaders(opts),
 		credentials: "include",
@@ -124,7 +124,7 @@ async function kickOffAsync(
 	if (limit !== null) body.limit = limit;
 	const headers = buildSqlHeaders(opts);
 	headers["X-Aidbox-Sql-Async"] = "true";
-	const response = await fetch(`${baseUrl}/$notebook-psql`, {
+	const response = await fetch(`${baseUrl}/$psql`, {
 		method: "POST",
 		headers,
 		credentials: "include",

--- a/src/routes/db-console.tsx
+++ b/src/routes/db-console.tsx
@@ -5,10 +5,9 @@ import {
 	Button,
 	CodeEditor,
 	DropdownMenu,
+	DropdownMenuCheckboxItem,
 	DropdownMenuContent,
 	DropdownMenuLabel,
-	DropdownMenuRadioGroup,
-	DropdownMenuRadioItem,
 	DropdownMenuSeparator,
 	DropdownMenuSub,
 	DropdownMenuSubContent,
@@ -953,29 +952,19 @@ function DbConsolePage() {
 															</span>
 														</DropdownMenuSubTrigger>
 														<DropdownMenuSubContent>
-															<DropdownMenuRadioGroup
-																value={
-																	timeoutSec === null
-																		? "none"
-																		: String(timeoutSec)
-																}
-																onValueChange={(v) =>
-																	setTimeoutSec(v === "none" ? null : Number(v))
-																}
-															>
-																{TIMEOUT_PRESETS.map((p) => {
-																	const val =
-																		p.value === null ? "none" : String(p.value);
-																	return (
-																		<DropdownMenuRadioItem
-																			key={val}
-																			value={val}
-																		>
-																			{p.label}
-																		</DropdownMenuRadioItem>
-																	);
-																})}
-															</DropdownMenuRadioGroup>
+															{TIMEOUT_PRESETS.map((p) => (
+																<DropdownMenuCheckboxItem
+																	key={
+																		p.value === null ? "none" : String(p.value)
+																	}
+																	checked={timeoutSec === p.value}
+																	onCheckedChange={(v) => {
+																		if (v) setTimeoutSec(p.value);
+																	}}
+																>
+																	{p.label}
+																</DropdownMenuCheckboxItem>
+															))}
 														</DropdownMenuSubContent>
 													</DropdownMenuSub>
 
@@ -983,37 +972,43 @@ function DbConsolePage() {
 													<DropdownMenuLabel className="typo-label-xs text-text-tertiary uppercase">
 														Transaction mode
 													</DropdownMenuLabel>
-													<DropdownMenuRadioGroup
-														value={autocommit ? "autocommit" : "transaction"}
-														onValueChange={(v) =>
-															setAutocommit(v === "autocommit")
-														}
+													<DropdownMenuCheckboxItem
+														checked={autocommit}
+														onCheckedChange={(v) => {
+															if (v) setAutocommit(true);
+														}}
 													>
-														<DropdownMenuRadioItem value="autocommit">
-															Autocommit
-														</DropdownMenuRadioItem>
-														<DropdownMenuRadioItem value="transaction">
-															Transaction
-														</DropdownMenuRadioItem>
-													</DropdownMenuRadioGroup>
+														Autocommit
+													</DropdownMenuCheckboxItem>
+													<DropdownMenuCheckboxItem
+														checked={!autocommit}
+														onCheckedChange={(v) => {
+															if (v) setAutocommit(false);
+														}}
+													>
+														Transaction
+													</DropdownMenuCheckboxItem>
 
 													<DropdownMenuSeparator />
 													<DropdownMenuLabel className="typo-label-xs text-text-tertiary uppercase">
 														Execution
 													</DropdownMenuLabel>
-													<DropdownMenuRadioGroup
-														value={asyncMode ? "background" : "foreground"}
-														onValueChange={(v) =>
-															setAsyncMode(v === "background")
-														}
+													<DropdownMenuCheckboxItem
+														checked={!asyncMode}
+														onCheckedChange={(v) => {
+															if (v) setAsyncMode(false);
+														}}
 													>
-														<DropdownMenuRadioItem value="foreground">
-															Foreground
-														</DropdownMenuRadioItem>
-														<DropdownMenuRadioItem value="background">
-															Background
-														</DropdownMenuRadioItem>
-													</DropdownMenuRadioGroup>
+														Foreground
+													</DropdownMenuCheckboxItem>
+													<DropdownMenuCheckboxItem
+														checked={asyncMode}
+														onCheckedChange={(v) => {
+															if (v) setAsyncMode(true);
+														}}
+													>
+														Background
+													</DropdownMenuCheckboxItem>
 												</DropdownMenuContent>
 											</DropdownMenu>
 										</div>

--- a/src/routes/db-console.tsx
+++ b/src/routes/db-console.tsx
@@ -101,12 +101,12 @@ function buildSqlHeaders(opts: SqlRunOpts): Record<string, string> {
 	const headers: Record<string, string> = {
 		"Content-Type": "application/json",
 		Accept: "application/json",
-		"X-Aidbox-Sql-Query-Id": opts.queryId,
+		"Aidbox-Sql-Query-Id": opts.queryId,
 	};
-	if (opts.autocommit) headers["X-Aidbox-Sql-Autocommit"] = "true";
+	if (opts.autocommit) headers["Aidbox-Sql-Autocommit"] = "true";
 	if (opts.timeoutSec !== null)
-		headers["X-Aidbox-Sql-Timeout"] = String(opts.timeoutSec);
-	if (opts.readOnly) headers["X-Aidbox-Sql-Read-Only"] = "true";
+		headers["Aidbox-Sql-Timeout"] = String(opts.timeoutSec);
+	if (opts.readOnly) headers["Aidbox-Sql-Read-Only"] = "true";
 	return headers;
 }
 
@@ -143,7 +143,7 @@ async function kickOffAsync(
 	const body: { query: string; limit?: number } = { query: block };
 	if (limit !== null) body.limit = limit;
 	const headers = buildSqlHeaders(opts);
-	headers["X-Aidbox-Sql-Async"] = "true";
+	headers["Aidbox-Sql-Async"] = "true";
 	const response = await fetch(`${baseUrl}/$psql`, {
 		method: "POST",
 		headers,

--- a/src/routes/db-console.tsx
+++ b/src/routes/db-console.tsx
@@ -4,6 +4,9 @@ import { type EditorView, keymap } from "@codemirror/view";
 import {
 	Button,
 	CodeEditor,
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
 	ResizableHandle,
 	ResizablePanel,
 	ResizablePanelGroup,
@@ -15,7 +18,7 @@ import {
 } from "@health-samurai/react-components";
 import { useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
-import { AlignLeft, PlayIcon, Square } from "lucide-react";
+import { AlignLeft, PlayIcon, Settings2, Square } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ImperativePanelHandle } from "react-resizable-panels";
 import { format as formatSQL } from "sql-formatter";
@@ -915,25 +918,47 @@ function DbConsolePage() {
 												rowLimit={rowLimit}
 												onRowLimitChange={setRowLimit}
 											/>
-											<TimeoutDropdown
-												timeoutSec={timeoutSec}
-												onTimeoutChange={setTimeoutSec}
-											/>
-											<AutocommitToggle
-												autocommit={autocommit}
-												onAutocommitChange={setAutocommit}
-											/>
-											{/* Read-only toggle hidden — keep state wired so behavior stays on the default (read-write). Re-enable when product decides to expose it. */}
-											{false && (
-												<ReadOnlyToggle
-													readOnly={readOnly}
-													onReadOnlyChange={setReadOnly}
-												/>
-											)}
-											<AsyncToggle
-												async={asyncMode}
-												onAsyncChange={setAsyncMode}
-											/>
+											<Popover>
+												<Tooltip delayDuration={300}>
+													<TooltipTrigger asChild>
+														<PopoverTrigger asChild>
+															<Button
+																variant="link"
+																className="text-text-secondary bg-bg-tertiary rounded-full px-2 h-6"
+															>
+																<Settings2 className="size-3.5" />
+															</Button>
+														</PopoverTrigger>
+													</TooltipTrigger>
+													<TooltipContent side="bottom">
+														SQL execution settings
+													</TooltipContent>
+												</Tooltip>
+												<PopoverContent
+													align="start"
+													className="w-auto p-3 flex flex-col gap-2"
+												>
+													<TimeoutDropdown
+														timeoutSec={timeoutSec}
+														onTimeoutChange={setTimeoutSec}
+													/>
+													<AutocommitToggle
+														autocommit={autocommit}
+														onAutocommitChange={setAutocommit}
+													/>
+													{/* Read-only toggle hidden — keep state wired so behavior stays on the default (read-write). Re-enable when product decides to expose it. */}
+													{false && (
+														<ReadOnlyToggle
+															readOnly={readOnly}
+															onReadOnlyChange={setReadOnly}
+														/>
+													)}
+													<AsyncToggle
+														async={asyncMode}
+														onAsyncChange={setAsyncMode}
+													/>
+												</PopoverContent>
+											</Popover>
 										</div>
 									</div>
 									<div className="flex-1 min-h-0">


### PR DESCRIPTION
Accompanies aidbox PR

## Changes

- Toolbar toggles for limit, statement timeout (default 1m), autocommit
  (default **on** for the psql-CLI-like UX, footgun flagged in tooltip),
  async/background mode. Read-only toggle is wired but hidden per product.
- Query text no longer split on `\n----\n` in the browser — raw input is
  posted as one blob.
- Tab key inserts tab/indent in the CodeMirror editor.
- `EXPLAIN` output renders as a monospace block instead of a table.
- `/db-console` accepts `?query=...` and preloads the SQL into a tab, so
  legacy `/ui/db?query=...` links keep working after the server-side redirect.
- Cancel uses `POST /$psql-cancel {query-id}` (exact backend match) instead
  of the old `pg_cancel_backend` `LIKE '%…%'` scan.
- Background mode kicks off via `X-Aidbox-Sql-Async: true`, polls
  `GET /$psql/operations/:id` every 1s, cancels via `DELETE`.

## Test plan

- [ ] Paste a multi-statement script and RUN — each statement result shown.
- [ ] `VACUUM ANALYZE patient` with autocommit on — completes; with autocommit
  off, fails with "VACUUM cannot run inside a transaction block".
- [ ] `SELECT pg_sleep(120)` with timeout 5s — cancelled with a clear error.
- [ ] STOP button cancels an in-flight query (watch `pg_stat_activity` —
  no stale `aidbox-psql:<uuid>` app_name after cancel).
- [ ] Async mode: RUN, close tab, reopen — poll resumes.
- [ ] `EXPLAIN SELECT * FROM patient` — monospace plan tree.
- [ ] Tab key in editor inserts tab/indents selection.
- [ ] Load `/ui/db?query=SELECT%201` on the old UI → click "Switch" → new
  console opens with the SQL pre-filled.