### PR TITLE
Analytics: recents list page

### DIFF
--- a/src/components/DataLineage/sidebar.tsx
+++ b/src/components/DataLineage/sidebar.tsx
@@ -42,6 +42,40 @@ function pickLabel(r: { id?: string; name?: string; title?: string }): string {
 	return r.title || r.name || r.id || "(unnamed)";
 }
 
+const SKELETON_WIDTHS = [
+	"w-32",
+	"w-40",
+	"w-28",
+	"w-44",
+	"w-36",
+	"w-24",
+	"w-48",
+	"w-32",
+];
+
+function SkeletonRows({ count }: { count: number }) {
+	const rows = React.useMemo(
+		() =>
+			Array.from({ length: count }, () => ({
+				id: crypto.randomUUID(),
+				width:
+					SKELETON_WIDTHS[Math.floor(Math.random() * SKELETON_WIDTHS.length)],
+			})),
+		[count],
+	);
+	return (
+		<>
+			{rows.map((r) => (
+				<HSComp.SidebarMenuSubItem key={r.id}>
+					<div className="flex items-center h-7 pl-[11px]">
+						<HSComp.Skeleton className={`h-3.5 ${r.width}`} />
+					</div>
+				</HSComp.SidebarMenuSubItem>
+			))}
+		</>
+	);
+}
+
 function useViewItems() {
 	const client = useAidboxClient();
 	return useQuery<SidebarItem[]>({
@@ -133,12 +167,16 @@ function ViewsSection({
 	currentPath,
 	currentTab,
 	items,
+	loading,
+	skeletonCount,
 }: {
 	open: boolean;
 	onOpenChange: (v: boolean) => void;
 	currentPath: string;
 	currentTab: string | undefined;
 	items: SidebarItem[];
+	loading: boolean;
+	skeletonCount: number;
 }) {
 	const editSearch = {
 		tab: mapToViewTab(currentTab),
@@ -180,35 +218,39 @@ function ViewsSection({
 				</div>
 				<HSComp.CollapsibleContent>
 					<HSComp.SidebarMenuSub>
-						{items.length === 0 && (
+						{loading && skeletonCount > 0 && (
+							<SkeletonRows count={skeletonCount} />
+						)}
+						{!loading && items.length === 0 && (
 							<HSComp.SidebarMenuSubItem>
 								<div className="pl-[11px] py-1 text-xs italic text-text-tertiary">
 									No views
 								</div>
 							</HSComp.SidebarMenuSubItem>
 						)}
-						{items.map((it) => {
-							const active = currentPath === `/analytics/views/edit/${it.id}`;
-							return (
-								<HSComp.SidebarMenuSubItem key={it.id}>
-									<HoverTooltip description={it.description}>
-										<HSComp.SidebarMenuSubButton
-											isActive={active}
-											asChild
-											className="text-xs font-normal pl-[11px] data-[active=true]:bg-bg-tertiary data-[active=true]:hover:bg-bg-tertiary"
-										>
-											<Link
-												to="/analytics/views/edit/$id"
-												params={{ id: it.id }}
-												search={editSearch}
+						{!loading &&
+							items.map((it) => {
+								const active = currentPath === `/analytics/views/edit/${it.id}`;
+								return (
+									<HSComp.SidebarMenuSubItem key={it.id}>
+										<HoverTooltip description={it.description}>
+											<HSComp.SidebarMenuSubButton
+												isActive={active}
+												asChild
+												className="text-xs font-normal pl-[11px] data-[active=true]:bg-bg-tertiary data-[active=true]:hover:bg-bg-tertiary"
 											>
-												<span className="truncate">{it.label}</span>
-											</Link>
-										</HSComp.SidebarMenuSubButton>
-									</HoverTooltip>
-								</HSComp.SidebarMenuSubItem>
-							);
-						})}
+												<Link
+													to="/analytics/views/edit/$id"
+													params={{ id: it.id }}
+													search={editSearch}
+												>
+													<span className="truncate">{it.label}</span>
+												</Link>
+											</HSComp.SidebarMenuSubButton>
+										</HoverTooltip>
+									</HSComp.SidebarMenuSubItem>
+								);
+							})}
 					</HSComp.SidebarMenuSub>
 				</HSComp.CollapsibleContent>
 			</HSComp.Collapsible>
@@ -222,12 +264,16 @@ function QueriesSection({
 	currentPath,
 	currentTab,
 	items,
+	loading,
+	skeletonCount,
 }: {
 	open: boolean;
 	onOpenChange: (v: boolean) => void;
 	currentPath: string;
 	currentTab: string | undefined;
 	items: SidebarItem[];
+	loading: boolean;
+	skeletonCount: number;
 }) {
 	const editSearch = {
 		tab: mapToQueryTab(currentTab),
@@ -269,35 +315,40 @@ function QueriesSection({
 				</div>
 				<HSComp.CollapsibleContent>
 					<HSComp.SidebarMenuSub>
-						{items.length === 0 && (
+						{loading && skeletonCount > 0 && (
+							<SkeletonRows count={skeletonCount} />
+						)}
+						{!loading && items.length === 0 && (
 							<HSComp.SidebarMenuSubItem>
 								<div className="pl-[11px] py-1 text-xs italic text-text-tertiary">
 									No queries
 								</div>
 							</HSComp.SidebarMenuSubItem>
 						)}
-						{items.map((it) => {
-							const active = currentPath === `/analytics/queries/edit/${it.id}`;
-							return (
-								<HSComp.SidebarMenuSubItem key={it.id}>
-									<HoverTooltip description={it.description}>
-										<HSComp.SidebarMenuSubButton
-											isActive={active}
-											asChild
-											className="text-xs font-normal pl-[11px] data-[active=true]:bg-bg-tertiary data-[active=true]:hover:bg-bg-tertiary"
-										>
-											<Link
-												to="/analytics/queries/edit/$id"
-												params={{ id: it.id }}
-												search={editSearch}
+						{!loading &&
+							items.map((it) => {
+								const active =
+									currentPath === `/analytics/queries/edit/${it.id}`;
+								return (
+									<HSComp.SidebarMenuSubItem key={it.id}>
+										<HoverTooltip description={it.description}>
+											<HSComp.SidebarMenuSubButton
+												isActive={active}
+												asChild
+												className="text-xs font-normal pl-[11px] data-[active=true]:bg-bg-tertiary data-[active=true]:hover:bg-bg-tertiary"
 											>
-												<span className="truncate">{it.label}</span>
-											</Link>
-										</HSComp.SidebarMenuSubButton>
-									</HoverTooltip>
-								</HSComp.SidebarMenuSubItem>
-							);
-						})}
+												<Link
+													to="/analytics/queries/edit/$id"
+													params={{ id: it.id }}
+													search={editSearch}
+												>
+													<span className="truncate">{it.label}</span>
+												</Link>
+											</HSComp.SidebarMenuSubButton>
+										</HoverTooltip>
+									</HSComp.SidebarMenuSubItem>
+								);
+							})}
 					</HSComp.SidebarMenuSub>
 				</HSComp.CollapsibleContent>
 			</HSComp.Collapsible>
@@ -323,7 +374,24 @@ export function DataLineageSidebar() {
 		defaultValue: true,
 		getInitialValueInEffect: false,
 	});
+	const [viewsCount, setViewsCount] = useLocalStorage<number | null>({
+		key: "data-lineage-sidebar:views-count",
+		defaultValue: null,
+		getInitialValueInEffect: false,
+	});
+	const [queriesCount, setQueriesCount] = useLocalStorage<number | null>({
+		key: "data-lineage-sidebar:queries-count",
+		defaultValue: null,
+		getInitialValueInEffect: false,
+	});
 	const [searchQ, setSearchQ] = React.useState("");
+
+	React.useEffect(() => {
+		if (views.data) setViewsCount(views.data.length);
+	}, [views.data, setViewsCount]);
+	React.useEffect(() => {
+		if (queries.data) setQueriesCount(queries.data.length);
+	}, [queries.data, setQueriesCount]);
 
 	const filteredViews = filterItems(views.data ?? [], searchQ);
 	const filteredQueries = filterItems(queries.data ?? [], searchQ);
@@ -346,6 +414,8 @@ export function DataLineageSidebar() {
 						currentPath={currentPath}
 						currentTab={currentTab}
 						items={filteredViews}
+						loading={views.isLoading}
+						skeletonCount={viewsCount ?? 0}
 					/>
 					<QueriesSection
 						open={openQueries || searchQ.trim() !== ""}
@@ -353,6 +423,8 @@ export function DataLineageSidebar() {
 						currentPath={currentPath}
 						currentTab={currentTab}
 						items={filteredQueries}
+						loading={queries.isLoading}
+						skeletonCount={queriesCount ?? 0}
 					/>
 				</HSComp.SidebarMenu>
 			</HSComp.SidebarContent>

--- a/src/components/ResourceEditor/action.tsx
+++ b/src/components/ResourceEditor/action.tsx
@@ -135,6 +135,7 @@ export const DeleteButton = ({
 		onSuccess: (_resource, _variables, _onMutateResult, _context) => {
 			HSComp.toast.success("Saved", defaultToastPlacement);
 			invalidateDataLineageSidebar(queryClient, resourceType);
+			window.dispatchEvent(new Event("aidbox-resource-deleted"));
 			if (onDeleted) {
 				onDeleted();
 				return;

--- a/src/components/ResourceEditor/page.tsx
+++ b/src/components/ResourceEditor/page.tsx
@@ -326,6 +326,8 @@ export const ResourceEditorPage = ({
 				};
 			try {
 				await deleteResource(client, resourceType, id);
+				setEditDirty(false);
+				window.dispatchEvent(new Event("aidbox-resource-deleted"));
 				if (onDeleted) {
 					onDeleted();
 				} else {

--- a/src/components/SQLQueryBuilder/lineage/detail-panel.tsx
+++ b/src/components/SQLQueryBuilder/lineage/detail-panel.tsx
@@ -461,7 +461,7 @@ export function LineageDetailPanel({
 			<PanelHeader
 				icon={<FileCode2 size={14} />}
 				label="Query"
-				color="text-text-brand-primary"
+				color="text-text-warning-primary"
 				onClose={onClose}
 			/>
 			<div className="flex flex-col gap-1">

--- a/src/components/SQLQueryBuilder/lineage/nodes.tsx
+++ b/src/components/SQLQueryBuilder/lineage/nodes.tsx
@@ -257,8 +257,8 @@ export function SQLQueryNode({ id, data, selected }: AnyNodeProps) {
 	const headerInner = (
 		<>
 			<div className="flex items-center gap-2">
-				<FileCode2 size={14} className="text-text-brand-primary shrink-0" />
-				<span className="font-mono text-xs text-text-brand-primary uppercase">
+				<FileCode2 size={14} className="text-text-warning-primary shrink-0" />
+				<span className="font-mono text-xs text-text-warning-primary uppercase">
 					Query
 				</span>
 			</div>

--- a/src/components/SQLQueryBuilder/page.tsx
+++ b/src/components/SQLQueryBuilder/page.tsx
@@ -45,7 +45,9 @@ export function SQLQueryProvider({
 	const [baselineHash, setBaselineHash] = React.useState<string>(() =>
 		computeLibraryHash(initialResource as SQLLibrary),
 	);
-	const isDirty = computeLibraryHash(library) !== baselineHash;
+	const isDeletedRef = React.useRef(false);
+	const isDirty =
+		!isDeletedRef.current && computeLibraryHash(library) !== baselineHash;
 	const isDirtyRef = React.useRef(false);
 	isDirtyRef.current = isDirty;
 
@@ -54,6 +56,14 @@ export function SQLQueryProvider({
 			setBaselineHash(computeLibraryHash(libraryRef.current));
 			isDirtyRef.current = false;
 		}
+	}, []);
+	React.useEffect(() => {
+		const handler = () => {
+			isDeletedRef.current = true;
+			isDirtyRef.current = false;
+		};
+		window.addEventListener("aidbox-resource-deleted", handler);
+		return () => window.removeEventListener("aidbox-resource-deleted", handler);
 	}, []);
 	const [runResult, setRunResult] = React.useState<RunResult | null>(null);
 	const [runError, setRunError] =

--- a/src/components/SQLQueryBuilder/resource-picker.tsx
+++ b/src/components/SQLQueryBuilder/resource-picker.tsx
@@ -1,12 +1,14 @@
 import type { Bundle } from "@aidbox-ui/fhir-types/hl7-fhir-r5-core";
 import * as HSComp from "@health-samurai/react-components";
 import { useQuery } from "@tanstack/react-query";
-import { ChevronDown, Info } from "lucide-react";
+import { ChevronDown, FileCode2, Info, Table } from "lucide-react";
 import * as React from "react";
 import { useAidboxClient } from "../../AidboxClient";
 import { SQL_QUERY_TYPE_CODE, SQL_QUERY_TYPE_SYSTEM } from "./types";
 
 type CandidateKind = "ViewDefinition" | "SQLQuery";
+
+type RelatedArtifactRef = { url: string; label?: string };
 
 type CandidateOption = {
 	url: string;
@@ -15,6 +17,9 @@ type CandidateOption = {
 	name?: string;
 	title?: string;
 	description?: string;
+	resource?: string;
+	relatedArtifacts?: RelatedArtifactRef[];
+	createdAt?: string;
 };
 
 type RawCandidate = {
@@ -23,7 +28,36 @@ type RawCandidate = {
 	name?: string;
 	title?: string;
 	description?: string;
+	resource?: string;
+	relatedArtifact?: Array<{
+		type?: string;
+		label?: string;
+		resource?: string;
+	}>;
+	meta?: {
+		lastUpdated?: string;
+		extension?: Array<{ url?: string; valueInstant?: string }>;
+	};
 };
+
+function extractCreatedAt(r: RawCandidate): string | undefined {
+	const ext = r.meta?.extension;
+	if (!ext) return undefined;
+	for (const e of ext) {
+		if (e.valueInstant) return e.valueInstant;
+	}
+	return undefined;
+}
+
+function Badge({ text, accentClass }: { text: string; accentClass: string }) {
+	return (
+		<span
+			className={`shrink-0 text-[11px] leading-4 normal-case whitespace-nowrap ${accentClass}`}
+		>
+			#{text}
+		</span>
+	);
+}
 
 const SQL_QUERY_TYPE_TOKEN = `${SQL_QUERY_TYPE_SYSTEM}|${SQL_QUERY_TYPE_CODE}`;
 
@@ -36,15 +70,17 @@ function useDebouncedValue<T>(value: T, delay: number): T {
 	return v;
 }
 
-function useCandidates(search: string) {
+function useCandidates(search: string, enabled = true) {
 	const client = useAidboxClient();
 	const debouncedSearch = useDebouncedValue(search, 200);
 	return useQuery<CandidateOption[]>({
 		queryKey: ["sqlquery-depends-on-candidates", debouncedSearch],
+		enabled,
 		queryFn: async () => {
 			const baseParams: Array<[string, string]> = [
-				["_count", "30"],
+				["_count", "1000"],
 				["url:missing", "false"],
+				["_sort", "-_createdAt"],
 			];
 			if (debouncedSearch) baseParams.push(["_ilike", debouncedSearch]);
 			const [vd, lib] = await Promise.all([
@@ -70,12 +106,17 @@ function useCandidates(search: string) {
 						name: r.name,
 						title: r.title,
 						description: r.description,
+						resource: r.resource,
+						createdAt: extractCreatedAt(r),
 					});
 				}
 			}
 			if (lib.isOk()) {
 				for (const entry of lib.value.resource.entry ?? []) {
 					const r = entry.resource as unknown as RawCandidate;
+					const relatedArtifacts = (r.relatedArtifact ?? []).flatMap((ra) =>
+						ra.resource ? [{ url: ra.resource, label: ra.label }] : [],
+					);
 					out.push({
 						url: r.url,
 						kind: "SQLQuery",
@@ -83,9 +124,17 @@ function useCandidates(search: string) {
 						name: r.name,
 						title: r.title,
 						description: r.description,
+						relatedArtifacts:
+							relatedArtifacts.length > 0 ? relatedArtifacts : undefined,
+						createdAt: extractCreatedAt(r),
 					});
 				}
 			}
+			out.sort((a, b) => {
+				const da = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+				const db = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+				return db - da;
+			});
 			return out;
 		},
 	});
@@ -102,8 +151,15 @@ export function ResourcePicker({
 }) {
 	const [open, setOpen] = React.useState(false);
 	const [search, setSearch] = React.useState("");
-	const { data: candidates = [] } = useCandidates(open ? search : "");
+	const { data: candidates = [] } = useCandidates(search, open);
+	const { data: allCandidates = [] } = useCandidates("", open);
 	const commandRef = React.useRef<HTMLDivElement>(null);
+	const lookupByUrl = React.useMemo(() => {
+		const map = new Map<string, CandidateOption>();
+		for (const c of allCandidates) map.set(c.url, c);
+		for (const c of candidates) map.set(c.url, c);
+		return (url: string) => map.get(url);
+	}, [allCandidates, candidates]);
 
 	React.useEffect(() => {
 		if (!open) return;
@@ -131,7 +187,7 @@ export function ResourcePicker({
 					<ChevronDown className="size-4 shrink-0 opacity-50" />
 				</HSComp.Button>
 			</HSComp.PopoverTrigger>
-			<HSComp.PopoverContent className="w-[420px] p-0" align="start">
+			<HSComp.PopoverContent className="w-[640px] p-0" align="start">
 				<div ref={commandRef}>
 					<HSComp.Command shouldFilter={false}>
 						<HSComp.CommandInput
@@ -139,48 +195,94 @@ export function ResourcePicker({
 							value={search}
 							onValueChange={setSearch}
 						/>
-						<HSComp.CommandList className="overflow-x-auto">
+						<HSComp.CommandList>
 							<HSComp.CommandEmpty>
-								<div className="flex flex-col items-center gap-2 px-4">
-									<span className="typo-body text-text-tertiary">
+								<div className="flex flex-col items-start gap-2 px-4 py-4 normal-case">
+									<span className="typo-body text-text-primary">
 										No matches
 									</span>
-									<div className="flex items-start gap-1.5 text-left typo-label-tiny text-text-tertiary">
-										<Info className="size-3.5 shrink-0 mt-px text-text-quaternary" />
+									<div className="flex items-start gap-1.5 text-left typo-body-xs text-text-secondary normal-case">
+										<Info className="size-3.5 shrink-0 mt-0.5 text-text-tertiary" />
 										<span>
 											Only ViewDefinitions and SQLQueries with a defined{" "}
-											<span className="font-mono text-text-secondary">url</span>{" "}
+											<span className="font-mono text-text-primary">url</span>{" "}
 											are listed — references rely on canonical URLs.
 										</span>
 									</div>
 								</div>
 							</HSComp.CommandEmpty>
-							<div className="min-w-max">
-								{candidates.map((c) => {
-									const label = c.title || c.name || c.id;
-									const secondary = c.description || c.url;
-									return (
-										<HSComp.CommandItem
-											key={c.url}
-											value={c.url}
-											onSelect={() => {
-												onChange(c.url);
-												setOpen(false);
-											}}
-										>
-											<div className="flex flex-col gap-0.5">
-												<span className="typo-label-tiny text-text-tertiary whitespace-nowrap">
-													{c.kind}
-												</span>
-												<span className="whitespace-nowrap">{label}</span>
-												<span className="font-mono text-xs text-text-tertiary whitespace-nowrap">
-													{secondary}
-												</span>
-											</div>
-										</HSComp.CommandItem>
+							{candidates.map((c) => {
+								const label = c.title || c.name || c.id;
+								const isView = c.kind === "ViewDefinition";
+								const Icon = isView ? Table : FileCode2;
+								const kindLabel = isView ? "View" : "Query";
+								const accentClass = isView
+									? "text-text-info-primary"
+									: "text-text-warning-primary";
+								const badges: React.ReactNode[] = [];
+								if (isView && c.resource) {
+									badges.push(
+										<Badge
+											key="resource"
+											text={c.resource}
+											accentClass="text-text-success-primary"
+										/>,
 									);
-								})}
-							</div>
+								}
+								if (!isView && c.relatedArtifacts) {
+									for (const ra of c.relatedArtifacts) {
+										const linked = lookupByUrl(ra.url);
+										const isLinkedView =
+											linked?.kind === "ViewDefinition" ||
+											ra.url.includes("/ViewDefinition/");
+										badges.push(
+											<Badge
+												key={ra.url}
+												text={
+													linked?.title ?? linked?.name ?? ra.label ?? ra.url
+												}
+												accentClass={
+													isLinkedView
+														? "text-text-info-primary"
+														: "text-text-warning-primary"
+												}
+											/>,
+										);
+									}
+								}
+								return (
+									<HSComp.CommandItem
+										key={c.url}
+										value={c.url}
+										onSelect={() => {
+											onChange(c.url);
+											setOpen(false);
+										}}
+									>
+										<div className="flex flex-col min-w-0">
+											<div
+												className={`flex items-center gap-1.5 typo-label-tiny uppercase tracking-wide ${accentClass}`}
+											>
+												<Icon className="size-3.5 shrink-0" />
+												<span>{kindLabel}</span>
+											</div>
+											<div className="typo-body text-text-primary truncate first-letter:uppercase mt-0.5">
+												{label}
+											</div>
+											{c.description && (
+												<div className="typo-body-xs text-text-secondary mt-0.5 line-clamp-1">
+													{c.description}
+												</div>
+											)}
+											{badges.length > 0 && (
+												<div className="flex flex-wrap gap-x-2 gap-y-0.5 mt-2">
+													{badges}
+												</div>
+											)}
+										</div>
+									</HSComp.CommandItem>
+								);
+							})}
 						</HSComp.CommandList>
 					</HSComp.Command>
 				</div>

--- a/src/routes/analytics.index.tsx
+++ b/src/routes/analytics.index.tsx
@@ -1,15 +1,608 @@
-import { createFileRoute } from "@tanstack/react-router";
+import type { Bundle } from "@aidbox-ui/fhir-types/hl7-fhir-r5-core";
+import type { ViewDefinition } from "@aidbox-ui/fhir-types/org-sql-on-fhir-ig";
+import * as HSComp from "@health-samurai/react-components";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import Fuse from "fuse.js";
+import {
+	EllipsisVertical,
+	FileCode2,
+	GitBranch,
+	Plus,
+	Search,
+	Table,
+	Trash2,
+} from "lucide-react";
+import * as React from "react";
+import { useAidboxClient } from "../AidboxClient";
 import { EmptyState } from "../components/empty-state";
 
-function DataLineageIndex() {
+type MatchRange = readonly [number, number];
+
+function highlight(text: string, ranges: readonly MatchRange[] | undefined) {
+	if (!ranges || ranges.length === 0) return text;
+	const sorted = ranges.slice().sort((a, b) => a[0] - b[0]);
+	const parts: React.ReactNode[] = [];
+	let cursor = 0;
+	sorted.forEach(([start, end]) => {
+		if (start < cursor) return;
+		if (start > cursor) parts.push(text.slice(cursor, start));
+		parts.push(
+			<span key={`${start}-${end}`} className="text-text-link">
+				{text.slice(start, end + 1)}
+			</span>,
+		);
+		cursor = end + 1;
+	});
+	if (cursor < text.length) parts.push(text.slice(cursor));
+	return <>{parts}</>;
+}
+
+const SQL_QUERY_TYPE_TOKEN =
+	"https://sql-on-fhir.org/ig/CodeSystem/LibraryTypesCodes|sql-query";
+
+type LibraryResource = {
+	resourceType: "Library";
+	id?: string;
+	name?: string;
+	title?: string;
+	description?: string;
+	url?: string;
+	meta?: { lastUpdated?: string };
+	relatedArtifact?: Array<{
+		type?: string;
+		label?: string;
+		resource?: string;
+	}>;
+};
+
+type RelatedArtifactRef = {
+	url: string;
+	label?: string;
+};
+
+type RecentItem = {
+	kind: "view" | "query";
+	id: string;
+	url?: string;
+	resource?: string;
+	relatedArtifacts?: RelatedArtifactRef[];
+	label: string;
+	description?: string;
+	lastUpdated?: string;
+	labelMatches?: readonly MatchRange[];
+	descriptionMatches?: readonly MatchRange[];
+};
+
+const VIEW_EDIT_SEARCH = {
+	tab: "builder" as const,
+	mode: "json" as const,
+	builderTab: "form" as const,
+};
+const QUERY_EDIT_SEARCH = {
+	tab: "sqlquery" as const,
+	mode: "json" as const,
+	builderTab: "form" as const,
+};
+
+function pickLabel(r: { id?: string; name?: string; title?: string }): string {
+	return r.title || r.name || r.id || "(unnamed)";
+}
+
+function useRecentViews() {
+	const client = useAidboxClient();
+	return useQuery<RecentItem[]>({
+		queryKey: ["analytics-recent-views"],
+		queryFn: async () => {
+			const r = await client.request<Bundle>({
+				method: "GET",
+				url: "/fhir/ViewDefinition",
+				params: [
+					["_count", "1000"],
+					["_sort", "-_lastUpdated"],
+				],
+			});
+			if (r.isErr()) return [];
+			return (r.value.resource.entry ?? []).flatMap((e) => {
+				const vd = e.resource as
+					| (ViewDefinition & {
+							description?: string;
+							url?: string;
+							meta?: { lastUpdated?: string };
+					  })
+					| undefined;
+				if (!vd?.id) return [];
+				return [
+					{
+						kind: "view",
+						id: vd.id,
+						url: vd.url,
+						resource: vd.resource,
+						label: pickLabel(vd),
+						description: vd.description,
+						lastUpdated: vd.meta?.lastUpdated,
+					} satisfies RecentItem,
+				];
+			});
+		},
+	});
+}
+
+function useRecentQueries() {
+	const client = useAidboxClient();
+	return useQuery<RecentItem[]>({
+		queryKey: ["analytics-recent-queries"],
+		queryFn: async () => {
+			const r = await client.request<Bundle>({
+				method: "GET",
+				url: "/fhir/Library",
+				params: [
+					["_count", "1000"],
+					["_sort", "-_lastUpdated"],
+					["type", SQL_QUERY_TYPE_TOKEN],
+				],
+			});
+			if (r.isErr()) return [];
+			return (r.value.resource.entry ?? []).flatMap((e) => {
+				const lib = e.resource as LibraryResource | undefined;
+				if (!lib?.id) return [];
+				const relatedArtifacts = (lib.relatedArtifact ?? []).flatMap((ra) =>
+					ra.resource ? [{ url: ra.resource, label: ra.label }] : [],
+				);
+				return [
+					{
+						kind: "query",
+						id: lib.id,
+						url: lib.url,
+						relatedArtifacts:
+							relatedArtifacts.length > 0 ? relatedArtifacts : undefined,
+						label: pickLabel(lib),
+						description: lib.description,
+						lastUpdated: lib.meta?.lastUpdated,
+					} satisfies RecentItem,
+				];
+			});
+		},
+	});
+}
+
+type LookupByUrl = (url: string) => RecentItem | undefined;
+
+function Badge({ text, accentClass }: { text: string; accentClass: string }) {
 	return (
-		<EmptyState
-			title="Analytics"
-			description="Select a view or query from the sidebar, or create a new one."
-		/>
+		<span
+			className={`shrink-0 text-[11px] leading-4 normal-case whitespace-nowrap ${accentClass}`}
+		>
+			#{text}
+		</span>
 	);
 }
 
+function ItemRow({
+	item,
+	lookup,
+	showKindLabel = true,
+}: {
+	item: RecentItem;
+	lookup: LookupByUrl;
+	showKindLabel?: boolean;
+}) {
+	const isView = item.kind === "view";
+	const Icon = isView ? Table : FileCode2;
+	const kindLabel = isView ? "View" : "Query";
+	const accentClass = isView
+		? "text-text-info-primary"
+		: "text-text-warning-primary";
+	const badges: React.ReactNode[] = [];
+	if (isView && item.resource) {
+		badges.push(
+			<Badge
+				key="resource"
+				text={item.resource}
+				accentClass="text-text-success-primary"
+			/>,
+		);
+	}
+	if (!isView && item.relatedArtifacts) {
+		for (const ra of item.relatedArtifacts) {
+			const linked = lookup(ra.url);
+			const isLinkedView =
+				linked?.kind === "view" || ra.url.includes("/ViewDefinition/");
+			badges.push(
+				<Badge
+					key={ra.url}
+					text={linked?.label ?? ra.label ?? ra.url}
+					accentClass={
+						isLinkedView
+							? "text-text-info-primary"
+							: "text-text-warning-primary"
+					}
+				/>,
+			);
+		}
+	}
+	return (
+		<div className="flex flex-col pl-7 pr-4 py-3 min-w-0">
+			{showKindLabel && (
+				<div
+					className={`flex items-center gap-1.5 typo-label-tiny uppercase tracking-wide ${accentClass}`}
+				>
+					<Icon className="size-3.5 shrink-0" />
+					<span>{kindLabel}</span>
+				</div>
+			)}
+			<div
+				className={`typo-body text-text-primary truncate first-letter:uppercase ${showKindLabel ? "mt-0.5" : ""}`}
+			>
+				{highlight(item.label, item.labelMatches)}
+			</div>
+			{item.description && (
+				<div className="typo-body-xs text-text-secondary mt-0.5 line-clamp-1">
+					{highlight(item.description, item.descriptionMatches)}
+				</div>
+			)}
+			{badges.length > 0 && (
+				<div className="flex flex-wrap gap-x-2 gap-y-0.5 mt-2">{badges}</div>
+			)}
+		</div>
+	);
+}
+
+export type AnalyticsListKind = "view" | "query";
+
+const VIEW_CREATE_SEARCH = {
+	tab: "builder" as const,
+	mode: "json" as const,
+	builderTab: "form" as const,
+};
+const QUERY_CREATE_SEARCH = {
+	tab: "sqlquery" as const,
+	mode: "json" as const,
+	builderTab: "form" as const,
+};
+
+export function AnalyticsListPage({
+	kind,
+	searchQ,
+	setSearchQ,
+}: {
+	kind?: AnalyticsListKind;
+	searchQ: string;
+	setSearchQ: (next: string) => void;
+}) {
+	const views = useRecentViews();
+	const queries = useRecentQueries();
+	const client = useAidboxClient();
+	const queryClient = useQueryClient();
+	const navigate = useNavigate();
+	const deleteMutation = useMutation({
+		mutationFn: async (item: RecentItem) => {
+			const url =
+				item.kind === "view"
+					? `/fhir/ViewDefinition/${item.id}`
+					: `/fhir/Library/${item.id}`;
+			const r = await client.request({ method: "DELETE", url });
+			if (r.isErr()) throw new Error("Delete failed");
+			return r.value;
+		},
+		onSuccess: (_data, item) => {
+			queryClient.invalidateQueries({
+				queryKey: [
+					item.kind === "view"
+						? "analytics-recent-views"
+						: "analytics-recent-queries",
+				],
+			});
+			HSComp.toast.success(
+				`${item.kind === "view" ? "View" : "Query"} deleted`,
+			);
+		},
+		onError: () => {
+			HSComp.toast.error("Failed to delete");
+		},
+	});
+	const [openMenuKey, setOpenMenuKey] = React.useState<string | null>(null);
+	const [confirmingDelete, setConfirmingDelete] =
+		React.useState<RecentItem | null>(null);
+	const openLineage = (item: RecentItem) => {
+		if (item.kind === "view") {
+			navigate({
+				to: "/analytics/views/edit/$id",
+				params: { id: item.id },
+				search: { tab: "lineage", mode: "json", builderTab: "form" },
+			});
+		} else {
+			navigate({
+				to: "/analytics/queries/edit/$id",
+				params: { id: item.id },
+				search: { tab: "lineage", mode: "json", builderTab: "form" },
+			});
+		}
+	};
+	const didFocus = React.useRef(false);
+	const setSearchInputRef = React.useCallback((el: HTMLInputElement | null) => {
+		if (el && !didFocus.current) {
+			el.focus();
+			didFocus.current = true;
+		}
+	}, []);
+
+	const loading =
+		kind === "view"
+			? views.isLoading
+			: kind === "query"
+				? queries.isLoading
+				: views.isLoading || queries.isLoading;
+	const combined: RecentItem[] = [
+		...(views.data ?? []),
+		...(queries.data ?? []),
+	];
+	const allItems: RecentItem[] = (
+		kind === "view"
+			? (views.data ?? [])
+			: kind === "query"
+				? (queries.data ?? [])
+				: combined
+	)
+		.slice()
+		.sort((a, b) => {
+			const da = a.lastUpdated ? new Date(a.lastUpdated).getTime() : 0;
+			const db = b.lastUpdated ? new Date(b.lastUpdated).getTime() : 0;
+			return db - da;
+		});
+	const lookup: LookupByUrl = React.useMemo(() => {
+		const map = new Map<string, RecentItem>();
+		for (const it of [...(views.data ?? []), ...(queries.data ?? [])]) {
+			if (it.url) map.set(it.url, it);
+		}
+		return (url: string) => map.get(url);
+	}, [views.data, queries.data]);
+	const needle = searchQ.trim();
+	const fuse = React.useMemo(
+		() =>
+			new Fuse(allItems, {
+				keys: ["label", "description"],
+				includeMatches: true,
+				threshold: 0.3,
+				ignoreLocation: true,
+				minMatchCharLength: 1,
+			}),
+		[allItems],
+	);
+	const minHighlight = Math.min(Math.max(needle.length, 1), 3);
+	const items: RecentItem[] = needle
+		? fuse.search(needle).map((r) => {
+				const labelMatch = r.matches?.find((m) => m.key === "label");
+				const descriptionMatch = r.matches?.find(
+					(m) => m.key === "description",
+				);
+				const filterRanges = (
+					indices?: readonly MatchRange[],
+				): readonly MatchRange[] | undefined =>
+					indices?.filter(([s, e]) => e - s + 1 >= minHighlight);
+				return {
+					...r.item,
+					labelMatches: filterRanges(
+						labelMatch?.indices as readonly MatchRange[] | undefined,
+					),
+					descriptionMatches: filterRanges(
+						descriptionMatch?.indices as readonly MatchRange[] | undefined,
+					),
+				};
+			})
+		: allItems;
+
+	if (loading) {
+		return (
+			<div className="h-full overflow-y-auto p-6 space-y-2">
+				<HSComp.Skeleton className="h-14 w-full" />
+				<HSComp.Skeleton className="h-14 w-full" />
+				<HSComp.Skeleton className="h-14 w-full" />
+			</div>
+		);
+	}
+
+	if (allItems.length === 0 && !searchQ) {
+		const noun =
+			kind === "view" ? "view" : kind === "query" ? "query" : "view or query";
+		return (
+			<EmptyState
+				title="Analytics"
+				description={`Create your first ${noun} from the sidebar.`}
+			/>
+		);
+	}
+
+	const placeholder =
+		kind === "view"
+			? "Search views by name or description…"
+			: kind === "query"
+				? "Search queries by name or description…"
+				: "Search by name or description…";
+	const createView = () =>
+		navigate({ to: "/analytics/views/create", search: VIEW_CREATE_SEARCH });
+	const createQuery = () =>
+		navigate({ to: "/analytics/queries/create", search: QUERY_CREATE_SEARCH });
+
+	return (
+		<div className="h-full overflow-y-auto pb-[250px]">
+			<div className="sticky top-0 z-10 bg-bg-primary border-b border-border-default px-4 py-3">
+				<div className="flex items-center gap-2">
+					<div className="flex flex-1 items-center gap-2 h-9 px-3 rounded-lg border border-border-primary bg-bg-primary">
+						<Search className="size-4 text-text-tertiary shrink-0" />
+						<input
+							ref={setSearchInputRef}
+							value={searchQ}
+							onChange={(e) => setSearchQ(e.target.value)}
+							placeholder={placeholder}
+							className="flex-1 bg-transparent outline-none typo-body text-text-primary placeholder:text-text-tertiary"
+						/>
+					</div>
+					{kind === "view" ? (
+						<HSComp.Button variant="secondary" onClick={createView}>
+							<Plus className="size-4 text-text-info-primary" />
+							Create
+						</HSComp.Button>
+					) : kind === "query" ? (
+						<HSComp.Button variant="secondary" onClick={createQuery}>
+							<Plus className="size-4 text-text-info-primary" />
+							Create
+						</HSComp.Button>
+					) : (
+						<HSComp.DropdownMenu>
+							<HSComp.DropdownMenuTrigger asChild>
+								<HSComp.Button variant="secondary">
+									<Plus className="size-4 text-text-info-primary" />
+									Create
+								</HSComp.Button>
+							</HSComp.DropdownMenuTrigger>
+							<HSComp.DropdownMenuContent align="end">
+								<HSComp.DropdownMenuItem
+									className="justify-start! text-text-info-primary!"
+									onSelect={createView}
+								>
+									<Table className="size-4 text-text-info-primary" />
+									View
+								</HSComp.DropdownMenuItem>
+								<HSComp.DropdownMenuItem
+									className="justify-start! text-text-warning-primary!"
+									onSelect={createQuery}
+								>
+									<FileCode2 className="size-4 text-text-warning-primary" />
+									Query
+								</HSComp.DropdownMenuItem>
+							</HSComp.DropdownMenuContent>
+						</HSComp.DropdownMenu>
+					)}
+				</div>
+			</div>
+			{items.length === 0 ? (
+				<div className="px-4 py-6 typo-body-xs text-text-tertiary italic">
+					Nothing matches “{searchQ}”.
+				</div>
+			) : (
+				<ul className="divide-y divide-border-default bg-bg-primary">
+					{items.map((it) => {
+						const itemKey = `${it.kind}-${it.id}`;
+						const isMenuOpen = openMenuKey === itemKey;
+						return (
+							<li
+								key={itemKey}
+								className="relative group/row transition-colors hover:bg-bg-secondary"
+							>
+								{it.kind === "view" ? (
+									<Link
+										to="/analytics/views/edit/$id"
+										params={{ id: it.id }}
+										search={VIEW_EDIT_SEARCH}
+										className="block"
+									>
+										<ItemRow item={it} lookup={lookup} showKindLabel={!kind} />
+									</Link>
+								) : (
+									<Link
+										to="/analytics/queries/edit/$id"
+										params={{ id: it.id }}
+										search={QUERY_EDIT_SEARCH}
+										className="block"
+									>
+										<ItemRow item={it} lookup={lookup} showKindLabel={!kind} />
+									</Link>
+								)}
+								<div
+									className={`${isMenuOpen ? "block" : "hidden group-hover/row:block focus-within:block"} absolute top-2 right-2`}
+								>
+									<HSComp.DropdownMenu
+										open={isMenuOpen}
+										onOpenChange={(o) => setOpenMenuKey(o ? itemKey : null)}
+									>
+										<HSComp.DropdownMenuTrigger asChild>
+											<button
+												type="button"
+												aria-label="More actions"
+												className="size-7 flex items-center justify-center rounded hover:bg-bg-tertiary text-text-secondary"
+											>
+												<EllipsisVertical className="size-4" />
+											</button>
+										</HSComp.DropdownMenuTrigger>
+										<HSComp.DropdownMenuContent align="end">
+											<HSComp.DropdownMenuItem
+												className="justify-start!"
+												onSelect={() => openLineage(it)}
+											>
+												<GitBranch className="size-4" />
+												Lineage
+											</HSComp.DropdownMenuItem>
+											<HSComp.DropdownMenuItem
+												className="justify-start!"
+												variant="destructive"
+												onSelect={() => setConfirmingDelete(it)}
+											>
+												<Trash2 className="size-4" />
+												Delete
+											</HSComp.DropdownMenuItem>
+										</HSComp.DropdownMenuContent>
+									</HSComp.DropdownMenu>
+								</div>
+							</li>
+						);
+					})}
+				</ul>
+			)}
+			<HSComp.AlertDialog
+				open={!!confirmingDelete}
+				onOpenChange={(o) => {
+					if (!o) setConfirmingDelete(null);
+				}}
+			>
+				<HSComp.AlertDialogContent>
+					<HSComp.AlertDialogHeader>
+						<HSComp.AlertDialogTitle>
+							Delete {confirmingDelete?.kind === "view" ? "view" : "query"}
+						</HSComp.AlertDialogTitle>
+					</HSComp.AlertDialogHeader>
+					<HSComp.AlertDialogDescription>
+						Are you sure you want to delete{" "}
+						<span className="font-medium text-text-primary">
+							{confirmingDelete?.label}
+						</span>
+						? This action cannot be undone.
+					</HSComp.AlertDialogDescription>
+					<HSComp.AlertDialogFooter>
+						<HSComp.AlertDialogCancel>Cancel</HSComp.AlertDialogCancel>
+						<HSComp.AlertDialogAction
+							danger
+							onClick={() => {
+								if (confirmingDelete) deleteMutation.mutate(confirmingDelete);
+								setConfirmingDelete(null);
+							}}
+						>
+							Delete
+						</HSComp.AlertDialogAction>
+					</HSComp.AlertDialogFooter>
+				</HSComp.AlertDialogContent>
+			</HSComp.AlertDialog>
+		</div>
+	);
+}
+
+export const validateAnalyticsSearch = (search: {
+	q?: unknown;
+}): { q?: string } =>
+	typeof search.q === "string" && search.q.length > 0 ? { q: search.q } : {};
+
+function AnalyticsHomeRoute() {
+	const { q: searchQ = "" } = Route.useSearch();
+	const navigate = useNavigate({ from: "/analytics/" });
+	const setSearchQ = (next: string) =>
+		navigate({
+			search: (prev) => ({ ...prev, q: next || undefined }),
+			replace: true,
+		});
+	return <AnalyticsListPage searchQ={searchQ} setSearchQ={setSearchQ} />;
+}
+
 export const Route = createFileRoute("/analytics/")({
-	component: DataLineageIndex,
+	component: AnalyticsHomeRoute,
+	validateSearch: validateAnalyticsSearch,
 });

--- a/src/routes/analytics.queries.edit.$id.tsx
+++ b/src/routes/analytics.queries.edit.$id.tsx
@@ -22,7 +22,7 @@ const PageComponent = () => {
 			onDeleted={() =>
 				navigate({
 					to: "/analytics/queries",
-					search: { q: undefined, page: undefined, pageSize: undefined },
+					search: { q: undefined },
 				})
 			}
 		/>

--- a/src/routes/analytics.queries.index.tsx
+++ b/src/routes/analytics.queries.index.tsx
@@ -1,16 +1,21 @@
-import { createFileRoute } from "@tanstack/react-router";
-import { EmptyState } from "../components/empty-state";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { AnalyticsListPage, validateAnalyticsSearch } from "./analytics.index";
 
-function QueriesPlaceholder() {
+function QueriesRoute() {
+	const { q: searchQ = "" } = Route.useSearch();
+	const navigate = useNavigate({ from: "/analytics/queries/" });
+	const setSearchQ = (next: string) =>
+		navigate({
+			search: (prev) => ({ ...prev, q: next || undefined }),
+			replace: true,
+		});
 	return (
-		<EmptyState
-			title="Pick a query"
-			description="Select a query from the sidebar or create a new one."
-		/>
+		<AnalyticsListPage kind="query" searchQ={searchQ} setSearchQ={setSearchQ} />
 	);
 }
 
 export const Route = createFileRoute("/analytics/queries/")({
 	staticData: { title: "Queries" },
-	component: QueriesPlaceholder,
+	component: QueriesRoute,
+	validateSearch: validateAnalyticsSearch,
 });

--- a/src/routes/analytics.views.edit.$id.tsx
+++ b/src/routes/analytics.views.edit.$id.tsx
@@ -22,7 +22,7 @@ const PageComponent = () => {
 			onDeleted={() =>
 				navigate({
 					to: "/analytics/views",
-					search: { q: undefined, page: undefined, pageSize: undefined },
+					search: { q: undefined },
 				})
 			}
 		/>

--- a/src/routes/analytics.views.index.tsx
+++ b/src/routes/analytics.views.index.tsx
@@ -1,16 +1,21 @@
-import { createFileRoute } from "@tanstack/react-router";
-import { EmptyState } from "../components/empty-state";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { AnalyticsListPage, validateAnalyticsSearch } from "./analytics.index";
 
-function ViewsPlaceholder() {
+function ViewsRoute() {
+	const { q: searchQ = "" } = Route.useSearch();
+	const navigate = useNavigate({ from: "/analytics/views/" });
+	const setSearchQ = (next: string) =>
+		navigate({
+			search: (prev) => ({ ...prev, q: next || undefined }),
+			replace: true,
+		});
 	return (
-		<EmptyState
-			title="Pick a view"
-			description="Select a view from the sidebar or create a new one."
-		/>
+		<AnalyticsListPage kind="view" searchQ={searchQ} setSearchQ={setSearchQ} />
 	);
 }
 
 export const Route = createFileRoute("/analytics/views/")({
 	staticData: { title: "Views" },
-	component: ViewsPlaceholder,
+	component: ViewsRoute,
+	validateSearch: validateAnalyticsSearch,
 });


### PR DESCRIPTION
## Summary

- New unified Recents list on `/analytics`, `/analytics/views`, `/analytics/queries` with fuzzy search (URL-synced via `?q=…`), highlighted matches, kind label, description (line-clamp-1), and hashtag tags for resource type and related artifacts
- Sticky search input + Create button (dropdown on `/analytics`, direct on filtered routes); Delete action uses an AlertDialog confirm
- `ResourcePicker` (SQL Query Builder depends-on) reuses the same item layout, is sorted by `createdAt`, and has a wider popover
- DataLineage sidebar shows skeleton rows on subsequent loads using a count cached in `localStorage`
- Query accent color switched to `text-text-warning-primary` (Lineage nodes, detail panel, list, picker)
- Fix unsaved-changes blocker firing on resource delete: both ResourceEditor paths now dispatch an `aidbox-resource-deleted` event; `SQLQueryBuilder` latches its dirty flag off in response
- Edit routes drop unused `page`/`pageSize` search params

## Test plan

- [ ] `/analytics` opens with a mixed Recents list sorted by `meta.lastUpdated` (newest first)
- [ ] Fuzzy search filters and highlights matches; `?q=` updates and survives reload
- [ ] Create button shows a dropdown on `/analytics`, navigates directly on `/analytics/views` and `/analytics/queries`
- [ ] Three-dots menu opens `Lineage` and `Delete` (with confirm dialog)
- [ ] Deleting a resource does NOT trigger the "Unsaved changes" dialog
- [ ] Hashtag chips resolve to canonical titles after typing in search
- [ ] `ResourcePicker` in SQL Query Builder shows the same card layout, sorted by `createdAt`
- [ ] DataLineage sidebar shows skeleton rows on subsequent loads