### PR TITLE
Analytics: Data Lineage UI for SQLQuery and ViewDefinition

### DIFF
--- a/src/components/ResourceEditor/page.tsx
+++ b/src/components/ResourceEditor/page.tsx
@@ -30,6 +30,7 @@ import { LineageTab } from "../SQLQueryBuilder/lineage/lineage-tab";
 import { SQLQueryProvider } from "../SQLQueryBuilder/page";
 import { SQL_QUERY_PROFILE } from "../SQLQueryBuilder/types";
 import { BuilderContent } from "../ViewDefinition/editor-panel-content";
+import { ViewDefinitionLineageTab } from "../ViewDefinition/lineage/lineage-tab";
 import { ViewDefinitionProvider } from "../ViewDefinition/page";
 import { DeleteButton, SaveButton, type SaveHandle } from "./action";
 import { deleteResource, fetchResource } from "./api";
@@ -360,6 +361,18 @@ export const ResourceEditorPage = ({
 			content: (
 				<HSComp.TabsContent value="builder" className="grow min-h-0">
 					<BuilderContent />
+				</HSComp.TabsContent>
+			),
+		});
+	}
+
+	if (isViewDefinition && id) {
+		tabs.push({
+			value: "lineage",
+			trigger: <HSComp.TabsTrigger value="lineage">Lineage</HSComp.TabsTrigger>,
+			content: (
+				<HSComp.TabsContent value="lineage" className="grow min-h-0 flex">
+					<ViewDefinitionLineageTab />
 				</HSComp.TabsContent>
 			),
 		});

--- a/src/components/SQLQueryBuilder/lineage/base-node.tsx
+++ b/src/components/SQLQueryBuilder/lineage/base-node.tsx
@@ -55,7 +55,7 @@ export function BaseNodeRow({
 }) {
 	return (
 		<div
-			className={`grid grid-cols-2 items-center px-3 py-1 border-b border-border-primary last:border-b-0 ${className ?? ""}`}
+			className={`grid grid-cols-[1fr_auto] gap-3 items-center px-3 py-1 border-b border-border-primary last:border-b-0 ${className ?? ""}`}
 		>
 			{children}
 		</div>

--- a/src/components/SQLQueryBuilder/lineage/lineage-result-panel.tsx
+++ b/src/components/SQLQueryBuilder/lineage/lineage-result-panel.tsx
@@ -1,6 +1,7 @@
 import * as HSComp from "@health-samurai/react-components";
 import { Maximize2, Minimize2, PanelBottomClose } from "lucide-react";
 import * as React from "react";
+import { useLocalStorage } from "../../../hooks";
 import { DataTableFooter } from "../../data-table/footer";
 import { EmptyState } from "../../empty-state";
 import { useLineageRunContext } from "./run-context";
@@ -56,6 +57,7 @@ function ResultBody({ page, pageSize }: { page: number; pageSize: number }) {
 					{runResult.columns.map((col) => (
 						<HSComp.TableHead key={col}>{col}</HSComp.TableHead>
 					))}
+					<HSComp.TableHead className="w-full p-0" />
 				</HSComp.TableRow>
 			</HSComp.TableHeader>
 			<HSComp.TableBody>
@@ -74,6 +76,7 @@ function ResultBody({ page, pageSize }: { page: number; pageSize: number }) {
 								</HSComp.TableCell>
 							);
 						})}
+						<HSComp.TableCell className="p-0" />
 					</HSComp.TableRow>
 				))}
 			</HSComp.TableBody>
