### PR TITLE
Analytics rename + UX fixes

### DIFF
--- a/src/components/DataLineage/sidebar.tsx
+++ b/src/components/DataLineage/sidebar.tsx
@@ -169,7 +169,7 @@ function ViewsSection({
 						className="top-0 right-0 h-full w-auto aspect-square rounded-lg"
 					>
 						<Link
-							to="/data-lineage/views/create"
+							to="/analytics/views/create"
 							search={createSearch}
 							className="text-text-link! hover:text-text-link! [&>svg]:text-text-link!"
 							aria-label="Create view"
@@ -188,8 +188,7 @@ function ViewsSection({
 							</HSComp.SidebarMenuSubItem>
 						)}
 						{items.map((it) => {
-							const active =
-								currentPath === `/data-lineage/views/edit/${it.id}`;
+							const active = currentPath === `/analytics/views/edit/${it.id}`;
 							return (
 								<HSComp.SidebarMenuSubItem key={it.id}>
 									<HoverTooltip description={it.description}>
@@ -199,7 +198,7 @@ function ViewsSection({
 											className="text-xs font-normal pl-[11px] data-[active=true]:bg-bg-tertiary data-[active=true]:hover:bg-bg-tertiary"
 										>
 											<Link
-												to="/data-lineage/views/edit/$id"
+												to="/analytics/views/edit/$id"
 												params={{ id: it.id }}
 												search={editSearch}
 											>
@@ -259,7 +258,7 @@ function QueriesSection({
 						className="top-0 right-0 h-full w-auto aspect-square rounded-lg"
 					>
 						<Link
-							to="/data-lineage/queries/create"
+							to="/analytics/queries/create"
 							search={createSearch}
 							className="text-text-link! hover:text-text-link! [&>svg]:text-text-link!"
 							aria-label="Create query"
@@ -278,8 +277,7 @@ function QueriesSection({
 							</HSComp.SidebarMenuSubItem>
 						)}
 						{items.map((it) => {
-							const active =
-								currentPath === `/data-lineage/queries/edit/${it.id}`;
+							const active = currentPath === `/analytics/queries/edit/${it.id}`;
 							return (
 								<HSComp.SidebarMenuSubItem key={it.id}>
 									<HoverTooltip description={it.description}>
@@ -289,7 +287,7 @@ function QueriesSection({
 											className="text-xs font-normal pl-[11px] data-[active=true]:bg-bg-tertiary data-[active=true]:hover:bg-bg-tertiary"
 										>
 											<Link
-												to="/data-lineage/queries/edit/$id"
+												to="/analytics/queries/edit/$id"
 												params={{ id: it.id }}
 												search={editSearch}
 											>

--- a/src/components/ResourceEditor/action.tsx
+++ b/src/components/ResourceEditor/action.tsx
@@ -12,6 +12,19 @@ import { createResource, deleteResource, updateResource } from "./api";
 import type { EditorMode } from "./types";
 import { pageId } from "./types";
 
+const DATA_LINEAGE_SIDEBAR_KEY_BY_RESOURCE_TYPE: Record<string, string> = {
+	Library: "data-lineage-sidebar-queries",
+	ViewDefinition: "data-lineage-sidebar-views",
+};
+
+const invalidateDataLineageSidebar = (
+	queryClient: ReturnType<typeof useQueryClient>,
+	resourceType: string,
+) => {
+	const key = DATA_LINEAGE_SIDEBAR_KEY_BY_RESOURCE_TYPE[resourceType];
+	if (key) queryClient.invalidateQueries({ queryKey: [key] });
+};
+
 export interface SaveHandle {
 	save: () => Promise<Resource>;
 }
@@ -56,6 +69,7 @@ export const SaveButton = ({
 			queryClient.invalidateQueries({
 				queryKey: [pageId, resourceType, id],
 			});
+			invalidateDataLineageSidebar(queryClient, resourceType);
 			if (!resource.id)
 				return Utils.toastError(
 					"Failed to open saved resource",
@@ -112,6 +126,7 @@ export const DeleteButton = ({
 	onDeleted?: () => void;
 }) => {
 	const navigate = Router.useNavigate();
+	const queryClient = useQueryClient();
 	const mutation = useMutation({
 		mutationFn: async () => {
 			return await deleteResource(client, resourceType, id);
@@ -119,6 +134,7 @@ export const DeleteButton = ({
 		onError: Utils.onMutationError,
 		onSuccess: (_resource, _variables, _onMutateResult, _context) => {
 			HSComp.toast.success("Saved", defaultToastPlacement);
+			invalidateDataLineageSidebar(queryClient, resourceType);
 			if (onDeleted) {
 				onDeleted();
 				return;

--- a/src/components/SQLQueryBuilder/builder-content.tsx
+++ b/src/components/SQLQueryBuilder/builder-content.tsx
@@ -183,7 +183,9 @@ export function SQLQueryBuilderContent() {
 				position: "bottom-right",
 				style: { margin: "1rem" },
 			});
-			queryClient.invalidateQueries({ queryKey: ["data-lineage-queries"] });
+			queryClient.invalidateQueries({
+				queryKey: ["data-lineage-sidebar-queries"],
+			});
 			if (created && onCreated) {
 				const id = (resource as SQLLibrary).id;
 				if (id) onCreated(id);

--- a/src/components/SQLQueryBuilder/lineage/detail-panel.tsx
+++ b/src/components/SQLQueryBuilder/lineage/detail-panel.tsx
@@ -390,7 +390,7 @@ export function LineageDetailPanel({
 						ID
 					</span>
 					<Link
-						to="/data-lineage/views/edit/$id"
+						to="/analytics/views/edit/$id"
 						params={{ id: data.id }}
 						search={{
 							tab: "builder" as const,
@@ -469,7 +469,7 @@ export function LineageDetailPanel({
 					ID
 				</span>
 				<Link
-					to="/data-lineage/queries/edit/$id"
+					to="/analytics/queries/edit/$id"
 					params={{ id: data.id }}
 					search={{
 						tab: "sqlquery" as const,

--- a/src/components/SQLQueryBuilder/page.tsx
+++ b/src/components/SQLQueryBuilder/page.tsx
@@ -52,6 +52,7 @@ export function SQLQueryProvider({
 	const setIsDirty = React.useCallback((value: boolean) => {
 		if (!value) {
 			setBaselineHash(computeLibraryHash(libraryRef.current));
+			isDirtyRef.current = false;
 		}
 	}, []);
 	const [runResult, setRunResult] = React.useState<RunResult | null>(null);

--- a/src/components/SQLQueryBuilder/result-panel.tsx
+++ b/src/components/SQLQueryBuilder/result-panel.tsx
@@ -59,6 +59,7 @@ function ResultBody({ page, pageSize }: { page: number; pageSize: number }) {
 					{runResult.columns.map((col) => (
 						<HSComp.TableHead key={col}>{col}</HSComp.TableHead>
 					))}
+					<HSComp.TableHead className="w-full p-0" />
 				</HSComp.TableRow>
 			</HSComp.TableHeader>
 			<HSComp.TableBody>
@@ -77,6 +78,7 @@ function ResultBody({ page, pageSize }: { page: number; pageSize: number }) {
 								</HSComp.TableCell>
 							);
 						})}
+						<HSComp.TableCell className="p-0" />
 					</HSComp.TableRow>
 				))}
 			</HSComp.TableBody>

--- a/src/components/ViewDefinition/editor-form-tab-content.tsx
+++ b/src/components/ViewDefinition/editor-form-tab-content.tsx
@@ -974,7 +974,7 @@ export const FormTabContent = ({
 	const [selectItems, setSelectItems] = useState<SelectItemInternal[]>([]);
 	const [collapsedItemIds, setCollapsedItemIds] = useLocalStorage<string[]>({
 		key: `viewDefinition-form-collapsed-${viewDefinition?.id || "default"}`,
-		defaultValue: ["_properties"],
+		defaultValue: [],
 	});
 
 	const paramPrefix = /^Parameters\.parameter\[\d+\]\.resource\./;

--- a/src/components/ViewDefinition/editor-panel-content.tsx
+++ b/src/components/ViewDefinition/editor-panel-content.tsx
@@ -16,7 +16,7 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "@health-samurai/react-components";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import * as Lucide from "lucide-react";
 import React from "react";
@@ -277,6 +277,11 @@ export const useViewDefinitionActions = (
 	options?: { onRunSuccess?: () => void },
 ) => {
 	const navigate = useNavigate({ from: "/resource/$resourceType/create" });
+	const queryClient = useQueryClient();
+	const invalidateSidebar = () =>
+		queryClient.invalidateQueries({
+			queryKey: ["data-lineage-sidebar-views"],
+		});
 	const viewDefinitionContext = React.useContext(ViewDefinitionContext);
 	const viewDefinitionResource = viewDefinitionContext.viewDefinition;
 
@@ -300,6 +305,7 @@ export const useViewDefinitionActions = (
 
 			viewDefinitionContext.setRunError(undefined);
 			viewDefinitionContext.setIsDirty(false);
+			invalidateSidebar();
 			HSComp.toast.success("ViewDefinition saved successfully", {
 				position: "bottom-right",
 				style: { margin: "1rem" },
@@ -325,6 +331,7 @@ export const useViewDefinitionActions = (
 
 			viewDefinitionContext.setRunError(undefined);
 			viewDefinitionContext.setIsDirty(false);
+			invalidateSidebar();
 			const id = result.value.resource.id;
 			if (!id)
 				return Utils.toastError(
@@ -510,6 +517,7 @@ export const useViewDefinitionActions = (
 		},
 		onSuccess: () => {
 			viewDefinitionContext.setIsDirty(false);
+			invalidateSidebar();
 			HSComp.toast.success("ViewDefinition deleted successfully", {
 				position: "bottom-right",
 				style: { margin: "1rem" },

--- a/src/layout/navbar.tsx
+++ b/src/layout/navbar.tsx
@@ -39,8 +39,8 @@ import { PREFERRED_UI_KEY, THEME_KEY, VIM_MODE_KEY } from "../shared/const";
 import { getAidboxBaseURL } from "../utils";
 
 function inferResourceTypeFromPath(path: string): string | null {
-	if (/^\/data-lineage\/views\/edit\//.test(path)) return "ViewDefinition";
-	if (/^\/data-lineage\/queries\/edit\//.test(path)) return "Library";
+	if (/^\/analytics\/views\/edit\//.test(path)) return "ViewDefinition";
+	if (/^\/analytics\/queries\/edit\//.test(path)) return "Library";
 	const m = path.match(/^\/resource\/([^/]+)\/edit\//);
 	if (m?.[1]) return m[1];
 	return null;

--- a/src/layout/sidebar.tsx
+++ b/src/layout/sidebar.tsx
@@ -14,6 +14,7 @@ import {
 	ClipboardList,
 	Columns3Cog,
 	Database,
+	FileChartPie,
 	Package,
 	PanelLeftClose,
 	PanelLeftOpen,
@@ -21,7 +22,6 @@ import {
 	ShieldUser,
 	SquareArrowOutUpRight,
 	SquareTerminal,
-	Workflow,
 } from "lucide-react";
 import { useEffect } from "react";
 import { useAuditLogEnabled } from "../components/AuditEvents/api";
@@ -67,12 +67,12 @@ const mainMenuItems: {
 		),
 	},
 	{
-		url: "/data-lineage",
-		title: "Data Lineage",
+		url: "/analytics",
+		title: "Analytics",
 		link: (
-			<Link to="/data-lineage">
-				<Workflow />
-				Data Lineage
+			<Link to="/analytics">
+				<FileChartPie />
+				Analytics
 			</Link>
 		),
 	},

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -14,27 +14,27 @@ import { Route as RestRouteImport } from './routes/rest'
 import { Route as ResourceRouteImport } from './routes/resource'
 import { Route as IgRouteImport } from './routes/ig'
 import { Route as DbConsoleRouteImport } from './routes/db-console'
-import { Route as DataLineageRouteImport } from './routes/data-lineage'
 import { Route as AuditEventsRouteImport } from './routes/audit-events'
+import { Route as AnalyticsRouteImport } from './routes/analytics'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ResourceIndexRouteImport } from './routes/resource.index'
 import { Route as IgIndexRouteImport } from './routes/ig.index'
-import { Route as DataLineageIndexRouteImport } from './routes/data-lineage.index'
+import { Route as AnalyticsIndexRouteImport } from './routes/analytics.index'
 import { Route as ResourceResourceTypeRouteImport } from './routes/resource.$resourceType'
 import { Route as IgAddRouteImport } from './routes/ig.add'
 import { Route as IgPackageIdRouteImport } from './routes/ig.$packageId'
-import { Route as DataLineageViewsRouteImport } from './routes/data-lineage.views'
-import { Route as DataLineageQueriesRouteImport } from './routes/data-lineage.queries'
+import { Route as AnalyticsViewsRouteImport } from './routes/analytics.views'
+import { Route as AnalyticsQueriesRouteImport } from './routes/analytics.queries'
 import { Route as ResourceResourceTypeIndexRouteImport } from './routes/resource.$resourceType.index'
 import { Route as IgPackageIdIndexRouteImport } from './routes/ig.$packageId.index'
-import { Route as DataLineageViewsIndexRouteImport } from './routes/data-lineage.views.index'
-import { Route as DataLineageQueriesIndexRouteImport } from './routes/data-lineage.queries.index'
+import { Route as AnalyticsViewsIndexRouteImport } from './routes/analytics.views.index'
+import { Route as AnalyticsQueriesIndexRouteImport } from './routes/analytics.queries.index'
 import { Route as ResourceResourceTypeCreateRouteImport } from './routes/resource.$resourceType.create'
-import { Route as DataLineageViewsCreateRouteImport } from './routes/data-lineage.views.create'
-import { Route as DataLineageQueriesCreateRouteImport } from './routes/data-lineage.queries.create'
+import { Route as AnalyticsViewsCreateRouteImport } from './routes/analytics.views.create'
+import { Route as AnalyticsQueriesCreateRouteImport } from './routes/analytics.queries.create'
 import { Route as ResourceResourceTypeEditIdRouteImport } from './routes/resource.$resourceType.edit.$id'
-import { Route as DataLineageViewsEditIdRouteImport } from './routes/data-lineage.views.edit.$id'
-import { Route as DataLineageQueriesEditIdRouteImport } from './routes/data-lineage.queries.edit.$id'
+import { Route as AnalyticsViewsEditIdRouteImport } from './routes/analytics.views.edit.$id'
+import { Route as AnalyticsQueriesEditIdRouteImport } from './routes/analytics.queries.edit.$id'
 import { Route as IgPackageIdResourceResourceTypeResourceIdRouteImport } from './routes/ig.$packageId.resource.$resourceType.$resourceId'
 
 const SettingsRoute = SettingsRouteImport.update({
@@ -62,14 +62,14 @@ const DbConsoleRoute = DbConsoleRouteImport.update({
   path: '/db-console',
   getParentRoute: () => rootRouteImport,
 } as any)
-const DataLineageRoute = DataLineageRouteImport.update({
-  id: '/data-lineage',
-  path: '/data-lineage',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const AuditEventsRoute = AuditEventsRouteImport.update({
   id: '/audit-events',
   path: '/audit-events',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AnalyticsRoute = AnalyticsRouteImport.update({
+  id: '/analytics',
+  path: '/analytics',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -87,10 +87,10 @@ const IgIndexRoute = IgIndexRouteImport.update({
   path: '/',
   getParentRoute: () => IgRoute,
 } as any)
-const DataLineageIndexRoute = DataLineageIndexRouteImport.update({
+const AnalyticsIndexRoute = AnalyticsIndexRouteImport.update({
   id: '/',
   path: '/',
-  getParentRoute: () => DataLineageRoute,
+  getParentRoute: () => AnalyticsRoute,
 } as any)
 const ResourceResourceTypeRoute = ResourceResourceTypeRouteImport.update({
   id: '/$resourceType',
@@ -107,15 +107,15 @@ const IgPackageIdRoute = IgPackageIdRouteImport.update({
   path: '/$packageId',
   getParentRoute: () => IgRoute,
 } as any)
-const DataLineageViewsRoute = DataLineageViewsRouteImport.update({
+const AnalyticsViewsRoute = AnalyticsViewsRouteImport.update({
   id: '/views',
   path: '/views',
-  getParentRoute: () => DataLineageRoute,
+  getParentRoute: () => AnalyticsRoute,
 } as any)
-const DataLineageQueriesRoute = DataLineageQueriesRouteImport.update({
+const AnalyticsQueriesRoute = AnalyticsQueriesRouteImport.update({
   id: '/queries',
   path: '/queries',
-  getParentRoute: () => DataLineageRoute,
+  getParentRoute: () => AnalyticsRoute,
 } as any)
 const ResourceResourceTypeIndexRoute =
   ResourceResourceTypeIndexRouteImport.update({
@@ -128,15 +128,15 @@ const IgPackageIdIndexRoute = IgPackageIdIndexRouteImport.update({
   path: '/',
   getParentRoute: () => IgPackageIdRoute,
 } as any)
-const DataLineageViewsIndexRoute = DataLineageViewsIndexRouteImport.update({
+const AnalyticsViewsIndexRoute = AnalyticsViewsIndexRouteImport.update({
   id: '/',
   path: '/',
-  getParentRoute: () => DataLineageViewsRoute,
+  getParentRoute: () => AnalyticsViewsRoute,
 } as any)
-const DataLineageQueriesIndexRoute = DataLineageQueriesIndexRouteImport.update({
+const AnalyticsQueriesIndexRoute = AnalyticsQueriesIndexRouteImport.update({
   id: '/',
   path: '/',
-  getParentRoute: () => DataLineageQueriesRoute,
+  getParentRoute: () => AnalyticsQueriesRoute,
 } as any)
 const ResourceResourceTypeCreateRoute =
   ResourceResourceTypeCreateRouteImport.update({
@@ -144,34 +144,32 @@ const ResourceResourceTypeCreateRoute =
     path: '/create',
     getParentRoute: () => ResourceResourceTypeRoute,
   } as any)
-const DataLineageViewsCreateRoute = DataLineageViewsCreateRouteImport.update({
+const AnalyticsViewsCreateRoute = AnalyticsViewsCreateRouteImport.update({
   id: '/create',
   path: '/create',
-  getParentRoute: () => DataLineageViewsRoute,
+  getParentRoute: () => AnalyticsViewsRoute,
 } as any)
-const DataLineageQueriesCreateRoute =
-  DataLineageQueriesCreateRouteImport.update({
-    id: '/create',
-    path: '/create',
-    getParentRoute: () => DataLineageQueriesRoute,
-  } as any)
+const AnalyticsQueriesCreateRoute = AnalyticsQueriesCreateRouteImport.update({
+  id: '/create',
+  path: '/create',
+  getParentRoute: () => AnalyticsQueriesRoute,
+} as any)
 const ResourceResourceTypeEditIdRoute =
   ResourceResourceTypeEditIdRouteImport.update({
     id: '/edit/$id',
     path: '/edit/$id',
     getParentRoute: () => ResourceResourceTypeRoute,
   } as any)
-const DataLineageViewsEditIdRoute = DataLineageViewsEditIdRouteImport.update({
+const AnalyticsViewsEditIdRoute = AnalyticsViewsEditIdRouteImport.update({
   id: '/edit/$id',
   path: '/edit/$id',
-  getParentRoute: () => DataLineageViewsRoute,
+  getParentRoute: () => AnalyticsViewsRoute,
 } as any)
-const DataLineageQueriesEditIdRoute =
-  DataLineageQueriesEditIdRouteImport.update({
-    id: '/edit/$id',
-    path: '/edit/$id',
-    getParentRoute: () => DataLineageQueriesRoute,
-  } as any)
+const AnalyticsQueriesEditIdRoute = AnalyticsQueriesEditIdRouteImport.update({
+  id: '/edit/$id',
+  path: '/edit/$id',
+  getParentRoute: () => AnalyticsQueriesRoute,
+} as any)
 const IgPackageIdResourceResourceTypeResourceIdRoute =
   IgPackageIdResourceResourceTypeResourceIdRouteImport.update({
     id: '/resource/$resourceType/$resourceId',
@@ -181,30 +179,30 @@ const IgPackageIdResourceResourceTypeResourceIdRoute =
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/analytics': typeof AnalyticsRouteWithChildren
   '/audit-events': typeof AuditEventsRoute
-  '/data-lineage': typeof DataLineageRouteWithChildren
   '/db-console': typeof DbConsoleRoute
   '/ig': typeof IgRouteWithChildren
   '/resource': typeof ResourceRouteWithChildren
   '/rest': typeof RestRoute
   '/settings': typeof SettingsRoute
-  '/data-lineage/queries': typeof DataLineageQueriesRouteWithChildren
-  '/data-lineage/views': typeof DataLineageViewsRouteWithChildren
+  '/analytics/queries': typeof AnalyticsQueriesRouteWithChildren
+  '/analytics/views': typeof AnalyticsViewsRouteWithChildren
   '/ig/$packageId': typeof IgPackageIdRouteWithChildren
   '/ig/add': typeof IgAddRoute
   '/resource/$resourceType': typeof ResourceResourceTypeRouteWithChildren
-  '/data-lineage/': typeof DataLineageIndexRoute
+  '/analytics/': typeof AnalyticsIndexRoute
   '/ig/': typeof IgIndexRoute
   '/resource/': typeof ResourceIndexRoute
-  '/data-lineage/queries/create': typeof DataLineageQueriesCreateRoute
-  '/data-lineage/views/create': typeof DataLineageViewsCreateRoute
+  '/analytics/queries/create': typeof AnalyticsQueriesCreateRoute
+  '/analytics/views/create': typeof AnalyticsViewsCreateRoute
   '/resource/$resourceType/create': typeof ResourceResourceTypeCreateRoute
-  '/data-lineage/queries/': typeof DataLineageQueriesIndexRoute
-  '/data-lineage/views/': typeof DataLineageViewsIndexRoute
+  '/analytics/queries/': typeof AnalyticsQueriesIndexRoute
+  '/analytics/views/': typeof AnalyticsViewsIndexRoute
   '/ig/$packageId/': typeof IgPackageIdIndexRoute
   '/resource/$resourceType/': typeof ResourceResourceTypeIndexRoute
-  '/data-lineage/queries/edit/$id': typeof DataLineageQueriesEditIdRoute
-  '/data-lineage/views/edit/$id': typeof DataLineageViewsEditIdRoute
+  '/analytics/queries/edit/$id': typeof AnalyticsQueriesEditIdRoute
+  '/analytics/views/edit/$id': typeof AnalyticsViewsEditIdRoute
   '/resource/$resourceType/edit/$id': typeof ResourceResourceTypeEditIdRoute
   '/ig/$packageId/resource/$resourceType/$resourceId': typeof IgPackageIdResourceResourceTypeResourceIdRoute
 }
@@ -215,48 +213,48 @@ export interface FileRoutesByTo {
   '/rest': typeof RestRoute
   '/settings': typeof SettingsRoute
   '/ig/add': typeof IgAddRoute
-  '/data-lineage': typeof DataLineageIndexRoute
+  '/analytics': typeof AnalyticsIndexRoute
   '/ig': typeof IgIndexRoute
   '/resource': typeof ResourceIndexRoute
-  '/data-lineage/queries/create': typeof DataLineageQueriesCreateRoute
-  '/data-lineage/views/create': typeof DataLineageViewsCreateRoute
+  '/analytics/queries/create': typeof AnalyticsQueriesCreateRoute
+  '/analytics/views/create': typeof AnalyticsViewsCreateRoute
   '/resource/$resourceType/create': typeof ResourceResourceTypeCreateRoute
-  '/data-lineage/queries': typeof DataLineageQueriesIndexRoute
-  '/data-lineage/views': typeof DataLineageViewsIndexRoute
+  '/analytics/queries': typeof AnalyticsQueriesIndexRoute
+  '/analytics/views': typeof AnalyticsViewsIndexRoute
   '/ig/$packageId': typeof IgPackageIdIndexRoute
   '/resource/$resourceType': typeof ResourceResourceTypeIndexRoute
-  '/data-lineage/queries/edit/$id': typeof DataLineageQueriesEditIdRoute
-  '/data-lineage/views/edit/$id': typeof DataLineageViewsEditIdRoute
+  '/analytics/queries/edit/$id': typeof AnalyticsQueriesEditIdRoute
+  '/analytics/views/edit/$id': typeof AnalyticsViewsEditIdRoute
   '/resource/$resourceType/edit/$id': typeof ResourceResourceTypeEditIdRoute
   '/ig/$packageId/resource/$resourceType/$resourceId': typeof IgPackageIdResourceResourceTypeResourceIdRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/analytics': typeof AnalyticsRouteWithChildren
   '/audit-events': typeof AuditEventsRoute
-  '/data-lineage': typeof DataLineageRouteWithChildren
   '/db-console': typeof DbConsoleRoute
   '/ig': typeof IgRouteWithChildren
   '/resource': typeof ResourceRouteWithChildren
   '/rest': typeof RestRoute
   '/settings': typeof SettingsRoute
-  '/data-lineage/queries': typeof DataLineageQueriesRouteWithChildren
-  '/data-lineage/views': typeof DataLineageViewsRouteWithChildren
+  '/analytics/queries': typeof AnalyticsQueriesRouteWithChildren
+  '/analytics/views': typeof AnalyticsViewsRouteWithChildren
   '/ig/$packageId': typeof IgPackageIdRouteWithChildren
   '/ig/add': typeof IgAddRoute
   '/resource/$resourceType': typeof ResourceResourceTypeRouteWithChildren
-  '/data-lineage/': typeof DataLineageIndexRoute
+  '/analytics/': typeof AnalyticsIndexRoute
   '/ig/': typeof IgIndexRoute
   '/resource/': typeof ResourceIndexRoute
-  '/data-lineage/queries/create': typeof DataLineageQueriesCreateRoute
-  '/data-lineage/views/create': typeof DataLineageViewsCreateRoute
+  '/analytics/queries/create': typeof AnalyticsQueriesCreateRoute
+  '/analytics/views/create': typeof AnalyticsViewsCreateRoute
   '/resource/$resourceType/create': typeof ResourceResourceTypeCreateRoute
-  '/data-lineage/queries/': typeof DataLineageQueriesIndexRoute
-  '/data-lineage/views/': typeof DataLineageViewsIndexRoute
+  '/analytics/queries/': typeof AnalyticsQueriesIndexRoute
+  '/analytics/views/': typeof AnalyticsViewsIndexRoute
   '/ig/$packageId/': typeof IgPackageIdIndexRoute
   '/resource/$resourceType/': typeof ResourceResourceTypeIndexRoute
-  '/data-lineage/queries/edit/$id': typeof DataLineageQueriesEditIdRoute
-  '/data-lineage/views/edit/$id': typeof DataLineageViewsEditIdRoute
+  '/analytics/queries/edit/$id': typeof AnalyticsQueriesEditIdRoute
+  '/analytics/views/edit/$id': typeof AnalyticsViewsEditIdRoute
   '/resource/$resourceType/edit/$id': typeof ResourceResourceTypeEditIdRoute
   '/ig/$packageId/resource/$resourceType/$resourceId': typeof IgPackageIdResourceResourceTypeResourceIdRoute
 }
@@ -264,30 +262,30 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/analytics'
     | '/audit-events'
-    | '/data-lineage'
     | '/db-console'
     | '/ig'
     | '/resource'
     | '/rest'
     | '/settings'
-    | '/data-lineage/queries'
-    | '/data-lineage/views'
+    | '/analytics/queries'
+    | '/analytics/views'
     | '/ig/$packageId'
     | '/ig/add'
     | '/resource/$resourceType'
-    | '/data-lineage/'
+    | '/analytics/'
     | '/ig/'
     | '/resource/'
-    | '/data-lineage/queries/create'
-    | '/data-lineage/views/create'
+    | '/analytics/queries/create'
+    | '/analytics/views/create'
     | '/resource/$resourceType/create'
-    | '/data-lineage/queries/'
-    | '/data-lineage/views/'
+    | '/analytics/queries/'
+    | '/analytics/views/'
     | '/ig/$packageId/'
     | '/resource/$resourceType/'
-    | '/data-lineage/queries/edit/$id'
-    | '/data-lineage/views/edit/$id'
+    | '/analytics/queries/edit/$id'
+    | '/analytics/views/edit/$id'
     | '/resource/$resourceType/edit/$id'
     | '/ig/$packageId/resource/$resourceType/$resourceId'
   fileRoutesByTo: FileRoutesByTo
@@ -298,55 +296,55 @@ export interface FileRouteTypes {
     | '/rest'
     | '/settings'
     | '/ig/add'
-    | '/data-lineage'
+    | '/analytics'
     | '/ig'
     | '/resource'
-    | '/data-lineage/queries/create'
-    | '/data-lineage/views/create'
+    | '/analytics/queries/create'
+    | '/analytics/views/create'
     | '/resource/$resourceType/create'
-    | '/data-lineage/queries'
-    | '/data-lineage/views'
+    | '/analytics/queries'
+    | '/analytics/views'
     | '/ig/$packageId'
     | '/resource/$resourceType'
-    | '/data-lineage/queries/edit/$id'
-    | '/data-lineage/views/edit/$id'
+    | '/analytics/queries/edit/$id'
+    | '/analytics/views/edit/$id'
     | '/resource/$resourceType/edit/$id'
     | '/ig/$packageId/resource/$resourceType/$resourceId'
   id:
     | '__root__'
     | '/'
+    | '/analytics'
     | '/audit-events'
-    | '/data-lineage'
     | '/db-console'
     | '/ig'
     | '/resource'
     | '/rest'
     | '/settings'
-    | '/data-lineage/queries'
-    | '/data-lineage/views'
+    | '/analytics/queries'
+    | '/analytics/views'
     | '/ig/$packageId'
     | '/ig/add'
     | '/resource/$resourceType'
-    | '/data-lineage/'
+    | '/analytics/'
     | '/ig/'
     | '/resource/'
-    | '/data-lineage/queries/create'
-    | '/data-lineage/views/create'
+    | '/analytics/queries/create'
+    | '/analytics/views/create'
     | '/resource/$resourceType/create'
-    | '/data-lineage/queries/'
-    | '/data-lineage/views/'
+    | '/analytics/queries/'
+    | '/analytics/views/'
     | '/ig/$packageId/'
     | '/resource/$resourceType/'
-    | '/data-lineage/queries/edit/$id'
-    | '/data-lineage/views/edit/$id'
+    | '/analytics/queries/edit/$id'
+    | '/analytics/views/edit/$id'
     | '/resource/$resourceType/edit/$id'
     | '/ig/$packageId/resource/$resourceType/$resourceId'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  AnalyticsRoute: typeof AnalyticsRouteWithChildren
   AuditEventsRoute: typeof AuditEventsRoute
-  DataLineageRoute: typeof DataLineageRouteWithChildren
   DbConsoleRoute: typeof DbConsoleRoute
   IgRoute: typeof IgRouteWithChildren
   ResourceRoute: typeof ResourceRouteWithChildren
@@ -391,18 +389,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DbConsoleRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/data-lineage': {
-      id: '/data-lineage'
-      path: '/data-lineage'
-      fullPath: '/data-lineage'
-      preLoaderRoute: typeof DataLineageRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/audit-events': {
       id: '/audit-events'
       path: '/audit-events'
       fullPath: '/audit-events'
       preLoaderRoute: typeof AuditEventsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/analytics': {
+      id: '/analytics'
+      path: '/analytics'
+      fullPath: '/analytics'
+      preLoaderRoute: typeof AnalyticsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -426,12 +424,12 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IgIndexRouteImport
       parentRoute: typeof IgRoute
     }
-    '/data-lineage/': {
-      id: '/data-lineage/'
+    '/analytics/': {
+      id: '/analytics/'
       path: '/'
-      fullPath: '/data-lineage/'
-      preLoaderRoute: typeof DataLineageIndexRouteImport
-      parentRoute: typeof DataLineageRoute
+      fullPath: '/analytics/'
+      preLoaderRoute: typeof AnalyticsIndexRouteImport
+      parentRoute: typeof AnalyticsRoute
     }
     '/resource/$resourceType': {
       id: '/resource/$resourceType'
@@ -454,19 +452,19 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IgPackageIdRouteImport
       parentRoute: typeof IgRoute
     }
-    '/data-lineage/views': {
-      id: '/data-lineage/views'
+    '/analytics/views': {
+      id: '/analytics/views'
       path: '/views'
-      fullPath: '/data-lineage/views'
-      preLoaderRoute: typeof DataLineageViewsRouteImport
-      parentRoute: typeof DataLineageRoute
+      fullPath: '/analytics/views'
+      preLoaderRoute: typeof AnalyticsViewsRouteImport
+      parentRoute: typeof AnalyticsRoute
     }
-    '/data-lineage/queries': {
-      id: '/data-lineage/queries'
+    '/analytics/queries': {
+      id: '/analytics/queries'
       path: '/queries'
-      fullPath: '/data-lineage/queries'
-      preLoaderRoute: typeof DataLineageQueriesRouteImport
-      parentRoute: typeof DataLineageRoute
+      fullPath: '/analytics/queries'
+      preLoaderRoute: typeof AnalyticsQueriesRouteImport
+      parentRoute: typeof AnalyticsRoute
     }
     '/resource/$resourceType/': {
       id: '/resource/$resourceType/'
@@ -482,19 +480,19 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IgPackageIdIndexRouteImport
       parentRoute: typeof IgPackageIdRoute
     }
-    '/data-lineage/views/': {
-      id: '/data-lineage/views/'
+    '/analytics/views/': {
+      id: '/analytics/views/'
       path: '/'
-      fullPath: '/data-lineage/views/'
-      preLoaderRoute: typeof DataLineageViewsIndexRouteImport
-      parentRoute: typeof DataLineageViewsRoute
+      fullPath: '/analytics/views/'
+      preLoaderRoute: typeof AnalyticsViewsIndexRouteImport
+      parentRoute: typeof AnalyticsViewsRoute
     }
-    '/data-lineage/queries/': {
-      id: '/data-lineage/queries/'
+    '/analytics/queries/': {
+      id: '/analytics/queries/'
       path: '/'
-      fullPath: '/data-lineage/queries/'
-      preLoaderRoute: typeof DataLineageQueriesIndexRouteImport
-      parentRoute: typeof DataLineageQueriesRoute
+      fullPath: '/analytics/queries/'
+      preLoaderRoute: typeof AnalyticsQueriesIndexRouteImport
+      parentRoute: typeof AnalyticsQueriesRoute
     }
     '/resource/$resourceType/create': {
       id: '/resource/$resourceType/create'
@@ -503,19 +501,19 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ResourceResourceTypeCreateRouteImport
       parentRoute: typeof ResourceResourceTypeRoute
     }
-    '/data-lineage/views/create': {
-      id: '/data-lineage/views/create'
+    '/analytics/views/create': {
+      id: '/analytics/views/create'
       path: '/create'
-      fullPath: '/data-lineage/views/create'
-      preLoaderRoute: typeof DataLineageViewsCreateRouteImport
-      parentRoute: typeof DataLineageViewsRoute
+      fullPath: '/analytics/views/create'
+      preLoaderRoute: typeof AnalyticsViewsCreateRouteImport
+      parentRoute: typeof AnalyticsViewsRoute
     }
-    '/data-lineage/queries/create': {
-      id: '/data-lineage/queries/create'
+    '/analytics/queries/create': {
+      id: '/analytics/queries/create'
       path: '/create'
-      fullPath: '/data-lineage/queries/create'
-      preLoaderRoute: typeof DataLineageQueriesCreateRouteImport
-      parentRoute: typeof DataLineageQueriesRoute
+      fullPath: '/analytics/queries/create'
+      preLoaderRoute: typeof AnalyticsQueriesCreateRouteImport
+      parentRoute: typeof AnalyticsQueriesRoute
     }
     '/resource/$resourceType/edit/$id': {
       id: '/resource/$resourceType/edit/$id'
@@ -524,19 +522,19 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ResourceResourceTypeEditIdRouteImport
       parentRoute: typeof ResourceResourceTypeRoute
     }
-    '/data-lineage/views/edit/$id': {
-      id: '/data-lineage/views/edit/$id'
+    '/analytics/views/edit/$id': {
+      id: '/analytics/views/edit/$id'
       path: '/edit/$id'
-      fullPath: '/data-lineage/views/edit/$id'
-      preLoaderRoute: typeof DataLineageViewsEditIdRouteImport
-      parentRoute: typeof DataLineageViewsRoute
+      fullPath: '/analytics/views/edit/$id'
+      preLoaderRoute: typeof AnalyticsViewsEditIdRouteImport
+      parentRoute: typeof AnalyticsViewsRoute
     }
-    '/data-lineage/queries/edit/$id': {
-      id: '/data-lineage/queries/edit/$id'
+    '/analytics/queries/edit/$id': {
+      id: '/analytics/queries/edit/$id'
       path: '/edit/$id'
-      fullPath: '/data-lineage/queries/edit/$id'
-      preLoaderRoute: typeof DataLineageQueriesEditIdRouteImport
-      parentRoute: typeof DataLineageQueriesRoute
+      fullPath: '/analytics/queries/edit/$id'
+      preLoaderRoute: typeof AnalyticsQueriesEditIdRouteImport
+      parentRoute: typeof AnalyticsQueriesRoute
     }
     '/ig/$packageId/resource/$resourceType/$resourceId': {
       id: '/ig/$packageId/resource/$resourceType/$resourceId'
@@ -548,50 +546,51 @@ declare module '@tanstack/react-router' {
   }
 }
 
-interface DataLineageQueriesRouteChildren {
-  DataLineageQueriesCreateRoute: typeof DataLineageQueriesCreateRoute
-  DataLineageQueriesIndexRoute: typeof DataLineageQueriesIndexRoute
-  DataLineageQueriesEditIdRoute: typeof DataLineageQueriesEditIdRoute
+interface AnalyticsQueriesRouteChildren {
+  AnalyticsQueriesCreateRoute: typeof AnalyticsQueriesCreateRoute
+  AnalyticsQueriesIndexRoute: typeof AnalyticsQueriesIndexRoute
+  AnalyticsQueriesEditIdRoute: typeof AnalyticsQueriesEditIdRoute
 }
 
-const DataLineageQueriesRouteChildren: DataLineageQueriesRouteChildren = {
-  DataLineageQueriesCreateRoute: DataLineageQueriesCreateRoute,
-  DataLineageQueriesIndexRoute: DataLineageQueriesIndexRoute,
-  DataLineageQueriesEditIdRoute: DataLineageQueriesEditIdRoute,
+const AnalyticsQueriesRouteChildren: AnalyticsQueriesRouteChildren = {
+  AnalyticsQueriesCreateRoute: AnalyticsQueriesCreateRoute,
+  AnalyticsQueriesIndexRoute: AnalyticsQueriesIndexRoute,
+  AnalyticsQueriesEditIdRoute: AnalyticsQueriesEditIdRoute,
 }
 
-const DataLineageQueriesRouteWithChildren =
-  DataLineageQueriesRoute._addFileChildren(DataLineageQueriesRouteChildren)
+const AnalyticsQueriesRouteWithChildren =
+  AnalyticsQueriesRoute._addFileChildren(AnalyticsQueriesRouteChildren)
 
-interface DataLineageViewsRouteChildren {
-  DataLineageViewsCreateRoute: typeof DataLineageViewsCreateRoute
-  DataLineageViewsIndexRoute: typeof DataLineageViewsIndexRoute
-  DataLineageViewsEditIdRoute: typeof DataLineageViewsEditIdRoute
+interface AnalyticsViewsRouteChildren {
+  AnalyticsViewsCreateRoute: typeof AnalyticsViewsCreateRoute
+  AnalyticsViewsIndexRoute: typeof AnalyticsViewsIndexRoute
+  AnalyticsViewsEditIdRoute: typeof AnalyticsViewsEditIdRoute
 }
 
-const DataLineageViewsRouteChildren: DataLineageViewsRouteChildren = {
-  DataLineageViewsCreateRoute: DataLineageViewsCreateRoute,
-  DataLineageViewsIndexRoute: DataLineageViewsIndexRoute,
-  DataLineageViewsEditIdRoute: DataLineageViewsEditIdRoute,
+const AnalyticsViewsRouteChildren: AnalyticsViewsRouteChildren = {
+  AnalyticsViewsCreateRoute: AnalyticsViewsCreateRoute,
+  AnalyticsViewsIndexRoute: AnalyticsViewsIndexRoute,
+  AnalyticsViewsEditIdRoute: AnalyticsViewsEditIdRoute,
 }
 
-const DataLineageViewsRouteWithChildren =
-  DataLineageViewsRoute._addFileChildren(DataLineageViewsRouteChildren)
+const AnalyticsViewsRouteWithChildren = AnalyticsViewsRoute._addFileChildren(
+  AnalyticsViewsRouteChildren,
+)
 
-interface DataLineageRouteChildren {
-  DataLineageQueriesRoute: typeof DataLineageQueriesRouteWithChildren
-  DataLineageViewsRoute: typeof DataLineageViewsRouteWithChildren
-  DataLineageIndexRoute: typeof DataLineageIndexRoute
+interface AnalyticsRouteChildren {
+  AnalyticsQueriesRoute: typeof AnalyticsQueriesRouteWithChildren
+  AnalyticsViewsRoute: typeof AnalyticsViewsRouteWithChildren
+  AnalyticsIndexRoute: typeof AnalyticsIndexRoute
 }
 
-const DataLineageRouteChildren: DataLineageRouteChildren = {
-  DataLineageQueriesRoute: DataLineageQueriesRouteWithChildren,
-  DataLineageViewsRoute: DataLineageViewsRouteWithChildren,
-  DataLineageIndexRoute: DataLineageIndexRoute,
+const AnalyticsRouteChildren: AnalyticsRouteChildren = {
+  AnalyticsQueriesRoute: AnalyticsQueriesRouteWithChildren,
+  AnalyticsViewsRoute: AnalyticsViewsRouteWithChildren,
+  AnalyticsIndexRoute: AnalyticsIndexRoute,
 }
 
-const DataLineageRouteWithChildren = DataLineageRoute._addFileChildren(
-  DataLineageRouteChildren,
+const AnalyticsRouteWithChildren = AnalyticsRoute._addFileChildren(
+  AnalyticsRouteChildren,
 )
 
 interface IgPackageIdRouteChildren {
@@ -654,8 +653,8 @@ const ResourceRouteWithChildren = ResourceRoute._addFileChildren(
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  AnalyticsRoute: AnalyticsRouteWithChildren,
   AuditEventsRoute: AuditEventsRoute,
-  DataLineageRoute: DataLineageRouteWithChildren,
   DbConsoleRoute: DbConsoleRoute,
   IgRoute: IgRouteWithChildren,
   ResourceRoute: ResourceRouteWithChildren,

--- a/src/routes/analytics.index.tsx
+++ b/src/routes/analytics.index.tsx
@@ -4,12 +4,12 @@ import { EmptyState } from "../components/empty-state";
 function DataLineageIndex() {
 	return (
 		<EmptyState
-			title="Data Lineage"
+			title="Analytics"
 			description="Select a view or query from the sidebar, or create a new one."
 		/>
 	);
 }
 
-export const Route = createFileRoute("/data-lineage/")({
+export const Route = createFileRoute("/analytics/")({
 	component: DataLineageIndex,
 });

--- a/src/routes/analytics.queries.create.tsx
+++ b/src/routes/analytics.queries.create.tsx
@@ -8,29 +8,38 @@ import {
 import { validateSearch } from "./resource.$resourceType.create";
 
 const initialResource: Resource = {
-	resource: "Patient",
-	resourceType: "ViewDefinition",
-	status: "draft",
-	select: [],
+	resourceType: "Library",
+	meta: {
+		profile: ["https://sql-on-fhir.org/ig/StructureDefinition/SQLQuery"],
+	},
+	status: "active",
+	type: {
+		coding: [
+			{
+				system: "https://sql-on-fhir.org/ig/CodeSystem/LibraryTypesCodes",
+				code: "sql-query",
+			},
+		],
+	},
 } as Resource;
 
 const PageComponent = () => {
 	const navigate = useNavigate();
-	const { tab, mode } = useSearch({ from: "/data-lineage/views/create" });
+	const { tab, mode } = useSearch({ from: "/analytics/queries/create" });
 
 	return (
 		<ResourceEditorPage
 			initialResource={initialResource}
-			resourceType="ViewDefinition"
+			resourceType="Library"
 			tab={tab}
 			mode={mode}
 			navigate={navigate}
 			onCreated={(id) =>
 				navigate({
-					to: "/data-lineage/views/edit/$id",
+					to: "/analytics/queries/edit/$id",
 					params: { id },
 					search: {
-						tab: "builder" as const,
+						tab: "sqlquery" as const,
 						mode: "json" as const,
 						builderTab: "form" as const,
 					},
@@ -40,9 +49,9 @@ const PageComponent = () => {
 	);
 };
 
-export const Route = createFileRoute("/data-lineage/views/create")({
+export const Route = createFileRoute("/analytics/queries/create")({
 	component: PageComponent,
 	validateSearch,
-	staticData: { title: "Create View" },
+	staticData: { title: "Create Query" },
 	loader: () => ({ breadCrumb: "Create" }),
 });

--- a/src/routes/analytics.queries.edit.$id.tsx
+++ b/src/routes/analytics.queries.edit.$id.tsx
@@ -8,9 +8,9 @@ import { validateSearch } from "./resource.$resourceType.create";
 
 const PageComponent = () => {
 	const { id } = Route.useParams();
-	const navigate = useNavigate({ from: "/data-lineage/queries/edit/$id" });
+	const navigate = useNavigate({ from: "/analytics/queries/edit/$id" });
 	const { tab, mode } = useSearch({
-		from: "/data-lineage/queries/edit/$id",
+		from: "/analytics/queries/edit/$id",
 	});
 	return (
 		<ResourceEditorPageWithLoader
@@ -21,7 +21,7 @@ const PageComponent = () => {
 			navigate={navigate}
 			onDeleted={() =>
 				navigate({
-					to: "/data-lineage/queries",
+					to: "/analytics/queries",
 					search: { q: undefined, page: undefined, pageSize: undefined },
 				})
 			}
@@ -29,7 +29,7 @@ const PageComponent = () => {
 	);
 };
 
-export const Route = createFileRoute("/data-lineage/queries/edit/$id")({
+export const Route = createFileRoute("/analytics/queries/edit/$id")({
 	component: PageComponent,
 	validateSearch,
 	loader: (cx) => ({ breadCrumb: cx.params.id }),

--- a/src/routes/analytics.queries.index.tsx
+++ b/src/routes/analytics.queries.index.tsx
@@ -10,7 +10,7 @@ function QueriesPlaceholder() {
 	);
 }
 
-export const Route = createFileRoute("/data-lineage/queries/")({
+export const Route = createFileRoute("/analytics/queries/")({
 	staticData: { title: "Queries" },
 	component: QueriesPlaceholder,
 });

--- a/src/routes/analytics.queries.tsx
+++ b/src/routes/analytics.queries.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router";
 
-export const Route = createFileRoute("/data-lineage/queries")({
+export const Route = createFileRoute("/analytics/queries")({
 	staticData: { title: "Queries" },
 	loader: () => ({ breadCrumb: "Queries" }),
 	component: () => <Outlet />,

--- a/src/routes/analytics.tsx
+++ b/src/routes/analytics.tsx
@@ -1,8 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { DataLineagePage } from "../components/DataLineage/page";
 
-export const Route = createFileRoute("/data-lineage")({
-	staticData: { title: "Data Lineage" },
-	loader: () => ({ breadCrumb: "Data Lineage" }),
+export const Route = createFileRoute("/analytics")({
+	staticData: { title: "Analytics" },
+	loader: () => ({ breadCrumb: "Analytics" }),
 	component: DataLineagePage,
 });

--- a/src/routes/analytics.views.create.tsx
+++ b/src/routes/analytics.views.create.tsx
@@ -8,38 +8,29 @@ import {
 import { validateSearch } from "./resource.$resourceType.create";
 
 const initialResource: Resource = {
-	resourceType: "Library",
-	meta: {
-		profile: ["https://sql-on-fhir.org/ig/StructureDefinition/SQLQuery"],
-	},
-	status: "active",
-	type: {
-		coding: [
-			{
-				system: "https://sql-on-fhir.org/ig/CodeSystem/LibraryTypesCodes",
-				code: "sql-query",
-			},
-		],
-	},
+	resource: "Patient",
+	resourceType: "ViewDefinition",
+	status: "draft",
+	select: [],
 } as Resource;
 
 const PageComponent = () => {
 	const navigate = useNavigate();
-	const { tab, mode } = useSearch({ from: "/data-lineage/queries/create" });
+	const { tab, mode } = useSearch({ from: "/analytics/views/create" });
 
 	return (
 		<ResourceEditorPage
 			initialResource={initialResource}
-			resourceType="Library"
+			resourceType="ViewDefinition"
 			tab={tab}
 			mode={mode}
 			navigate={navigate}
 			onCreated={(id) =>
 				navigate({
-					to: "/data-lineage/queries/edit/$id",
+					to: "/analytics/views/edit/$id",
 					params: { id },
 					search: {
-						tab: "sqlquery" as const,
+						tab: "builder" as const,
 						mode: "json" as const,
 						builderTab: "form" as const,
 					},
@@ -49,9 +40,9 @@ const PageComponent = () => {
 	);
 };
 
-export const Route = createFileRoute("/data-lineage/queries/create")({
+export const Route = createFileRoute("/analytics/views/create")({
 	component: PageComponent,
 	validateSearch,
-	staticData: { title: "Create Query" },
+	staticData: { title: "Create View" },
 	loader: () => ({ breadCrumb: "Create" }),
 });

--- a/src/routes/analytics.views.edit.$id.tsx
+++ b/src/routes/analytics.views.edit.$id.tsx
@@ -8,9 +8,9 @@ import { validateSearch } from "./resource.$resourceType.create";
 
 const PageComponent = () => {
 	const { id } = Route.useParams();
-	const navigate = useNavigate({ from: "/data-lineage/views/edit/$id" });
+	const navigate = useNavigate({ from: "/analytics/views/edit/$id" });
 	const { tab, mode } = useSearch({
-		from: "/data-lineage/views/edit/$id",
+		from: "/analytics/views/edit/$id",
 	});
 	return (
 		<ResourceEditorPageWithLoader
@@ -21,7 +21,7 @@ const PageComponent = () => {
 			navigate={navigate}
 			onDeleted={() =>
 				navigate({
-					to: "/data-lineage/views",
+					to: "/analytics/views",
 					search: { q: undefined, page: undefined, pageSize: undefined },
 				})
 			}
@@ -29,7 +29,7 @@ const PageComponent = () => {
 	);
 };
 
-export const Route = createFileRoute("/data-lineage/views/edit/$id")({
+export const Route = createFileRoute("/analytics/views/edit/$id")({
 	component: PageComponent,
 	validateSearch,
 	loader: (cx) => ({ breadCrumb: cx.params.id }),

--- a/src/routes/analytics.views.index.tsx
+++ b/src/routes/analytics.views.index.tsx
@@ -10,7 +10,7 @@ function ViewsPlaceholder() {
 	);
 }
 
-export const Route = createFileRoute("/data-lineage/views/")({
+export const Route = createFileRoute("/analytics/views/")({
 	staticData: { title: "Views" },
 	component: ViewsPlaceholder,
 });

--- a/src/routes/analytics.views.tsx
+++ b/src/routes/analytics.views.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router";
 
-export const Route = createFileRoute("/data-lineage/views")({
+export const Route = createFileRoute("/analytics/views")({
 	staticData: { title: "Views" },
 	loader: () => ({ breadCrumb: "Views" }),
 	component: () => <Outlet />,


### PR DESCRIPTION
## Summary
- Renamed `/data-lineage/*` routes to `/analytics/*` across navbar, sidebar links, builder/lineage detail panels and the generated route tree.
- Replaced the section icon `Workflow` with `FileChartPie`.
- Library/ViewDefinition saves and deletes now invalidate the analytics sidebar caches, so newly created/removed items appear without a manual refresh.
- `_properties` panel in the ViewDefinition form is expanded by default.
- Fixed `isDirtyRef` not being reset alongside `isDirty` in the SQLQueryBuilder context.
- Added a spacer column in the SQL run result so narrow result sets no longer stretch their columns across the full table width.

## Test plan
- [ ] Open `/analytics`, `/analytics/views`, `/analytics/queries` and confirm both index pages and edit/create flows load.
- [ ] Verify navbar/sidebar links navigate to the new `/analytics/*` routes and that the section icon shows `FileChartPie`.
- [ ] Create and delete a `ViewDefinition` and a `Library` resource and confirm the sidebar list refreshes immediately.
- [ ] In the ViewDefinition form, confirm the `_properties` section is expanded on first open.
- [ ] Run a SQL query that returns few narrow columns (e.g. `select id, resource #>> '{gender}' from patient`) and verify columns hug their content with the remaining space on the right.