### PR TITLE
Remove MDM references

### DIFF
--- a/src/components/IGBrowser/browser.tsx
+++ b/src/components/IGBrowser/browser.tsx
@@ -28,7 +28,6 @@ function capitalize(s: string): string {
 const SYSTEM_PREFIXES = [
 	"io.health-samurai.core",
 	"io.health-samurai.sdc",
-	"io.health-samurai.mdm",
 ];
 
 function getPackageType(name: string, installation: Installation[]): string {

--- a/src/components/settings/constants.ts
+++ b/src/components/settings/constants.ts
@@ -76,7 +76,6 @@ export const CATEGORIES: CategoryDef[] = [
 				category: ["Modules", "SMARTbox"],
 				desc: "SMARTbox settings",
 			},
-			{ category: ["Modules", "MDM"], desc: "MDM settings" },
 			{ category: ["Modules", "MCP"], desc: "MCP settings" },
 			{ category: ["Modules", "Forms"], desc: "Forms settings" },
 			{ category: ["Modules", "GraphQL"], desc: "GraphQL settings" },


### PR DESCRIPTION
## Summary
- Drop the **Modules > MDM** entry from the settings categories (`src/components/settings/constants.ts`).
- Remove the `io.health-samurai.mdm` system-package prefix from the IG Browser's package-type detection (`src/components/IGBrowser/browser.tsx`).

The MDM module is being removed from Aidbox; this PR is the UI-side cleanup that pairs with the backend deletion in HealthSamurai/aidbox.

## Test plan
- [ ] Settings page loads without the MDM category
- [ ] IG Browser still classifies `io.health-samurai.core.*` and `io.health-samurai.sdc.*` as System packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)