@@ -92,7 +95,11 @@ export function LineageResultPanel({
 }) {
 	const { runResult } = useLineageRunContext();
 	const [page, setPage] = React.useState(1);
-	const [pageSize, setPageSize] = React.useState(DEFAULT_PAGE_SIZE);
+	const [pageSize, setPageSize] = useLocalStorage<number>({
+		key: "lineage-result-panel:page-size",
+		defaultValue: DEFAULT_PAGE_SIZE,
+		getInitialValueInEffect: false,
+	});
 	const total = runResult?.rows.length ?? 0;
 	const totalPages = Math.max(1, Math.ceil(total / pageSize));
 

--- a/src/components/ViewDefinition/lineage/expand-context.ts
+++ b/src/components/ViewDefinition/lineage/expand-context.ts
@@ -1,0 +1,20 @@
+import * as React from "react";
+
+export type ExpandContextValue = {
+	expandingNodeId: string | null;
+	expand: (queryNodeId: string) => void;
+};
+
+export const ExpandContext = React.createContext<ExpandContextValue | null>(
+	null,
+);
+
+export function useExpandContext(): ExpandContextValue {
+	const ctx = React.useContext(ExpandContext);
+	if (!ctx) {
+		throw new Error(
+			"useExpandContext must be used within ExpandContext.Provider",
+		);
+	}
+	return ctx;
+}

--- a/src/components/ViewDefinition/lineage/expand-node.tsx
+++ b/src/components/ViewDefinition/lineage/expand-node.tsx
@@ -1,0 +1,50 @@
+import { Handle, Position } from "@xyflow/react";
+import { ChevronsRight, Loader2 } from "lucide-react";
+import * as React from "react";
+import { useExpandContext } from "./expand-context";
+import type { ExpandPlaceholderNodeData } from "./types";
+
+type Props = {
+	id: string;
+	data: Record<string, unknown>;
+	selected?: boolean;
+};
+
+export function ExpandPlaceholderNode({ id, data, selected }: Props) {
+	const d = data as unknown as ExpandPlaceholderNodeData;
+	const { expand, expandingNodeId } = useExpandContext();
+	const isLoading = expandingNodeId === id;
+
+	const handleClick = React.useCallback(
+		(e: React.MouseEvent) => {
+			e.stopPropagation();
+			if (isLoading) return;
+			expand(d.queryNodeId);
+		},
+		[expand, d.queryNodeId, isLoading],
+	);
+
+	return (
+		<button
+			type="button"
+			onClick={handleClick}
+			disabled={isLoading}
+			aria-label="Expand backrefs"
+			className={`flex items-center justify-center w-8 h-8 rounded-full bg-bg-primary border shadow-sm transition-colors ${
+				selected ? "border-border-link" : "border-border-primary"
+			} hover:border-border-link hover:bg-bg-secondary disabled:opacity-60 disabled:cursor-not-allowed`}
+		>
+			{isLoading ? (
+				<Loader2 className="w-4 h-4 text-text-tertiary animate-spin" />
+			) : (
+				<ChevronsRight className="w-4 h-4 text-text-secondary" />
+			)}
+			<Handle
+				type="target"
+				position={Position.Left}
+				className="w-2 h-2 left-0!"
+				isConnectable={false}
+			/>
+		</button>
+	);
+}

--- a/src/components/ViewDefinition/lineage/lineage-tab.tsx
+++ b/src/components/ViewDefinition/lineage/lineage-tab.tsx
@@ -1,0 +1,681 @@
+import * as HSComp from "@health-samurai/react-components";
+import { useMutation } from "@tanstack/react-query";
+import {
+	Background,
+	Controls,
+	type Edge,
+	MarkerType,
+	ReactFlow,
+	useEdgesState,
+	useNodesState,
+} from "@xyflow/react";
+import { PanelBottomOpen } from "lucide-react";
+import * as React from "react";
+import { useAidboxClient } from "../../../AidboxClient";
+import { useLocalStorage } from "../../../hooks";
+import { EmptyState } from "../../empty-state";
+import { LineageDetailPanel } from "../../SQLQueryBuilder/lineage/detail-panel";
+import { LineageResultPanel } from "../../SQLQueryBuilder/lineage/lineage-result-panel";
+import { NodeSearch } from "../../SQLQueryBuilder/lineage/node-search";
+import { persistParamValues } from "../../SQLQueryBuilder/lineage/param-storage";
+import {
+	LineageRunContext,
+	type LineageRunResult,
+	type RunQueryArgs,
+} from "../../SQLQueryBuilder/lineage/run-context";
+import type {
+	LineageNodeData,
+	ParamSpec,
+} from "../../SQLQueryBuilder/lineage/types";
+import { ViewDefinitionContext } from "../page";
+import { ExpandContext } from "./expand-context";
+import { nodeTypes } from "./node-types";
+import {
+	expandQueryNode,
+	stateToGraph,
+	useViewDefinitionLineageGraph,
+} from "./resolve-graph";
+import type { BackrefGraphState, BackrefNode, BackrefNodeData } from "./types";
+
+import "@xyflow/react/dist/style.css";
+
+const HIGHLIGHT_COLOR = "#2378e1";
+const DIM_COLOR = "#d4d4d8";
+
+const DEFAULT_DETAILS_WIDTH = 440;
+const MIN_DETAILS_WIDTH = 280;
+const MAX_DETAILS_WIDTH = 800;
+
+const DEFAULT_RESULT_HEIGHT = 320;
+const MIN_RESULT_HEIGHT = 120;
+const MAX_RESULT_HEIGHT = 800;
+
+function collectConnectedEdges(edges: Edge[], rootId: string): Set<string> {
+	const bySource = new Map<string, Edge[]>();
+	const byTarget = new Map<string, Edge[]>();
+	for (const e of edges) {
+		const s = bySource.get(e.source) ?? [];
+		s.push(e);
+		bySource.set(e.source, s);
+		const t = byTarget.get(e.target) ?? [];
+		t.push(e);
+		byTarget.set(e.target, t);
+	}
+	const result = new Set<string>();
+
+	const seenDown = new Set<string>();
+	const dQ: string[] = [rootId];
+	while (dQ.length > 0) {
+		const id = dQ.shift();
+		if (!id || seenDown.has(id)) continue;
+		seenDown.add(id);
+		for (const e of bySource.get(id) ?? []) {
+			result.add(e.id);
+			dQ.push(e.target);
+		}
+	}
+
+	const seenUp = new Set<string>();
+	const uQ: string[] = [rootId];
+	while (uQ.length > 0) {
+		const id = uQ.shift();
+		if (!id || seenUp.has(id)) continue;
+		seenUp.add(id);
+		for (const e of byTarget.get(id) ?? []) {
+			result.add(e.id);
+			uQ.push(e.source);
+		}
+	}
+	return result;
+}
+
+function toOperationOutcome(err: unknown): HSComp.OperationOutcome {
+	if (
+		typeof err === "object" &&
+		err !== null &&
+		"resourceType" in err &&
+		(err as { resourceType: string }).resourceType === "OperationOutcome"
+	) {
+		return err as unknown as HSComp.OperationOutcome;
+	}
+	return {
+		resourceType: "OperationOutcome",
+		issue: [
+			{
+				severity: "error",
+				code: "exception",
+				diagnostics: err instanceof Error ? err.message : String(err),
+			},
+		],
+	};
+}
+
+function decodeBase64ToText(b64: string): string {
+	const bytes = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+	return new TextDecoder().decode(bytes);
+}
+
+function jsonToRunResult(decoded: string): LineageRunResult {
+	let arr: unknown;
+	try {
+		arr = JSON.parse(decoded);
+	} catch {
+		return { columns: [], rows: [] };
+	}
+	if (!Array.isArray(arr)) return { columns: [], rows: [] };
+	const columnsSet = new Set<string>();
+	for (const r of arr as Record<string, unknown>[]) {
+		if (r && typeof r === "object") {
+			for (const k of Object.keys(r)) columnsSet.add(k);
+		}
+	}
+	const columns = Array.from(columnsSet);
+	const rows = (arr as Record<string, unknown>[]).map((r) =>
+		columns.map((c) => r[c] ?? null),
+	);
+	return { columns, rows };
+}
+
+function clamp(value: number, min: number, max: number): number {
+	return Math.max(min, Math.min(max, value));
+}
+
+type FhirParametersResponse = {
+	resourceType: "Parameters";
+	parameter?: Array<{
+		name?: string;
+		part?: Array<{ name?: string; [key: `value${string}`]: unknown }>;
+	}>;
+};
+
+function capitalizeFirstLetter(s: string): string {
+	return s.length === 0 ? s : s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function buildParamValueEntry(
+	name: string,
+	type: string,
+	raw: string,
+): Record<string, unknown> | null {
+	if (raw === "" && type !== "boolean") return null;
+	const valueField = `value${capitalizeFirstLetter(type)}`;
+	let value: unknown = raw;
+	if (type === "integer") {
+		const n = Number.parseInt(raw, 10);
+		if (Number.isNaN(n)) return null;
+		value = n;
+	} else if (type === "decimal") {
+		const n = Number.parseFloat(raw);
+		if (Number.isNaN(n)) return null;
+		value = n;
+	} else if (type === "boolean") {
+		value = raw === "true";
+	}
+	return { name, [valueField]: value };
+}
+
+function buildAllParamEntries(
+	allParams: ParamSpec[],
+	paramValues: Record<string, string>,
+): Record<string, unknown>[] {
+	const entries: Record<string, unknown>[] = [];
+	for (const p of allParams) {
+		const type = p.type ?? "string";
+		let raw = paramValues[p.name];
+		if (raw === undefined) {
+			if (type !== "boolean") continue;
+			raw = "";
+		}
+		const entry = buildParamValueEntry(p.name, type, raw);
+		if (entry) entries.push(entry);
+	}
+	return entries;
+}
+
+function getPartValue(
+	part: { name?: string; [key: string]: unknown } | undefined,
+): unknown {
+	if (!part) return null;
+	for (const key of Object.keys(part)) {
+		if (key.startsWith("value")) return part[key];
+	}
+	return null;
+}
+
+function fhirParametersToRunResult(
+	body: FhirParametersResponse,
+): LineageRunResult {
+	const rowParams = (body.parameter ?? []).filter((p) => p.name === "row");
+	if (rowParams.length === 0) return { columns: [], rows: [] };
+	const columns: string[] = [];
+	const seen = new Set<string>();
+	for (const rp of rowParams) {
+		for (const part of rp.part ?? []) {
+			if (part.name && !seen.has(part.name)) {
+				seen.add(part.name);
+				columns.push(part.name);
+			}
+		}
+	}
+	const rows = rowParams.map((rp) => {
+		const byName = new Map<string, unknown>();
+		for (const part of rp.part ?? []) {
+			if (part.name) byName.set(part.name, getPartValue(part));
+		}
+		return columns.map((c) => byName.get(c) ?? null);
+	});
+	return { columns, rows };
+}
+
+function isLineageNodeData(data: BackrefNodeData): data is LineageNodeData {
+	return data.kind !== "expand-placeholder";
+}
+
+export function ViewDefinitionLineageTab() {
+	const client = useAidboxClient();
+	const { viewDefinition } = React.useContext(ViewDefinitionContext);
+	const { state: initialState, isLoading } =
+		useViewDefinitionLineageGraph(viewDefinition);
+
+	const [state, setState] = React.useState<BackrefGraphState | null>(null);
+	const stateRef = React.useRef<BackrefGraphState | null>(null);
+	stateRef.current = state;
+
+	React.useEffect(() => {
+		if (initialState) setState(initialState);
+	}, [initialState]);
+
+	const graph = React.useMemo(
+		() => (state ? stateToGraph(state) : { nodes: [], edges: [] }),
+		[state],
+	);
+
+	const [nodes, setNodes, onNodesChange] = useNodesState<BackrefNode>(
+		graph.nodes,
+	);
+	const [edges, setEdges, onEdgesChange] = useEdgesState(graph.edges);
+	const [selectedId, setSelectedId] = React.useState<string | null>(null);
+
+	const [runningNodeId, setRunningNodeId] = React.useState<string | null>(null);
+	const [resultNodeId, setResultNodeId] = React.useState<string | null>(null);
+	const [runResult, setRunResult] = React.useState<LineageRunResult | null>(
+		null,
+	);
+	const [runError, setRunError] =
+		React.useState<HSComp.OperationOutcome | null>(null);
+	const [isResultCollapsed, setIsResultCollapsed] = React.useState(false);
+	const [isMaximized, setIsMaximized] = React.useState(false);
+
+	const [expandingNodeId, setExpandingNodeId] = React.useState<string | null>(
+		null,
+	);
+
+	const [detailsWidth, setDetailsWidth] = useLocalStorage<number>({
+		key: "lineage-tab:details-width",
+		defaultValue: DEFAULT_DETAILS_WIDTH,
+		getInitialValueInEffect: false,
+	});
+	const [resultHeight, setResultHeight] = useLocalStorage<number>({
+		key: "lineage-tab:result-height",
+		defaultValue: DEFAULT_RESULT_HEIGHT,
+		getInitialValueInEffect: false,
+	});
+	const detailsWidthRef = React.useRef(detailsWidth);
+	detailsWidthRef.current = detailsWidth;
+	const resultHeightRef = React.useRef(resultHeight);
+	resultHeightRef.current = resultHeight;
+
+	React.useEffect(() => {
+		setNodes(graph.nodes);
+		setEdges(graph.edges);
+	}, [graph.nodes, graph.edges, setNodes, setEdges]);
+
+	const runMutation = useMutation({
+		mutationFn: async ({
+			nodeId,
+			viewId,
+		}: {
+			nodeId: string;
+			viewId: string;
+		}) => {
+			setRunningNodeId(nodeId);
+			setResultNodeId(nodeId);
+			setRunError(null);
+			setRunResult(null);
+			const result = await client.request<{
+				contentType: string;
+				data: string;
+			}>({
+				method: "POST",
+				url: `/fhir/ViewDefinition/${viewId}/$run`,
+				headers: {
+					"Content-Type": "application/json",
+					Accept: "application/fhir+json",
+				},
+				body: JSON.stringify({
+					resourceType: "Parameters",
+					parameter: [
+						{ name: "_format", valueCode: "json" },
+						{ name: "_limit", valueInteger: 1000 },
+						{ name: "_page", valueInteger: 1 },
+					],
+				}),
+			});
+			if (result.isErr()) throw result.value.resource;
+			return result.value.resource;
+		},
+		onSuccess: (data) => {
+			setRunningNodeId(null);
+			setRunResult(jsonToRunResult(decodeBase64ToText(data.data)));
+		},
+		onError: (err) => {
+			setRunningNodeId(null);
+			setRunError(toOperationOutcome(err));
+		},
+	});
+
+	const runView = React.useCallback(
+		(nodeId: string, viewId: string) => {
+			if (!viewId) return;
+			setIsResultCollapsed(false);
+			setIsMaximized(false);
+			runMutation.mutate({ nodeId, viewId });
+		},
+		[runMutation],
+	);
+
+	const runQueryMutation = useMutation({
+		mutationFn: async ({
+			nodeId,
+			queryId,
+			allParams,
+			paramValues,
+		}: RunQueryArgs) => {
+			setRunningNodeId(nodeId);
+			setResultNodeId(nodeId);
+			setRunError(null);
+			setRunResult(null);
+			const valueEntries = buildAllParamEntries(allParams, paramValues);
+			const topLevelParameters: Record<string, unknown>[] = [
+				{ name: "_format", valueCode: "fhir" },
+			];
+			if (valueEntries.length > 0) {
+				topLevelParameters.push({
+					name: "parameters",
+					resource: {
+						resourceType: "Parameters",
+						parameter: valueEntries,
+					},
+				});
+			}
+			const result = await client.request<FhirParametersResponse>({
+				method: "POST",
+				url: `/fhir/Library/${queryId}/$sqlquery-run`,
+				body: JSON.stringify({
+					resourceType: "Parameters",
+					parameter: topLevelParameters,
+				}),
+				headers: { "Content-Type": "application/json" },
+			});
+			if (result.isErr()) throw result.value.resource;
+			return result.value.resource;
+		},
+		onSuccess: (data, variables) => {
+			setRunningNodeId(null);
+			setRunResult(fhirParametersToRunResult(data));
+			persistParamValues(variables.queryId, variables.paramValues);
+		},
+		onError: (err) => {
+			setRunningNodeId(null);
+			setRunError(toOperationOutcome(err));
+		},
+	});
+
+	const runQuery = React.useCallback(
+		(args: RunQueryArgs) => {
+			if (!args.queryId) return;
+			setIsResultCollapsed(false);
+			setIsMaximized(false);
+			runQueryMutation.mutate(args);
+		},
+		[runQueryMutation],
+	);
+
+	const styledEdges = React.useMemo<Edge[]>(() => {
+		if (!selectedId) {
+			return edges.map((e) => ({
+				...e,
+				style: undefined,
+				markerEnd: { type: MarkerType.ArrowClosed },
+			}));
+		}
+		const highlighted = collectConnectedEdges(edges, selectedId);
+		return edges.map((e) => {
+			const on = highlighted.has(e.id);
+			return {
+				...e,
+				style: {
+					stroke: on ? HIGHLIGHT_COLOR : DIM_COLOR,
+					strokeWidth: on ? 2 : 1,
+				},
+				markerEnd: {
+					type: MarkerType.ArrowClosed,
+					color: on ? HIGHLIGHT_COLOR : DIM_COLOR,
+				},
+				animated: on,
+			};
+		});
+	}, [edges, selectedId]);
+
+	const clearSelection = React.useCallback(() => {
+		setSelectedId(null);
+		setNodes((nds) =>
+			nds.map((n) => (n.selected ? { ...n, selected: false } : n)),
+		);
+	}, [setNodes]);
+
+	const clearRunState = React.useCallback(() => {
+		setRunResult(null);
+		setRunError(null);
+		setResultNodeId(null);
+		setRunningNodeId(null);
+	}, []);
+
+	const handlePaneClick = React.useCallback(() => {
+		clearSelection();
+		clearRunState();
+	}, [clearSelection, clearRunState]);
+
+	const handleNodeClick = React.useCallback(
+		(nodeId: string) => {
+			const node = nodes.find((n) => n.id === nodeId);
+			if (node?.type === "expand-placeholder") return;
+			setSelectedId(nodeId);
+			if (resultNodeId !== null && resultNodeId !== nodeId) {
+				clearRunState();
+			}
+		},
+		[nodes, resultNodeId, clearRunState],
+	);
+
+	const handleToggleMaximize = React.useCallback(() => {
+		setIsMaximized((p) => !p);
+	}, []);
+
+	React.useEffect(() => {
+		if (!isMaximized) return;
+		const onEscape = (e: KeyboardEvent) => {
+			if (e.key === "Escape") setIsMaximized(false);
+		};
+		document.addEventListener("keydown", onEscape);
+		return () => document.removeEventListener("keydown", onEscape);
+	}, [isMaximized]);
+
+	const startDrag = React.useCallback(
+		(e: React.MouseEvent, axis: "x" | "y") => {
+			e.preventDefault();
+			const startClient = axis === "x" ? e.clientX : e.clientY;
+			const startSize =
+				axis === "x" ? detailsWidthRef.current : resultHeightRef.current;
+			const prevUserSelect = document.body.style.userSelect;
+			const prevCursor = document.body.style.cursor;
+			document.body.style.userSelect = "none";
+			document.body.style.cursor = axis === "x" ? "col-resize" : "row-resize";
+			const onMove = (ev: MouseEvent) => {
+				const delta = startClient - (axis === "x" ? ev.clientX : ev.clientY);
+				if (axis === "x") {
+					setDetailsWidth(
+						clamp(startSize + delta, MIN_DETAILS_WIDTH, MAX_DETAILS_WIDTH),
+					);
+				} else {
+					setResultHeight(
+						clamp(startSize + delta, MIN_RESULT_HEIGHT, MAX_RESULT_HEIGHT),
+					);
+				}
+			};
+			const onUp = () => {
+				document.body.style.userSelect = prevUserSelect;
+				document.body.style.cursor = prevCursor;
+				document.removeEventListener("mousemove", onMove);
+				document.removeEventListener("mouseup", onUp);
+			};
+			document.addEventListener("mousemove", onMove);
+			document.addEventListener("mouseup", onUp);
+		},
+		[setDetailsWidth, setResultHeight],
+	);
+
+	const runContextValue = React.useMemo(
+		() => ({
+			runningNodeId,
+			resultNodeId,
+			runResult,
+			runError,
+			runView,
+			runQuery,
+		}),
+		[runningNodeId, resultNodeId, runResult, runError, runView, runQuery],
+	);
+
+	const handleExpand = React.useCallback(
+		async (queryNodeId: string) => {
+			const current = stateRef.current;
+			if (!current || expandingNodeId) return;
+			setExpandingNodeId(queryNodeId);
+			try {
+				const next = await expandQueryNode(client, current, queryNodeId);
+				setState({
+					rootId: next.rootId,
+					nodesById: new Map(next.nodesById),
+					depthById: new Map(next.depthById),
+					edges: [...next.edges],
+				});
+			} finally {
+				setExpandingNodeId(null);
+			}
+		},
+		[client, expandingNodeId],
+	);
+
+	const expandContextValue = React.useMemo(
+		() => ({ expandingNodeId, expand: handleExpand }),
+		[expandingNodeId, handleExpand],
+	);
+
+	if (isLoading && nodes.length === 0) {
+		return (
+			<div className="flex items-center justify-center h-full text-text-secondary">
+				Resolving lineage…
+			</div>
+		);
+	}
+
+	if (nodes.length === 0) {
+		return (
+			<EmptyState
+				title="No lineage"
+				description="This ViewDefinition is not referenced by any SQLQuery yet."
+			/>
+		);
+	}
+
+	const selectedNode = nodes.find((n) => n.id === selectedId);
+	const selectedData =
+		selectedNode && isLineageNodeData(selectedNode.data as BackrefNodeData)
+			? (selectedNode.data as LineageNodeData)
+			: null;
+
+	const hasResult = resultNodeId !== null;
+	const detailsOpen = selectedData !== null;
+	const showResult = hasResult && !isResultCollapsed;
+	const showResultBar = hasResult && isResultCollapsed && !isMaximized;
+
+	return (
+		<LineageRunContext.Provider value={runContextValue}>
+			<ExpandContext.Provider value={expandContextValue}>
+				<div className="relative h-full w-full overflow-hidden">
+					<div className="absolute inset-0 bg-bg-primary">
+						<ReactFlow<BackrefNode>
+							nodes={nodes}
+							edges={styledEdges}
+							onNodesChange={onNodesChange}
+							onEdgesChange={onEdgesChange}
+							onNodeClick={(_, node) => handleNodeClick(node.id)}
+							onPaneClick={handlePaneClick}
+							nodeTypes={nodeTypes}
+							nodesDraggable={false}
+							nodesConnectable={false}
+							fitView
+							fitViewOptions={{ padding: 0.2 }}
+							defaultEdgeOptions={{
+								type: "default",
+								markerEnd: { type: MarkerType.ArrowClosed },
+							}}
+							minZoom={0.2}
+							proOptions={{ hideAttribution: true }}
+						>
+							<Background />
+							<Controls showFitView={false} />
+							<NodeSearch onSelect={handleNodeClick} />
+						</ReactFlow>
+					</div>
+
+					{detailsOpen && (
+						<div
+							className="absolute top-0 right-0 bottom-0 z-20 bg-bg-primary border-l border-border-primary shadow-lg"
+							style={{ width: detailsWidth }}
+						>
+							<button
+								type="button"
+								aria-label="Resize details panel"
+								className="absolute left-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-border-link/60 z-10 -translate-x-1/2 bg-transparent border-0 p-0"
+								onMouseDown={(e) => startDrag(e, "x")}
+								style={{ touchAction: "none" }}
+							/>
+							<LineageDetailPanel
+								data={selectedData}
+								onClose={clearSelection}
+							/>
+						</div>
+					)}
+
+					{showResult && (
+						<div
+							className={
+								isMaximized
+									? "absolute inset-0 z-30 bg-bg-primary"
+									: "absolute bottom-0 left-0 z-20 bg-bg-primary border-t border-border-primary shadow-lg"
+							}
+							style={
+								isMaximized
+									? undefined
+									: {
+											height: resultHeight,
+											right: detailsOpen ? detailsWidth : 0,
+										}
+							}
+						>
+							{!isMaximized && (
+								<button
+									type="button"
+									aria-label="Resize result panel"
+									className="absolute left-0 right-0 top-0 h-1 cursor-row-resize hover:bg-border-link/60 z-10 -translate-y-1/2 bg-transparent border-0 p-0"
+									onMouseDown={(e) => startDrag(e, "y")}
+									style={{ touchAction: "none" }}
+								/>
+							)}
+							<LineageResultPanel
+								isMaximized={isMaximized}
+								onToggleMaximize={handleToggleMaximize}
+								onToggleCollapse={() => setIsResultCollapsed(true)}
+							/>
+						</div>
+					)}
+
+					{showResultBar && (
+						<div
+							className="absolute bottom-0 left-0 z-20 bg-bg-secondary border-t border-border-primary flex items-center justify-between pl-6 pr-2 h-10"
+							style={{ right: detailsOpen ? detailsWidth : 0 }}
+						>
+							<span className="typo-label text-text-secondary">Result</span>
+							<HSComp.Tooltip>
+								<HSComp.TooltipTrigger asChild>
+									<HSComp.Button
+										variant="ghost"
+										size="small"
+										onClick={() => setIsResultCollapsed(false)}
+									>
+										<PanelBottomOpen className="w-4 h-4" />
+									</HSComp.Button>
+								</HSComp.TooltipTrigger>
+								<HSComp.TooltipContent align="end">
+									Restore
+								</HSComp.TooltipContent>
+							</HSComp.Tooltip>
+						</div>
+					)}
+				</div>
+			</ExpandContext.Provider>
+		</LineageRunContext.Provider>
+	);
+}

--- a/src/components/ViewDefinition/lineage/node-types.ts
+++ b/src/components/ViewDefinition/lineage/node-types.ts
@@ -1,0 +1,13 @@
+import {
+	ResourceTypeNode,
+	SQLQueryNode,
+	ViewDefinitionNode,
+} from "../../SQLQueryBuilder/lineage/nodes";
+import { ExpandPlaceholderNode } from "./expand-node";
+
+export const nodeTypes = {
+	"resource-type": ResourceTypeNode,
+	"view-definition": ViewDefinitionNode,
+	"sql-query": SQLQueryNode,
+	"expand-placeholder": ExpandPlaceholderNode,
+};

--- a/src/components/ViewDefinition/lineage/resolve-graph.ts
+++ b/src/components/ViewDefinition/lineage/resolve-graph.ts
@@ -595,6 +595,10 @@ export function useViewDefinitionLineageGraph(
 			return buildInitialState(client, raw);
 		},
 		placeholderData: (prev) => prev,
+		staleTime: Number.POSITIVE_INFINITY,
+		refetchOnWindowFocus: false,
+		refetchOnReconnect: false,
+		refetchOnMount: false,
 	});
 	return {
 		state: data ?? null,

--- a/src/components/ViewDefinition/lineage/resolve-graph.ts
+++ b/src/components/ViewDefinition/lineage/resolve-graph.ts
@@ -3,6 +3,7 @@ import type { ViewDefinition } from "@aidbox-ui/fhir-types/org-sql-on-fhir-ig";
 import { useQuery } from "@tanstack/react-query";
 import { type AidboxClientR5, useAidboxClient } from "../../../AidboxClient";
 import type {
+	ParamSpec,
 	ResourceTypeNodeData,
 	SQLQueryNodeData,
 	ViewConstant,
@@ -60,6 +61,88 @@ type RawViewDefinition = {
 	select?: RawSelect[];
 	where?: Array<{ path?: string; description?: string }>;
 };
+
+function dependsOnCanonicals(lib: RawLibrary): string[] {
+	return (lib.relatedArtifact ?? [])
+		.filter((ra) => ra.type === "depends-on")
+		.map((ra) => ra.resource ?? "")
+		.filter(Boolean);
+}
+
+function splitCanonical(canonical: string): { url: string; version?: string } {
+	const idx = canonical.indexOf("|");
+	if (idx < 0) return { url: canonical };
+	return { url: canonical.slice(0, idx), version: canonical.slice(idx + 1) };
+}
+
+async function fetchLibraryByCanonical(
+	client: AidboxClientR5,
+	canonical: string,
+): Promise<RawLibrary | null> {
+	const relative = canonical.match(/^Library\/([^/?#]+)$/);
+	if (relative) {
+		const result = await client.request<RawLibrary>({
+			method: "GET",
+			url: `/fhir/Library/${relative[1]}`,
+		});
+		if (result.isErr()) return null;
+		return result.value.resource;
+	}
+	if (canonical.startsWith("ViewDefinition/")) return null;
+	const { url, version } = splitCanonical(canonical);
+	const params: Array<[string, string]> = [
+		["url", url],
+		["_count", "1"],
+	];
+	if (version) params.push(["version", version]);
+	const result = await client.request<Bundle>({
+		method: "GET",
+		url: "/fhir/Library",
+		params,
+	});
+	if (result.isErr()) return null;
+	const entry = result.value.resource.entry?.[0];
+	const lib = entry?.resource as RawLibrary | undefined;
+	if (!lib || lib.resourceType !== "Library") return null;
+	return lib;
+}
+
+async function resolveInheritedParameters(
+	client: AidboxClientR5,
+	rootLib: RawLibrary,
+): Promise<ParamSpec[]> {
+	const ownNames = new Set(
+		(rootLib.parameter ?? [])
+			.map((p) => p.name)
+			.filter((n): n is string => Boolean(n)),
+	);
+	const collected = new Map<string, ParamSpec>();
+	const visited = new Set<string>();
+
+	let frontier = dependsOnCanonicals(rootLib);
+	while (frontier.length > 0) {
+		const toFetch = frontier.filter((c) => !visited.has(c));
+		for (const c of toFetch) visited.add(c);
+		const libs = await Promise.all(
+			toFetch.map((c) => fetchLibraryByCanonical(client, c)),
+		);
+		const next: string[] = [];
+		for (const lib of libs) {
+			if (!lib) continue;
+			for (const p of lib.parameter ?? []) {
+				if (!p.name) continue;
+				if (ownNames.has(p.name) || collected.has(p.name)) continue;
+				collected.set(p.name, { name: p.name, type: p.type });
+			}
+			for (const c of dependsOnCanonicals(lib)) {
+				if (!visited.has(c)) next.push(c);
+			}
+		}
+		frontier = next;
+	}
+
+	return Array.from(collected.values());
+}
 
 function isSqlQueryLibrary(lib: RawLibrary): boolean {
 	const profiles = lib.meta?.profile ?? [];
@@ -147,7 +230,10 @@ function librarySql(lib: RawLibrary): string {
 	return data ? decodeBase64(data) : "";
 }
 
-function sqlQueryNodeData(lib: RawLibrary): SQLQueryNodeData {
+function sqlQueryNodeData(
+	lib: RawLibrary,
+	inheritedParameters: ParamSpec[] = [],
+): SQLQueryNodeData {
 	return {
 		kind: "sql-query",
 		id: lib.id ?? "",
@@ -159,7 +245,7 @@ function sqlQueryNodeData(lib: RawLibrary): SQLQueryNodeData {
 		parameters: (lib.parameter ?? [])
 			.filter((p) => p.name)
 			.map((p) => ({ name: p.name as string, type: p.type })),
-		inheritedParameters: [],
+		inheritedParameters,
 		isRoot: false,
 	};
 }
@@ -269,13 +355,16 @@ function rootViewNode(vd: RawViewDefinition): BackrefNode {
 	};
 }
 
-function backrefQueryNode(lib: RawLibrary): BackrefNode {
+function backrefQueryNode(
+	lib: RawLibrary,
+	inheritedParameters: ParamSpec[] = [],
+): BackrefNode {
 	const id = queryNodeId(lib);
 	return {
 		id,
 		type: "sql-query",
 		position: { x: 0, y: 0 },
-		data: sqlQueryNodeData(lib),
+		data: sqlQueryNodeData(lib, inheritedParameters),
 	};
 }
 
@@ -415,15 +504,19 @@ async function buildInitialState(
 		canonical: view.url,
 	});
 
+	const inheritedList = await Promise.all(
+		libs.map((lib) => resolveInheritedParameters(client, lib)),
+	);
+
 	const placed: { node: BackrefNode; lib: RawLibrary; depth: number }[] = [];
-	for (const lib of libs) {
-		const node = backrefQueryNode(lib);
-		if (state.nodesById.has(node.id)) continue;
+	libs.forEach((lib, i) => {
+		const node = backrefQueryNode(lib, inheritedList[i] ?? []);
+		if (state.nodesById.has(node.id)) return;
 		state.nodesById.set(node.id, node);
 		setDepth(state, node.id, 1);
 		addEdge(state, root.id, node.id);
 		placed.push({ node, lib, depth: 1 });
-	}
+	});
 
 	await attachPlaceholders(client, state, placed);
 	return state;
@@ -454,20 +547,24 @@ export async function expandQueryNode(
 		canonical: data.canonical,
 	});
 
+	const inheritedList = await Promise.all(
+		libs.map((lib) => resolveInheritedParameters(client, lib)),
+	);
+
 	const placed: { node: BackrefNode; lib: RawLibrary; depth: number }[] = [];
-	for (const lib of libs) {
-		const node = backrefQueryNode(lib);
+	libs.forEach((lib, i) => {
+		const node = backrefQueryNode(lib, inheritedList[i] ?? []);
 		if (node.id === queryNodeId || state.nodesById.has(node.id)) {
 			if (!state.edges.some((e) => e.id === `${queryNodeId}->${node.id}`)) {
 				addEdge(state, queryNodeId, node.id);
 			}
-			continue;
+			return;
 		}
 		state.nodesById.set(node.id, node);
 		setDepth(state, node.id, queryDepth + 1);
 		addEdge(state, queryNodeId, node.id);
 		placed.push({ node, lib, depth: queryDepth + 1 });
-	}
+	});
 
 	await attachPlaceholders(client, state, placed);
 	return state;

--- a/src/components/ViewDefinition/lineage/resolve-graph.ts
+++ b/src/components/ViewDefinition/lineage/resolve-graph.ts
@@ -1,0 +1,507 @@
+import type { Bundle } from "@aidbox-ui/fhir-types/hl7-fhir-r5-core";
+import type { ViewDefinition } from "@aidbox-ui/fhir-types/org-sql-on-fhir-ig";
+import { useQuery } from "@tanstack/react-query";
+import { type AidboxClientR5, useAidboxClient } from "../../../AidboxClient";
+import type {
+	ResourceTypeNodeData,
+	SQLQueryNodeData,
+	ViewConstant,
+	ViewDefinitionNodeData,
+	ViewSelect,
+} from "../../SQLQueryBuilder/lineage/types";
+import type { SQLLibrary } from "../../SQLQueryBuilder/types";
+import {
+	SQL_QUERY_PROFILE,
+	SQL_QUERY_TYPE_CODE,
+	SQL_QUERY_TYPE_SYSTEM,
+} from "../../SQLQueryBuilder/types";
+import type {
+	BackrefGraph,
+	BackrefGraphState,
+	BackrefNode,
+	ExpandPlaceholderNodeData,
+} from "./types";
+
+const SQL_QUERY_TYPE_TOKEN = `${SQL_QUERY_TYPE_SYSTEM}|${SQL_QUERY_TYPE_CODE}`;
+
+const COL_WIDTH = 560;
+const ROW_HEIGHT = 360;
+const PLACEHOLDER_X_OFFSET = 480;
+
+type RawLibrary = SQLLibrary & { description?: string };
+
+type RawSelect = {
+	column?: Array<{
+		name?: string;
+		path?: string;
+		type?: string;
+		description?: string;
+		collection?: boolean;
+	}>;
+	forEach?: string;
+	forEachOrNull?: string;
+	repeat?: string;
+	where?: Array<{ path?: string; description?: string }>;
+	select?: RawSelect[];
+	unionAll?: RawSelect[];
+};
+
+type RawConstant = { name?: string } & Record<string, unknown>;
+
+type RawViewDefinition = {
+	resourceType: "ViewDefinition";
+	id?: string;
+	url?: string;
+	name?: string;
+	title?: string;
+	description?: string;
+	resource?: string;
+	constant?: RawConstant[];
+	select?: RawSelect[];
+	where?: Array<{ path?: string; description?: string }>;
+};
+
+function isSqlQueryLibrary(lib: RawLibrary): boolean {
+	const profiles = lib.meta?.profile ?? [];
+	if (profiles.includes(SQL_QUERY_PROFILE)) return true;
+	const codings = lib.type?.coding ?? [];
+	return codings.some(
+		(c) =>
+			c.code === "sql-query" &&
+			(c.system === undefined ||
+				c.system === "https://sql-on-fhir.org/ig/CodeSystem/LibraryTypesCodes"),
+	);
+}
+
+function normalizeSelect(s: RawSelect): ViewSelect {
+	return {
+		column: (s.column ?? [])
+			.filter((c) => c.name)
+			.map((c) => ({
+				name: c.name as string,
+				path: c.path,
+				type: c.type,
+				description: c.description,
+				collection: c.collection,
+			})),
+		forEach: s.forEach,
+		forEachOrNull: s.forEachOrNull,
+		repeat: s.repeat,
+		where: (s.where ?? [])
+			.filter((w) => w.path)
+			.map((w) => ({ path: w.path as string, description: w.description })),
+		select: (s.select ?? []).map(normalizeSelect),
+		unionAll: (s.unionAll ?? []).map(normalizeSelect),
+	};
+}
+
+function normalizeConstants(vd: RawViewDefinition): ViewConstant[] {
+	const out: ViewConstant[] = [];
+	for (const c of vd.constant ?? []) {
+		if (!c.name) continue;
+		for (const key of Object.keys(c)) {
+			if (key.startsWith("value")) {
+				const type = key.slice("value".length);
+				const v = c[key];
+				out.push({
+					name: c.name,
+					type: type.charAt(0).toLowerCase() + type.slice(1),
+					value: typeof v === "object" ? JSON.stringify(v) : String(v),
+				});
+				break;
+			}
+		}
+	}
+	return out;
+}
+
+function viewDefinitionNodeData(vd: RawViewDefinition): ViewDefinitionNodeData {
+	return {
+		kind: "view-definition",
+		id: vd.id ?? "",
+		canonical: vd.url ?? "",
+		name: vd.name ?? "",
+		title: vd.title,
+		description: vd.description,
+		resourceType: vd.resource,
+		constants: normalizeConstants(vd),
+		select: (vd.select ?? []).map(normalizeSelect),
+		where: (vd.where ?? [])
+			.filter((w): w is { path: string; description?: string } =>
+				Boolean(w.path),
+			)
+			.map((w) => ({ path: w.path, description: w.description })),
+	};
+}
+
+function decodeBase64(b64: string): string {
+	try {
+		return atob(b64);
+	} catch {
+		return "";
+	}
+}
+
+function librarySql(lib: RawLibrary): string {
+	const data = lib.content?.[0]?.data;
+	return data ? decodeBase64(data) : "";
+}
+
+function sqlQueryNodeData(lib: RawLibrary): SQLQueryNodeData {
+	return {
+		kind: "sql-query",
+		id: lib.id ?? "",
+		canonical: lib.url ?? "",
+		name: lib.name ?? "",
+		title: lib.title,
+		description: lib.description,
+		sql: librarySql(lib),
+		parameters: (lib.parameter ?? [])
+			.filter((p) => p.name)
+			.map((p) => ({ name: p.name as string, type: p.type })),
+		inheritedParameters: [],
+		isRoot: false,
+	};
+}
+
+function viewNodeId(vd: RawViewDefinition): string {
+	return `view-definition:${vd.id ?? vd.url ?? "root"}`;
+}
+
+function queryNodeId(lib: RawLibrary): string {
+	return `library:${lib.id ?? lib.url ?? Math.random().toString(36)}`;
+}
+
+function placeholderNodeId(queryId: string): string {
+	return `expand:${queryId}`;
+}
+
+function buildBackrefSearchParams(target: {
+	resourceType: "ViewDefinition" | "Library";
+	id?: string;
+	canonical?: string;
+}): Array<Array<[string, string]>> {
+	const variants: string[] = [];
+	if (target.id) variants.push(`${target.resourceType}/${target.id}`);
+	if (target.canonical) variants.push(target.canonical);
+	const unique = Array.from(new Set(variants));
+	return unique.map((value) => [
+		["depends-on", value],
+		["type", SQL_QUERY_TYPE_TOKEN],
+		["_count", "100"],
+	]);
+}
+
+async function fetchBackrefLibraries(
+	client: AidboxClientR5,
+	target: {
+		resourceType: "ViewDefinition" | "Library";
+		id?: string;
+		canonical?: string;
+	},
+): Promise<RawLibrary[]> {
+	const variantParams = buildBackrefSearchParams(target);
+	if (variantParams.length === 0) return [];
+	const results = await Promise.all(
+		variantParams.map((params) =>
+			client.request<Bundle>({
+				method: "GET",
+				url: "/fhir/Library",
+				params,
+			}),
+		),
+	);
+	const byId = new Map<string, RawLibrary>();
+	for (const result of results) {
+		if (result.isErr()) continue;
+		for (const entry of result.value.resource.entry ?? []) {
+			const lib = entry.resource as RawLibrary | undefined;
+			if (!lib || lib.resourceType !== "Library" || !lib.id) continue;
+			if (!isSqlQueryLibrary(lib)) continue;
+			byId.set(lib.id, lib);
+		}
+	}
+	return Array.from(byId.values());
+}
+
+async function hasBackrefs(
+	client: AidboxClientR5,
+	target: {
+		resourceType: "ViewDefinition" | "Library";
+		id?: string;
+		canonical?: string;
+	},
+): Promise<boolean> {
+	const variants: string[] = [];
+	if (target.id) variants.push(`${target.resourceType}/${target.id}`);
+	if (target.canonical) variants.push(target.canonical);
+	const unique = Array.from(new Set(variants));
+	if (unique.length === 0) return false;
+	const results = await Promise.all(
+		unique.map((value) =>
+			client.request<Bundle & { total?: number }>({
+				method: "GET",
+				url: "/fhir/Library",
+				params: [
+					["depends-on", value],
+					["type", SQL_QUERY_TYPE_TOKEN],
+					["_count", "1"],
+					["_elements", "id"],
+				],
+			}),
+		),
+	);
+	for (const r of results) {
+		if (r.isErr()) continue;
+		if ((r.value.resource.total ?? 0) > 0) return true;
+		if ((r.value.resource.entry ?? []).length > 0) return true;
+	}
+	return false;
+}
+
+function rootViewNode(vd: RawViewDefinition): BackrefNode {
+	const id = viewNodeId(vd);
+	return {
+		id,
+		type: "view-definition",
+		position: { x: 0, y: 0 },
+		data: viewDefinitionNodeData(vd),
+	};
+}
+
+function backrefQueryNode(lib: RawLibrary): BackrefNode {
+	const id = queryNodeId(lib);
+	return {
+		id,
+		type: "sql-query",
+		position: { x: 0, y: 0 },
+		data: sqlQueryNodeData(lib),
+	};
+}
+
+function resourceTypeNode(resourceType: string): BackrefNode {
+	const data: ResourceTypeNodeData = {
+		kind: "resource-type",
+		resourceType,
+	};
+	return {
+		id: `resource-type:${resourceType}`,
+		type: "resource-type",
+		position: { x: 0, y: 0 },
+		data,
+	};
+}
+
+function placeholderNode(queryNode: BackrefNode): BackrefNode {
+	const id = placeholderNodeId(queryNode.id);
+	const data: ExpandPlaceholderNodeData = {
+		kind: "expand-placeholder",
+		queryNodeId: queryNode.id,
+	};
+	return {
+		id,
+		type: "expand-placeholder",
+		position: { x: 0, y: 0 },
+		data,
+	};
+}
+
+function addEdge(state: BackrefGraphState, source: string, target: string) {
+	state.edges.push({ id: `${source}->${target}`, source, target });
+}
+
+function setDepth(state: BackrefGraphState, id: string, depth: number) {
+	const prev = state.depthById.get(id);
+	state.depthById.set(id, prev === undefined ? depth : Math.max(prev, depth));
+}
+
+function layoutGraph(state: BackrefGraphState): BackrefGraph {
+	const byDepth = new Map<number, string[]>();
+	const placeholderIds: string[] = [];
+	for (const [id, depth] of state.depthById) {
+		const node = state.nodesById.get(id);
+		if (!node) continue;
+		if (node.type === "expand-placeholder") {
+			placeholderIds.push(id);
+			continue;
+		}
+		const list = byDepth.get(depth) ?? [];
+		list.push(id);
+		byDepth.set(depth, list);
+	}
+
+	const positionedNodes: BackrefNode[] = [];
+	const positionsById = new Map<string, { x: number; y: number }>();
+	for (const [depth, ids] of byDepth) {
+		ids.forEach((id, i) => {
+			const node = state.nodesById.get(id);
+			if (!node) return;
+			const x = depth * COL_WIDTH;
+			const y = (i - (ids.length - 1) / 2) * ROW_HEIGHT;
+			const positioned: BackrefNode = { ...node, position: { x, y } };
+			positionsById.set(id, { x, y });
+			positionedNodes.push(positioned);
+		});
+	}
+
+	for (const placeholderId of placeholderIds) {
+		const node = state.nodesById.get(placeholderId);
+		if (!node) continue;
+		const data = node.data as ExpandPlaceholderNodeData;
+		const targetPos = positionsById.get(data.queryNodeId);
+		if (!targetPos) continue;
+		positionedNodes.push({
+			...node,
+			position: {
+				x: targetPos.x + PLACEHOLDER_X_OFFSET,
+				y: targetPos.y,
+			},
+		});
+	}
+
+	return { nodes: positionedNodes, edges: state.edges };
+}
+
+async function attachPlaceholders(
+	client: AidboxClientR5,
+	state: BackrefGraphState,
+	queries: { node: BackrefNode; lib: RawLibrary; depth: number }[],
+): Promise<void> {
+	if (queries.length === 0) return;
+	const presence = await Promise.all(
+		queries.map((q) =>
+			hasBackrefs(client, {
+				resourceType: "Library",
+				id: q.lib.id,
+				canonical: q.lib.url,
+			}),
+		),
+	);
+	queries.forEach((q, i) => {
+		if (!presence[i]) return;
+		const ph = placeholderNode(q.node);
+		state.nodesById.set(ph.id, ph);
+		setDepth(state, ph.id, q.depth + 1);
+		addEdge(state, q.node.id, ph.id);
+	});
+}
+
+function attachResourceType(state: BackrefGraphState, vd: RawViewDefinition) {
+	if (!vd.resource) return;
+	const rt = resourceTypeNode(vd.resource);
+	if (!state.nodesById.has(rt.id)) state.nodesById.set(rt.id, rt);
+	setDepth(state, rt.id, -1);
+	const viewId = viewNodeId(vd);
+	addEdge(state, rt.id, viewId);
+}
+
+async function buildInitialState(
+	client: AidboxClientR5,
+	view: RawViewDefinition,
+): Promise<BackrefGraphState> {
+	const root = rootViewNode(view);
+	const state: BackrefGraphState = {
+		rootId: root.id,
+		nodesById: new Map([[root.id, root]]),
+		depthById: new Map([[root.id, 0]]),
+		edges: [],
+	};
+
+	attachResourceType(state, view);
+
+	const libs = await fetchBackrefLibraries(client, {
+		resourceType: "ViewDefinition",
+		id: view.id,
+		canonical: view.url,
+	});
+
+	const placed: { node: BackrefNode; lib: RawLibrary; depth: number }[] = [];
+	for (const lib of libs) {
+		const node = backrefQueryNode(lib);
+		if (state.nodesById.has(node.id)) continue;
+		state.nodesById.set(node.id, node);
+		setDepth(state, node.id, 1);
+		addEdge(state, root.id, node.id);
+		placed.push({ node, lib, depth: 1 });
+	}
+
+	await attachPlaceholders(client, state, placed);
+	return state;
+}
+
+export async function expandQueryNode(
+	client: AidboxClientR5,
+	state: BackrefGraphState,
+	queryNodeId: string,
+): Promise<BackrefGraphState> {
+	const queryNode = state.nodesById.get(queryNodeId);
+	if (!queryNode || queryNode.type !== "sql-query") return state;
+	const queryDepth = state.depthById.get(queryNodeId) ?? 1;
+	const data = queryNode.data as SQLQueryNodeData;
+
+	const placeholderId = placeholderNodeId(queryNodeId);
+	if (state.nodesById.has(placeholderId)) {
+		state.nodesById.delete(placeholderId);
+		state.depthById.delete(placeholderId);
+	}
+	state.edges = state.edges.filter(
+		(e) => e.source !== placeholderId && e.target !== placeholderId,
+	);
+
+	const libs = await fetchBackrefLibraries(client, {
+		resourceType: "Library",
+		id: data.id,
+		canonical: data.canonical,
+	});
+
+	const placed: { node: BackrefNode; lib: RawLibrary; depth: number }[] = [];
+	for (const lib of libs) {
+		const node = backrefQueryNode(lib);
+		if (node.id === queryNodeId || state.nodesById.has(node.id)) {
+			if (!state.edges.some((e) => e.id === `${queryNodeId}->${node.id}`)) {
+				addEdge(state, queryNodeId, node.id);
+			}
+			continue;
+		}
+		state.nodesById.set(node.id, node);
+		setDepth(state, node.id, queryDepth + 1);
+		addEdge(state, queryNodeId, node.id);
+		placed.push({ node, lib, depth: queryDepth + 1 });
+	}
+
+	await attachPlaceholders(client, state, placed);
+	return state;
+}
+
+export function stateToGraph(state: BackrefGraphState): BackrefGraph {
+	return layoutGraph(state);
+}
+
+export function useViewDefinitionLineageGraph(
+	view: ViewDefinition | undefined,
+): {
+	state: BackrefGraphState | null;
+	graph: BackrefGraph;
+	isLoading: boolean;
+} {
+	const client = useAidboxClient();
+	const raw = view as unknown as RawViewDefinition | undefined;
+	const { data, isLoading } = useQuery<BackrefGraphState>({
+		enabled: Boolean(raw?.id || raw?.url),
+		queryKey: [
+			"view-definition-lineage-state",
+			raw?.id ?? null,
+			raw?.url ?? null,
+		],
+		queryFn: () => {
+			if (!raw) throw new Error("view is required");
+			return buildInitialState(client, raw);
+		},
+		placeholderData: (prev) => prev,
+	});
+	return {
+		state: data ?? null,
+		graph: data ? layoutGraph(data) : { nodes: [], edges: [] },
+		isLoading,
+	};
+}

--- a/src/components/ViewDefinition/lineage/types.ts
+++ b/src/components/ViewDefinition/lineage/types.ts
@@ -1,0 +1,29 @@
+import type { Edge, Node } from "@xyflow/react";
+import type {
+	LineageNodeData,
+	SQLQueryNodeData,
+	ViewDefinitionNodeData,
+} from "../../SQLQueryBuilder/lineage/types";
+
+export type ExpandPlaceholderNodeData = {
+	kind: "expand-placeholder";
+	queryNodeId: string;
+};
+
+export type BackrefNodeData = LineageNodeData | ExpandPlaceholderNodeData;
+
+export type BackrefNode = Node<BackrefNodeData>;
+
+export type BackrefGraph = {
+	nodes: BackrefNode[];
+	edges: Edge[];
+};
+
+export type BackrefGraphState = {
+	rootId: string;
+	nodesById: Map<string, BackrefNode>;
+	depthById: Map<string, number>;
+	edges: Edge[];
+};
+
+export type { LineageNodeData, SQLQueryNodeData, ViewDefinitionNodeData };


### PR DESCRIPTION
## Summary
- Add **Data Lineage** UI for the Analytics section (formerly data-lineage, renamed to analytics): browse, edit and run SQL on FHIR ViewDefinitions and SQLQueries with a graph-based lineage view.
- New **Lineage tab on SQLQuery**: forward `depends-on` graph rooted at the current Library, with inherited parameters, RUN actions and detail panel.
- New **Lineage tab on ViewDefinition**: backref graph showing the Resource Type, the current View and SQLQueries that `depends-on` it. Each Query lazily expands deeper backrefs via a chevron node (FHIR `Library.depends-on` search) and surfaces its own transitive inherited parameters.
- UX polish: spacer column and persisted page size in the Lineage result table, `1fr/auto` row layout so long parameter names take all available width, stop refetching the lineage state on tab focus so expanded nodes are preserved.

## Test plan
- [ ] Open `/analytics/views/edit/{id}` → switch to **Lineage** tab. View node, Resource Type node (left) and direct backref Query nodes (right) are visible.
- [ ] Queries that are themselves referenced by other Queries show a `»` chevron node; click it to lazily expand the next backref level.
- [ ] Open `/analytics/queries/edit/{id}` → **Lineage** tab still shows the forward depends-on graph as before.
- [ ] RUN on a View or Query node opens the result panel; the result table has a trailing spacer column and the page-size dropdown persists across reloads.
- [ ] Long parameter / column names in nodes occupy the full row instead of being truncated at 50%.
- [ ] Switch browser tabs and return — expanded Lineage state is preserved, no refetch storms.