### PR TITLE
Fix duplicate autocomplete popup in ViewDefinition (prod only)

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
 			"yaml": "^2.8.3",
 			"diff": "^8.0.3",
 			"postcss@<8.5.10": ">=8.5.10",
-			"@codemirror/view": "^6.42.0"
+			"@codemirror/view": "^6.42.0",
+			"@codemirror/autocomplete": "6.20.2"
 		}
 	},
 	"dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   diff: ^8.0.3
   postcss@<8.5.10: '>=8.5.10'
   '@codemirror/view': ^6.42.0
+  '@codemirror/autocomplete': 6.20.2
 
 importers:
 
@@ -337,9 +338,6 @@ packages:
 
   '@cfworker/json-schema@4.1.1':
     resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
-
-  '@codemirror/autocomplete@6.20.1':
-    resolution: {integrity: sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==}
 
   '@codemirror/autocomplete@6.20.2':
     resolution: {integrity: sha512-G5FPkgIiLjOgZMjqVjvuKQ1rGPtHogLldJr33eFJdVLtmwY+giGrlv/ewljLz6b9BSQLkjxuwBc6g6omDM+YxQ==}
@@ -2981,7 +2979,7 @@ snapshots:
   '@atomic-ehr/fhirpath-lsp@0.0.7(typescript@5.9.3)':
     dependencies:
       '@atomic-ehr/fhirpath': 0.1.4(typescript@5.9.3)
-      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/autocomplete': 6.20.2
       '@codemirror/commands': 6.10.3
       '@codemirror/language': 6.12.2
       '@codemirror/lint': 6.9.5
@@ -3174,13 +3172,6 @@ snapshots:
 
   '@cfworker/json-schema@4.1.1': {}
 
-  '@codemirror/autocomplete@6.20.1':
-    dependencies:
-      '@codemirror/language': 6.12.2
-      '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.42.1
-      '@lezer/common': 1.5.1
-
   '@codemirror/autocomplete@6.20.2':
     dependencies:
       '@codemirror/language': 6.12.2
@@ -3202,7 +3193,7 @@ snapshots:
 
   '@codemirror/lang-sql@6.10.0':
     dependencies:
-      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/autocomplete': 6.20.2
       '@codemirror/language': 6.12.2
       '@codemirror/state': 6.6.0
       '@lezer/common': 1.5.1
@@ -3211,7 +3202,7 @@ snapshots:
 
   '@codemirror/lang-yaml@6.1.2':
     dependencies:
-      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/autocomplete': 6.20.2
       '@codemirror/language': 6.12.2
       '@codemirror/state': 6.6.0
       '@lezer/common': 1.5.1
@@ -3439,7 +3430,7 @@ snapshots:
 
   '@health-samurai/react-components@file:aidbox-ts-sdk/packages/react-components(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-is@19.2.4)(redux@5.0.1)':
     dependencies:
-      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/autocomplete': 6.20.2
       '@codemirror/commands': 6.10.3
       '@codemirror/lang-json': 6.0.2
       '@codemirror/lang-sql': 6.10.0
@@ -4985,7 +4976,7 @@ snapshots:
 
   codemirror@6.0.2:
     dependencies:
-      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/autocomplete': 6.20.2
       '@codemirror/commands': 6.10.3
       '@codemirror/language': 6.12.2
       '@codemirror/lint': 6.9.5


### PR DESCRIPTION
## Summary
- Force a single `@codemirror/autocomplete` version (6.20.2) via `pnpm.overrides` so `EditorInput` and `@codemirror/lsp-client`'s `serverCompletion()` share the same module instance.
- Removes the duplicated autocomplete dropdown that appeared in production ViewDefinition column inputs.

## Root cause
`@codemirror/lsp-client@6.2.2` pulled in `@codemirror/autocomplete@6.20.2`, while `react-components` still resolved `6.20.1`. Two module copies meant two different `completionPlugin = ViewPlugin.fromClass(...)` classes, so CodeMirror instantiated both — `EditorInput`'s styled tooltip and the LSP plugin's bare tooltip — at the same time. Dev builds happened to dedupe both copies through Vite's prebundling, so the bug only surfaced in the production bundle.

## Test plan
- [ ] `pnpm install` succeeds, lockfile only references `@codemirror/autocomplete@6.20.2`
- [ ] `pnpm build` produces a single bundle with one autocomplete chunk
- [ ] In the built app, open ViewDefinition, focus a Column name input, type "i" — only one styled dropdown appears
- [ ] FHIRPath completions (icons, descriptions) still work
- [ ] No regressions in other CodeMirror editors (SQL builder, JSON editor, REST console)