### PR TITLE
support configuring base path from backend

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,13 +5,13 @@
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width">
 	<title>Aidbox UI</title>
-	<link href="/favicon/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180">
-	<link href="/favicon/favicon-32x32.png" rel="icon" sizes="32x32" type="image/png">
-	<link href="/favicon/favicon-16x16.png" rel="icon" sizes="16x16" type="image/png">
-	<link href="/site.webmanifest" rel="manifest">
-	<link href="/fonts/Inter/index.css" rel="stylesheet">
-	<link href="/fonts/JetBrainsMono/index.css" rel="stylesheet">
-	<link color="#5bbad5" href="/favicon/safari-pinned-tab.svg" rel="mask-icon">
+	<link href="favicon/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180">
+	<link href="favicon/favicon-32x32.png" rel="icon" sizes="32x32" type="image/png">
+	<link href="favicon/favicon-16x16.png" rel="icon" sizes="16x16" type="image/png">
+	<link href="site.webmanifest" rel="manifest">
+	<link href="fonts/Inter/index.css" rel="stylesheet">
+	<link href="fonts/JetBrainsMono/index.css" rel="stylesheet">
+	<link color="#5bbad5" href="favicon/safari-pinned-tab.svg" rel="mask-icon">
 	<meta content="#da532c" name="msapplication-TileColor">
 	<meta content="#ffffff" name="theme-color">
 	<style>

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
 	"main": "index.js",
 	"type": "module",
 	"scripts": {
-		"preinstall": "cd aidbox-ts-sdk/packages/react-components && pnpm install && pnpm build",
+		"preinstall": "cd aidbox-ts-sdk/packages/aidbox-client && pnpm install && pnpm build && cd ../react-components && pnpm install && pnpm build",
 		"dev": "vite",
 		"rc:build": "cd aidbox-ts-sdk/packages/react-components && pnpm build && cd ../../.. && pnpm install && rm -rf node_modules/.vite",
+		"client:build": "cd aidbox-ts-sdk/packages/aidbox-client && pnpm build && cd ../../.. && pnpm install && rm -rf node_modules/.vite",
 		"typecheck": "pnpm tsc --noEmit --project tsconfig.app.json",
 		"build": "pnpm exec vite build",
 		"format": "biome format --write",
@@ -58,7 +59,7 @@
 	"dependencies": {
 		"@git-diff-view/file": "^0.0.30",
 		"@git-diff-view/react": "^0.0.30",
-		"@health-samurai/aidbox-client": "0.0.0-alpha.5",
+		"@health-samurai/aidbox-client": "file:aidbox-ts-sdk/packages/aidbox-client",
 		"@health-samurai/aidbox-fhirpath-lsp": "0.0.0-alpha.7",
 		"@health-samurai/react-components": "file:aidbox-ts-sdk/packages/react-components",
 		"@mcp-b/global": "^2.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         specifier: ^0.0.30
         version: 0.0.30(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@health-samurai/aidbox-client':
-        specifier: 0.0.0-alpha.5
-        version: 0.0.0-alpha.5
+        specifier: file:aidbox-ts-sdk/packages/aidbox-client
+        version: file:aidbox-ts-sdk/packages/aidbox-client
       '@health-samurai/aidbox-fhirpath-lsp':
         specifier: 0.0.0-alpha.7
         version: 0.0.0-alpha.7(@codemirror/lsp-client@6.2.2)(@codemirror/state@6.6.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
@@ -569,6 +569,9 @@ packages:
 
   '@health-samurai/aidbox-client@0.0.0-alpha.5':
     resolution: {integrity: sha512-WYXfTgMAMRRvJPhnSjB7KiOMhgQ7CDEOS7IUJDvPsjWUbIrRVzfjl89UzyDw6Rv/kum3nDIcVZHyHjVoWbms6g==}
+
+  '@health-samurai/aidbox-client@file:aidbox-ts-sdk/packages/aidbox-client':
+    resolution: {directory: aidbox-ts-sdk/packages/aidbox-client, type: directory}
 
   '@health-samurai/aidbox-fhirpath-lsp@0.0.0-alpha.7':
     resolution: {integrity: sha512-AX3f07EMoZg8OWduVWq6rx5HOk+h7ISj6dIgMmaHLLZJ3wcH+LHjAfPv1H6Q/Hc1kqMx+xyfX68z1AOaqGnANw==}
@@ -3316,6 +3319,12 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
 
   '@health-samurai/aidbox-client@0.0.0-alpha.5':
+    dependencies:
+      '@types/json-patch': 0.0.33
+      oauth4webapi: 3.8.5
+      yaml: 2.8.3
+
+  '@health-samurai/aidbox-client@file:aidbox-ts-sdk/packages/aidbox-client':
     dependencies:
       '@types/json-patch': 0.0.33
       oauth4webapi: 3.8.5

--- a/src/shared/const.ts
+++ b/src/shared/const.ts
@@ -1,6 +1,8 @@
+import { getPathPrefix } from "../utils/path-prefix";
+
 export const SIDEBAR_MODE_KEY = "aidbox-sidebar-mode";
 export const REST_CONSOLE_TABS_KEY = "aidbox-rest-console-tabs";
-export const UI_BASE_PATH = "/u";
+export const UI_BASE_PATH = `${getPathPrefix()}/u`;
 export const PREFERRED_UI_KEY = "aidbox-preferred-ui";
 export const THEME_KEY = "aidbox-theme";
 export const VIM_MODE_KEY = "aidbox-vim-mode";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 import type { TreeViewItem } from "@health-samurai/react-components";
 import type { Header, Tab } from "./components/rest/active-tabs";
 import type { Meta, Snapshot } from "./components/ViewDefinition/types";
+import { getCookie } from "./utils/cookie";
 
 export function generateId(): string {
 	if (
@@ -49,8 +50,11 @@ export function syncPathFromParams(params: Header[], path: string): string {
 }
 
 export function getAidboxBaseURL(): string {
+	if (import.meta.env.VITE_AIDBOX_BASE_URL) {
+		return import.meta.env.VITE_AIDBOX_BASE_URL;
+	}
 	return (
-		import.meta.env.VITE_AIDBOX_BASE_URL ||
+		getCookie("aidbox-base-url") ??
 		`${window.location.protocol}//${window.location.host}`
 	);
 }

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -1,0 +1,4 @@
+export function getCookie(name: string): string | null {
+	const match = document.cookie.match(new RegExp(`(?:^|; )${name}=([^;]*)`));
+	return match?.[1] ? decodeURIComponent(match[1]) : null;
+}

--- a/src/utils/path-prefix.ts
+++ b/src/utils/path-prefix.ts
@@ -1,0 +1,11 @@
+import { getCookie } from "./cookie";
+
+export function getPathPrefix(): string {
+	const raw = getCookie("aidbox-base-url");
+	if (!raw) return "";
+	try {
+		return new URL(raw).pathname.replace(/\/+$/, "");
+	} catch {
+		return "";
+	}
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,7 @@ import claudeChat from "./vite-plugin-claude-chat.ts";
 const ReactCompilerConfig = {};
 
 export default defineConfig({
+	base: "./",
 	optimizeDeps: {
 		exclude: ["@health-samurai/aidbox-fhirpath-lsp"],
 	},
@@ -16,6 +17,16 @@ export default defineConfig({
 	// 	},
 	// },
 	plugins: [
+		{
+			name: "inject-base-href",
+			transformIndexHtml: {
+				order: "pre",
+				handler(html, ctx) {
+					const href = ctx.server ? "/" : "/static/aidbox-ui/";
+					return html.replace("<head>", `<head>\n\t<base href="${href}">`);
+				},
+			},
+		},
 		claudeChat(),
 		tailwindcss(),
 		tanstackRouter({


### PR DESCRIPTION
`BOX_WEB_BASE_URL=http://host/my/path` breaks the UI because built `index.html` hardcodes asset paths.

  ## Approach

  Use `<base href>` as the single source of truth for the deployment prefix. All asset URLs in HTML are relative — they resolve against `<base>`. Aidbox mutates one attribute at serve time; client derives router basepath
  and API base URL from `document.baseURI`.

  ## Changes

  - `vite.config.ts`: `base: "./"` (relative asset URLs) + plugin injecting `<base href>` per mode (dev `/`, build `/static/aidbox-ui/`).
  - `index.html`: removed `<base>` (plugin injects); static asset paths made relative.
  - `src/shared/const.ts`: `getPathPrefix()` reads `document.baseURI`; `UI_BASE_PATH = ${prefix}/u`.
  - `src/utils.ts`: `getAidboxBaseURL()` appends prefix to origin.

  ## Aidbox contract

  Aidbox rewrites `<base href="/static/aidbox-ui/">` → `<base href="${prefix}/static/aidbox-ui/">` at serve time.
