### PR TITLE
Analytics & builder polish

### DIFF
--- a/src/components/DataLineage/page.tsx
+++ b/src/components/DataLineage/page.tsx
@@ -1,21 +1,9 @@
-import * as HSComp from "@health-samurai/react-components";
 import { Outlet } from "@tanstack/react-router";
-import { DataLineageSidebar } from "./sidebar";
 
 export function DataLineagePage() {
 	return (
-		<HSComp.ResizablePanelGroup
-			direction="horizontal"
-			autoSaveId="data-lineage-sidebar"
-			className="h-full"
-		>
-			<HSComp.ResizablePanel defaultSize={18} minSize={12} maxSize={40}>
-				<DataLineageSidebar />
-			</HSComp.ResizablePanel>
-			<HSComp.ResizableHandle />
-			<HSComp.ResizablePanel minSize={40}>
-				<Outlet />
-			</HSComp.ResizablePanel>
-		</HSComp.ResizablePanelGroup>
+		<div className="h-full">
+			<Outlet />
+		</div>
 	);
 }

--- a/src/components/ResourceBrowser/browser.tsx
+++ b/src/components/ResourceBrowser/browser.tsx
@@ -1,283 +1,527 @@
 import { useLocalStorage } from "@aidbox-ui/hooks/useLocalStorage";
 import * as HSComp from "@health-samurai/react-components";
 import { useQuery } from "@tanstack/react-query";
-import { useNavigate, useSearch } from "@tanstack/react-router";
-import { X } from "lucide-react";
-import React, { useMemo, useRef, useState } from "react";
+import { Link, useNavigate, useSearch } from "@tanstack/react-router";
+import {
+	ArrowDownAZ,
+	ArrowDownZA,
+	ArrowUpDown,
+	Pin,
+	Search,
+	X,
+} from "lucide-react";
+import React, { useMemo, useRef } from "react";
 import { type AidboxClientR5, useAidboxClient } from "../../AidboxClient";
 import { createFuzzySearch } from "../../utils/fuzzy-search";
+import { buildQuery, parseQuery, tagSlug } from "../../utils/tag-search";
 import { useWebMCPResourceBrowser } from "../../webmcp/resource-browser";
 import type { ResourceBrowserActions } from "../../webmcp/resource-browser-context";
 import { EmptyState } from "../empty-state";
 
-type ResourceRow = {
-	resourceType: string;
-	url: string;
+const CATEGORY_EXT_URL =
+	"http://hl7.org/fhir/StructureDefinition/structuredefinition-category";
+const STATUS_EXT_URL =
+	"http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status";
+
+const STATUS_VALUES = new Set([
+	"normative",
+	"trial-use",
+	"draft",
+	"informative",
+]);
+
+type SDExtension = {
+	url?: string;
+	valueString?: string;
+	valueCode?: string;
 };
 
-const skeletonRows = Array.from({ length: 30 }, (_, i) => (
-	// biome-ignore lint/suspicious/noArrayIndexKey: static skeleton rows
-	<HSComp.TableRow key={`skeleton-${i}`} zebra index={i}>
-		<HSComp.TableCell className="w-8" />
-		<HSComp.TableCell>
-			<HSComp.Skeleton
-				className="h-5"
-				style={{ width: `${100 + ((i * 47) % 120)}px` }}
-			/>
-		</HSComp.TableCell>
-		<HSComp.TableCell>
-			<HSComp.Skeleton
-				className="h-5"
-				style={{ width: `${200 + ((i * 73) % 300)}px` }}
-			/>
-		</HSComp.TableCell>
-	</HSComp.TableRow>
-));
+type SDItem = {
+	resourceType: string;
+	name: string;
+	url: string;
+	description?: string;
+	categoryTop?: string;
+	categorySub?: string;
+	standardsStatus?: string;
+};
 
-function ResourceList({
-	data,
-	favorites,
-	onToggleFavorite,
-	isLoading,
-	focusedIndex,
-	sort,
-	onSort,
-}: {
-	data: ResourceRow[];
-	favorites: Set<string>;
-	onToggleFavorite: (resourceType: string) => void;
-	isLoading: boolean;
-	focusedIndex: number;
-	sort: SortState;
-	onSort: (column: SortColumn) => void;
-}) {
-	const navigate = useNavigate();
-	const focusedRowRef = React.useRef<HTMLTableRowElement | null>(null);
-
-	// biome-ignore lint/correctness/useExhaustiveDependencies: focusedIndex triggers scroll
-	React.useEffect(() => {
-		focusedRowRef.current?.scrollIntoView({ block: "nearest" });
-	}, [focusedIndex]);
-
-	const goToResource = (resourceType: string) =>
-		navigate({
-			to: "/resource/$resourceType",
-			params: { resourceType },
-		});
-
-	return (
-		<HSComp.Table zebra className="typo-code">
-			<HSComp.TableHeader className="block shrink-0 overflow-y-scroll scrollbar-none [&_tr]:table [&_tr]:table-fixed [&_tr]:w-full">
-				<HSComp.TableRow>
-					<HSComp.TableHead className="w-8 px-1 text-text-secondary">
-						<span className="opacity-50 flex items-center justify-center">
-							<HSComp.PinIcon />
-						</span>
-					</HSComp.TableHead>
-					<HSComp.TableHead
-						className="w-72"
-						sortable
-						sorted={sort.column === "resourceType" && sort.direction}
-						onClick={() => onSort("resourceType")}
-					>
-						Resource type
-					</HSComp.TableHead>
-					<HSComp.TableHead
-						sortable
-						sorted={sort.column === "url" && sort.direction}
-						onClick={() => onSort("url")}
-					>
-						URL
-					</HSComp.TableHead>
-				</HSComp.TableRow>
-			</HSComp.TableHeader>
-			<HSComp.TableBody className="block grow min-h-0 overflow-y-auto pb-10 [&_tr]:table [&_tr]:table-fixed [&_tr]:w-full">
-				{isLoading
-					? skeletonRows
-					: data.length
-						? data.map((row, index) => {
-								const isFavorite = favorites.has(row.resourceType);
-								const isLastFavorite =
-									isFavorite &&
-									(index + 1 >= data.length ||
-										!favorites.has(data[index + 1]?.resourceType as string));
-								return (
-									<HSComp.TableRow
-										ref={index === focusedIndex ? focusedRowRef : undefined}
-										key={row.resourceType}
-										zebra
-										index={index}
-										className={HSComp.cn(
-											"cursor-pointer",
-											isLastFavorite && "border-b border-border-secondary",
-											index === focusedIndex && "bg-bg-hover",
-										)}
-										onClick={() => goToResource(row.resourceType)}
-									>
-										<HSComp.TableCell
-											className="w-8 px-1 align-middle text-center"
-											onClick={(e) => {
-												e.stopPropagation();
-												onToggleFavorite(row.resourceType);
-											}}
-										>
-											<span
-												className="pin-button flex items-center justify-center transition-opacity"
-												style={{
-													opacity: favorites.has(row.resourceType) ? 0.5 : 0,
-												}}
-											>
-												<HSComp.PinIcon />
-											</span>
-										</HSComp.TableCell>
-										<HSComp.TableCell className="w-72">
-											<a
-												href={`/u/resource/${row.resourceType}`}
-												onClick={(e) => {
-													e.preventDefault();
-												}}
-												className="text-text-link hover:underline"
-											>
-												{row.resourceType}
-											</a>
-										</HSComp.TableCell>
-										<HSComp.TableCell>{row.url}</HSComp.TableCell>
-									</HSComp.TableRow>
-								);
-							})
-						: null}
-			</HSComp.TableBody>
-		</HSComp.Table>
-	);
+function decodeAmp(s: string): string {
+	return s.replace(/&amp;/g, "&");
 }
 
-type StructureDefinitionEntry = {
-	resource: {
-		type?: string;
-		name?: string;
-		url?: string;
-	};
+function parseCategory(extensions: SDExtension[] | undefined): {
+	top?: string;
+	sub?: string;
+} {
+	const ext = extensions?.find((e) => e.url === CATEGORY_EXT_URL);
+	if (!ext?.valueString) return {};
+	const raw = decodeAmp(ext.valueString);
+	const dot = raw.indexOf(".");
+	if (dot === -1) return { top: raw };
+	return { top: raw.slice(0, dot), sub: raw.slice(dot + 1) };
+}
+
+function parseStandardsStatus(
+	extensions: SDExtension[] | undefined,
+): string | undefined {
+	const ext = extensions?.find((e) => e.url === STATUS_EXT_URL);
+	return ext?.valueCode;
+}
+
+function itemTagSlugs(item: SDItem): string[] {
+	const slugs: string[] = [tagSlug(item.resourceType)];
+	if (item.categoryTop) slugs.push(tagSlug(item.categoryTop));
+	if (item.categorySub) slugs.push(tagSlug(item.categorySub));
+	if (item.standardsStatus) slugs.push(tagSlug(item.standardsStatus));
+	return slugs;
+}
+
+function filterByTags(items: SDItem[], tagTokens: string[]): SDItem[] {
+	if (tagTokens.length === 0) return items;
+	return items.filter((item) => {
+		const slugs = itemTagSlugs(item);
+		return tagTokens.every((tag) => slugs.some((slug) => slug === tag));
+	});
+}
+
+function chipStyleFor(slug: string): string {
+	if (STATUS_VALUES.has(slug)) return "bg-yellow-50 text-text-warning-primary";
+	return "bg-blue-50 text-text-info-primary";
+}
+
+type StructureDefinitionResource = {
+	resourceType: "StructureDefinition";
+	type?: string;
+	name?: string;
+	url?: string;
+	description?: string;
+	extension?: SDExtension[];
 };
 
 type StructureDefinitionBundle = {
-	entry?: StructureDefinitionEntry[];
+	entry?: { resource: StructureDefinitionResource }[];
 };
 
-function useResourceData(client: AidboxClientR5) {
-	return useQuery<ResourceRow[]>({
-		queryKey: ["resource-browser-resources"],
+function useStructureDefinitions(client: AidboxClientR5) {
+	return useQuery<SDItem[]>({
+		queryKey: ["resource-browser-sd"],
 		staleTime: 5 * 60 * 1000,
 		queryFn: async () => {
 			const response = await client.rawRequest({
 				method: "GET",
-				url: "/fhir/StructureDefinition?kind=resource&derivation=specialization&_count=1000&_elements=type,name,url",
+				url: "/fhir/StructureDefinition?kind=resource&derivation=specialization&_count=1000&_elements=type,name,url,description,extension",
 			});
 			const bundle: StructureDefinitionBundle = await response.response.json();
-			return (bundle.entry ?? []).map((entry) => ({
-				resourceType: entry.resource.type ?? entry.resource.name ?? "",
-				url: entry.resource.url ?? "",
-			}));
+			return (bundle.entry ?? []).flatMap((entry) => {
+				const r = entry.resource;
+				const resourceType = r.type ?? r.name;
+				if (!resourceType) return [];
+				const cat = parseCategory(r.extension);
+				return [
+					{
+						resourceType,
+						name: r.name ?? resourceType,
+						url: r.url ?? "",
+						description: r.description,
+						categoryTop: cat.top,
+						categorySub: cat.sub,
+						standardsStatus: parseStandardsStatus(r.extension),
+					} satisfies SDItem,
+				];
+			});
 		},
 	});
 }
 
-type SortColumn = "resourceType" | "url";
+type SortColumn = "name" | "url";
 type SortDirection = "asc" | "desc";
 type SortState = { column: SortColumn; direction: SortDirection };
 
+function Badge({ text, onClick }: { text: string; onClick: () => void }) {
+	return (
+		<button
+			type="button"
+			onClick={(e) => {
+				e.preventDefault();
+				e.stopPropagation();
+				onClick();
+			}}
+			className="shrink-0 text-[11px] leading-4 normal-case whitespace-nowrap text-text-info-primary cursor-pointer hover:underline data-[status=true]:text-text-warning-primary"
+			data-status={STATUS_VALUES.has(tagSlug(text))}
+		>
+			#{text}
+		</button>
+	);
+}
+
+function ItemCard({
+	item,
+	isFavorite,
+	onTagClick,
+	onToggleFavorite,
+	focused,
+	rowRef,
+}: {
+	item: SDItem;
+	isFavorite: boolean;
+	onTagClick: (text: string) => void;
+	onToggleFavorite: () => void;
+	focused: boolean;
+	rowRef?: React.Ref<HTMLLIElement>;
+}) {
+	return (
+		<li
+			ref={rowRef}
+			className={`relative group/row transition-colors hover:bg-bg-secondary ${focused ? "bg-bg-secondary" : ""}`}
+		>
+			<Link
+				to="/resource/$resourceType"
+				params={{ resourceType: item.resourceType }}
+				className="block"
+			>
+				<div className="flex flex-col pl-3 pr-10 py-3 min-w-0">
+					<div className="typo-body text-text-primary truncate first-letter:uppercase">
+						{item.name}
+					</div>
+					{item.description && (
+						<div className="typo-body-xs text-text-secondary mt-0.5">
+							{item.description}
+						</div>
+					)}
+					{(item.categoryTop || item.standardsStatus) && (
+						<div className="flex flex-wrap gap-x-2 gap-y-0.5 mt-2">
+							{item.categoryTop && (
+								<Badge
+									text={item.categoryTop}
+									onClick={() => onTagClick(item.categoryTop ?? "")}
+								/>
+							)}
+							{item.categorySub && (
+								<Badge
+									text={item.categorySub}
+									onClick={() => onTagClick(item.categorySub ?? "")}
+								/>
+							)}
+							{item.standardsStatus && (
+								<Badge
+									text={item.standardsStatus}
+									onClick={() => onTagClick(item.standardsStatus ?? "")}
+								/>
+							)}
+						</div>
+					)}
+				</div>
+			</Link>
+			<button
+				type="button"
+				aria-label={isFavorite ? "Unpin" : "Pin"}
+				onClick={(e) => {
+					e.preventDefault();
+					e.stopPropagation();
+					onToggleFavorite();
+				}}
+				className={`absolute top-2 right-2 size-7 flex items-center justify-center rounded hover:bg-bg-tertiary transition-opacity ${isFavorite ? "opacity-100 text-text-info-primary" : "opacity-0 group-hover/row:opacity-100 text-text-secondary"}`}
+			>
+				<Pin className="size-4" />
+			</button>
+		</li>
+	);
+}
+
+function SearchBar({
+	chips,
+	textPart,
+	inputRef,
+	onTextChange,
+	onRemoveChip,
+	onClear,
+	onInputKeyDown,
+}: {
+	chips: string[];
+	textPart: string;
+	inputRef: (el: HTMLInputElement | null) => void;
+	onTextChange: (next: string) => void;
+	onRemoveChip: (slug: string) => void;
+	onClear: () => void;
+	onInputKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+}) {
+	return (
+		<div className="flex flex-1 items-center gap-2 min-h-9 px-3 py-1 rounded-lg border border-border-primary bg-bg-primary flex-wrap">
+			<Search className="size-4 text-text-tertiary shrink-0" />
+			{chips.map((chip) => (
+				<span
+					key={chip}
+					className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[11px] leading-4 whitespace-nowrap ${chipStyleFor(chip)}`}
+				>
+					#{chip}
+					<button
+						type="button"
+						aria-label={`Remove tag ${chip}`}
+						onClick={() => onRemoveChip(chip)}
+						className="flex items-center justify-center rounded opacity-70 hover:opacity-100"
+					>
+						<X className="size-3" />
+					</button>
+				</span>
+			))}
+			<input
+				ref={inputRef}
+				value={textPart}
+				onChange={(e) => onTextChange(e.target.value)}
+				onKeyDown={(e) => {
+					const last = chips[chips.length - 1];
+					if (e.key === "Backspace" && textPart === "" && last) {
+						e.preventDefault();
+						onRemoveChip(last);
+						return;
+					}
+					onInputKeyDown?.(e);
+				}}
+				placeholder={
+					chips.length === 0 ? "Search resources by name or description…" : ""
+				}
+				className="flex-1 min-w-[80px] bg-transparent outline-none typo-body text-text-primary placeholder:text-text-tertiary"
+			/>
+			{(chips.length > 0 || textPart.length > 0) && (
+				<HSComp.IconButton
+					variant="link"
+					aria-label="Clear"
+					onClick={onClear}
+					icon={<X />}
+				/>
+			)}
+		</div>
+	);
+}
+
+function SortDropdown({
+	sort,
+	onChange,
+}: {
+	sort: SortState;
+	onChange: (s: SortState) => void;
+}) {
+	const label =
+		sort.column === "name"
+			? sort.direction === "asc"
+				? "Name A→Z"
+				: "Name Z→A"
+			: sort.direction === "asc"
+				? "URL A→Z"
+				: "URL Z→A";
+	const Icon = sort.direction === "asc" ? ArrowDownAZ : ArrowDownZA;
+	return (
+		<HSComp.DropdownMenu>
+			<HSComp.DropdownMenuTrigger asChild>
+				<HSComp.Button variant="secondary">
+					<Icon className="size-4" />
+					{label}
+				</HSComp.Button>
+			</HSComp.DropdownMenuTrigger>
+			<HSComp.DropdownMenuContent align="end">
+				<HSComp.DropdownMenuItem
+					className="justify-start!"
+					onSelect={() => onChange({ column: "name", direction: "asc" })}
+				>
+					<ArrowDownAZ className="size-4" />
+					Name A→Z
+				</HSComp.DropdownMenuItem>
+				<HSComp.DropdownMenuItem
+					className="justify-start!"
+					onSelect={() => onChange({ column: "name", direction: "desc" })}
+				>
+					<ArrowDownZA className="size-4" />
+					Name Z→A
+				</HSComp.DropdownMenuItem>
+				<HSComp.DropdownMenuItem
+					className="justify-start!"
+					onSelect={() => onChange({ column: "url", direction: "asc" })}
+				>
+					<ArrowUpDown className="size-4" />
+					URL A→Z
+				</HSComp.DropdownMenuItem>
+				<HSComp.DropdownMenuItem
+					className="justify-start!"
+					onSelect={() => onChange({ column: "url", direction: "desc" })}
+				>
+					<ArrowUpDown className="size-4" />
+					URL Z→A
+				</HSComp.DropdownMenuItem>
+			</HSComp.DropdownMenuContent>
+		</HSComp.DropdownMenu>
+	);
+}
+
+function sortItems(items: SDItem[], sort: SortState): SDItem[] {
+	const sorted = [...items];
+	sorted.sort((a, b) => {
+		const av = sort.column === "name" ? a.name : a.url;
+		const bv = sort.column === "name" ? b.name : b.url;
+		const cmp = av.localeCompare(bv);
+		return sort.direction === "asc" ? cmp : -cmp;
+	});
+	return sorted;
+}
+
+function applyFavorites(
+	items: SDItem[],
+	favorites: Set<string>,
+	hasQuery: boolean,
+): SDItem[] {
+	if (hasQuery) return items;
+	return [...items].sort((a, b) => {
+		const af = favorites.has(a.resourceType);
+		const bf = favorites.has(b.resourceType);
+		if (af === bf) return 0;
+		return af ? -1 : 1;
+	});
+}
+
 export function Browser() {
 	const client = useAidboxClient();
-
 	const { q } = useSearch({ from: "/resource/" });
-	const filterQuery = q ?? "";
-
-	const [favoritesArray, setFavoritesArray] = useLocalStorage<string[]>({
-		key: "resource-browser-favorites",
-		defaultValue: [],
-	});
-
-	const favorites = useMemo(() => new Set(favoritesArray), [favoritesArray]);
-
-	const actionsRef = useRef<ResourceBrowserActions>(null);
-	useWebMCPResourceBrowser(actionsRef);
-
-	const [sort, setSort] = useState<SortState>({
-		column: "resourceType",
-		direction: "asc",
-	});
-
-	const handleSort = (column: SortColumn) => {
-		setSort((prev) =>
-			prev.column === column
-				? { column, direction: prev.direction === "asc" ? "desc" : "asc" }
-				: { column, direction: "asc" },
-		);
-	};
-
-	const { data, isLoading } = useResourceData(client);
-
-	const fuzzySearch = useMemo(
-		() =>
-			data
-				? createFuzzySearch(data, {
-						keys: [
-							{ name: "resourceType", weight: 2 },
-							{ name: "url", weight: 1 },
-						],
-						minMatchCharLength: 1,
-						threshold: 0.3,
-					})
-				: () => [],
-		[data],
-	);
-
-	const filteredData = useMemo(() => {
-		const results = fuzzySearch(filterQuery);
-		return [...results].sort((a, b) => {
-			const aFav = favorites.has(a.resourceType);
-			const bFav = favorites.has(b.resourceType);
-			if (aFav !== bFav) return aFav ? -1 : 1;
-			if (filterQuery) return 0;
-			const cmp = a[sort.column].localeCompare(b[sort.column]);
-			return sort.direction === "asc" ? cmp : -cmp;
-		});
-	}, [fuzzySearch, filterQuery, favorites, sort]);
-
-	const [focusedIndex, setFocusedIndex] = useState(-1);
 	const navigate = useNavigate();
 
-	const setFilterQuery = (value: string) => {
+	const searchQ = q ?? "";
+	const { chips, text: textPart } = parseQuery(searchQ);
+	const tagTokens = chips.map((c) => c.toLowerCase());
+
+	const setSearchQ = (value: string) => {
 		navigate({
 			from: "/resource/",
 			search: (prev) => ({ ...prev, q: value || undefined }),
 		});
 	};
 
+	const [favoritesArray, setFavoritesArray] = useLocalStorage<string[]>({
+		key: "resource-browser-favorites",
+		defaultValue: [],
+	});
+	const favorites = useMemo(() => new Set(favoritesArray), [favoritesArray]);
+
+	const [sort, setSort] = React.useState<SortState>({
+		column: "name",
+		direction: "asc",
+	});
+
+	const { data, isLoading } = useStructureDefinitions(client);
+	const allItems = data ?? [];
+
+	const tagFiltered = filterByTags(allItems, tagTokens);
+
+	const fuzzy = useMemo(
+		() =>
+			createFuzzySearch(tagFiltered, {
+				keys: [
+					{ name: "name", weight: 2 },
+					{ name: "description", weight: 1 },
+				],
+				minMatchCharLength: 1,
+				threshold: 0.3,
+			}),
+		[tagFiltered],
+	);
+
+	const textFiltered = textPart ? fuzzy(textPart) : tagFiltered;
+	const sorted = sortItems(textFiltered, sort);
+	const items = applyFavorites(sorted, favorites, Boolean(searchQ));
+
+	const handleTagClick = (tagText: string) => {
+		const slug = tagSlug(tagText);
+		if (chips.includes(slug)) return;
+		setSearchQ(buildQuery([...chips, slug], textPart));
+	};
+	const removeChip = (slug: string) => {
+		setSearchQ(
+			buildQuery(
+				chips.filter((c) => c !== slug),
+				textPart,
+			),
+		);
+	};
+	const updateTextPart = (next: string) => {
+		setSearchQ(buildQuery(chips, next));
+	};
+
+	const toggleFavorite = (resourceType: string) => {
+		setFavoritesArray((prev) =>
+			prev.includes(resourceType)
+				? prev.filter((x) => x !== resourceType)
+				: [...prev, resourceType],
+		);
+	};
+
+	const [focusedIndex, setFocusedIndex] = React.useState(-1);
+	const focusedRowRef = useRef<HTMLLIElement | null>(null);
+	const didFocus = useRef(false);
+	const setSearchInputRef = React.useCallback((el: HTMLInputElement | null) => {
+		if (el && !didFocus.current) {
+			el.focus();
+			didFocus.current = true;
+		}
+	}, []);
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: focusedIndex triggers scroll
+	React.useEffect(() => {
+		focusedRowRef.current?.scrollIntoView({ block: "nearest" });
+	}, [focusedIndex]);
+
+	React.useEffect(() => {
+		setFocusedIndex(-1);
+	}, []);
+
+	const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+		if (e.key === "ArrowDown" || (e.key === "Tab" && !e.shiftKey)) {
+			e.preventDefault();
+			setFocusedIndex((p) => Math.min(p + 1, items.length - 1));
+		} else if (e.key === "ArrowUp" || (e.key === "Tab" && e.shiftKey)) {
+			e.preventDefault();
+			setFocusedIndex((p) => Math.max(p - 1, -1));
+		} else if (
+			e.key === "Enter" &&
+			focusedIndex >= 0 &&
+			focusedIndex < items.length
+		) {
+			const it = items[focusedIndex];
+			if (!it) return;
+			e.preventDefault();
+			navigate({
+				to: "/resource/$resourceType",
+				params: { resourceType: it.resourceType },
+			});
+		}
+	};
+
+	const actionsRef = useRef<ResourceBrowserActions>(null);
+	useWebMCPResourceBrowser(actionsRef);
 	actionsRef.current = {
 		listResourceTypes: (filter) => {
-			if (filter !== undefined) {
-				setFilterQuery(filter);
-			}
-			const effectiveQuery = filter ?? filterQuery;
-			const results = fuzzySearch(effectiveQuery);
-			const sorted = [...results].sort((a, b) => {
-				const aFav = favorites.has(a.resourceType);
-				const bFav = favorites.has(b.resourceType);
-				if (aFav !== bFav) return aFav ? -1 : 1;
-				if (effectiveQuery) return 0;
-				const cmp = a[sort.column].localeCompare(b[sort.column]);
-				return sort.direction === "asc" ? cmp : -cmp;
-			});
-			return sorted.map((row) => ({
+			if (filter !== undefined) setSearchQ(filter);
+			const q2 = filter ?? searchQ;
+			const parsed = parseQuery(q2);
+			const tags = parsed.chips.map((c) => c.toLowerCase());
+			const filtered = filterByTags(allItems, tags);
+			const t = parsed.text
+				? createFuzzySearch(filtered, {
+						keys: [
+							{ name: "name", weight: 2 },
+							{ name: "description", weight: 1 },
+						],
+						minMatchCharLength: 1,
+						threshold: 0.3,
+					})(parsed.text)
+				: filtered;
+			const sortedRes = sortItems(t, sort);
+			const finalList = applyFavorites(sortedRes, favorites, Boolean(q2));
+			return finalList.map((row) => ({
 				resourceType: row.resourceType,
 				url: row.url,
 				isFavorite: favorites.has(row.resourceType),
 			}));
 		},
 		getFavorites: () => favoritesArray,
-		toggleFavorite: (resourceType) => {
-			toggleFavorite(resourceType);
-		},
+		toggleFavorite,
 		navigateToResourceType: (resourceType) => {
 			navigate({
 				to: "/resource/$resourceType",
@@ -286,89 +530,44 @@ export function Browser() {
 		},
 	};
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: reset focus on filter change
-	React.useEffect(() => {
-		setFocusedIndex(-1);
-	}, [filterQuery]);
-
-	const toggleFavorite = useMemo(
-		() => (resourceType: string) => {
-			setFavoritesArray((prev) => {
-				if (prev.includes(resourceType)) {
-					return prev.filter((item) => item !== resourceType);
-				}
-				return [...prev, resourceType];
-			});
-		},
-		[setFavoritesArray],
-	);
-
-	const handleSearchKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-		if (e.key === "ArrowDown" || (e.key === "Tab" && !e.shiftKey)) {
-			e.preventDefault();
-			setFocusedIndex((prev) => Math.min(prev + 1, filteredData.length - 1));
-		} else if (e.key === "ArrowUp" || (e.key === "Tab" && e.shiftKey)) {
-			e.preventDefault();
-			setFocusedIndex((prev) => Math.max(prev - 1, -1));
-		} else if (
-			e.key === "Enter" &&
-			focusedIndex >= 0 &&
-			focusedIndex < filteredData.length
-		) {
-			const item = filteredData[focusedIndex];
-			if (!item) return;
-			e.preventDefault();
-			navigate({
-				to: "/resource/$resourceType",
-				params: { resourceType: item.resourceType },
-			});
-		}
-	};
-
 	return (
-		<div className="overflow-hidden h-full flex flex-col">
-			<div className="flex gap-4 items-center px-4 py-3 border-b border-border-secondary">
-				<HSComp.Input
-					autoFocus
-					type="text"
-					className="flex-1 bg-bg-primary"
-					placeholder="Search resources"
-					value={filterQuery}
-					onChange={(e) => setFilterQuery(e.target.value)}
-					onKeyDown={handleSearchKeyDown}
-					rightSlot={
-						filterQuery && (
-							<HSComp.IconButton
-								icon={<X />}
-								aria-label="Clear"
-								variant="link"
-								onClick={() => setFilterQuery("")}
-							/>
-						)
-					}
-				/>
-				<HSComp.Button variant="primary" className="min-w-24">
-					Search
-				</HSComp.Button>
+		<div className="h-full overflow-y-auto pb-[250px]">
+			<div className="sticky top-0 z-10 bg-bg-primary py-4 shadow-[0_10px_10px_0_var(--color-bg-primary)]">
+				<div className="mx-auto max-w-[990px] px-8 flex items-center gap-2">
+					<SearchBar
+						chips={chips}
+						textPart={textPart}
+						inputRef={setSearchInputRef}
+						onTextChange={updateTextPart}
+						onRemoveChip={removeChip}
+						onClear={() => setSearchQ("")}
+						onInputKeyDown={handleKeyDown}
+					/>
+					<SortDropdown sort={sort} onChange={setSort} />
+				</div>
 			</div>
-			<div className="grow min-h-0 overflow-hidden [&_[data-slot=table-container]]:overflow-visible [&_[data-slot=table-container]]:h-full [&_table]:flex [&_table]:flex-col [&_table]:h-full">
-				{!isLoading && filteredData.length === 0 ? (
+			{!isLoading && items.length === 0 ? (
+				<div className="mx-auto max-w-[990px] px-8">
 					<EmptyState
 						title="No resource types found"
 						description="Try a different search query"
 					/>
-				) : (
-					<ResourceList
-						data={filteredData}
-						favorites={favorites}
-						onToggleFavorite={toggleFavorite}
-						isLoading={isLoading}
-						focusedIndex={focusedIndex}
-						sort={sort}
-						onSort={handleSort}
-					/>
-				)}
-			</div>
+				</div>
+			) : (
+				<ul className="mx-auto max-w-[990px] px-8 bg-bg-primary divide-y divide-border-default">
+					{items.map((it, index) => (
+						<ItemCard
+							key={it.resourceType}
+							item={it}
+							isFavorite={favorites.has(it.resourceType)}
+							onTagClick={handleTagClick}
+							onToggleFavorite={() => toggleFavorite(it.resourceType)}
+							focused={index === focusedIndex}
+							rowRef={index === focusedIndex ? focusedRowRef : undefined}
+						/>
+					))}
+				</ul>
+			)}
 		</div>
 	);
 }

--- a/src/components/SQLQueryBuilder/builder-content.tsx
+++ b/src/components/SQLQueryBuilder/builder-content.tsx
@@ -5,6 +5,7 @@ import * as React from "react";
 import { useAidboxClient } from "../../AidboxClient";
 import * as Utils from "../../api/utils";
 import { useLocalStorage } from "../../hooks";
+import { addUrlToHistory } from "../../utils/url-history";
 import { useSQLQueryContext } from "./context";
 import { EditorHeaderMenu } from "./header-menu";
 import { PropertiesTree } from "./properties-tree";
@@ -12,7 +13,8 @@ import { useResolvedParameterTree } from "./resolve-tree";
 import { ResultPanel } from "./result-panel";
 import { buildRunPayload, ensureSQLQueryShape } from "./run-payload";
 import type { SQLLibrary } from "./types";
-import { addUrlToHistory } from "./url-history";
+
+const URL_HISTORY_KEY = "sqlquery-library-url-history";
 
 function toOperationOutcome(err: unknown): HSComp.OperationOutcome {
 	if (
@@ -178,7 +180,7 @@ export function SQLQueryBuilderContent() {
 		},
 		onSuccess: ({ resource, created }) => {
 			setIsDirty(false);
-			addUrlToHistory(library.url);
+			addUrlToHistory(URL_HISTORY_KEY, library.url);
 			HSComp.toast.success("SQLQuery saved successfully", {
 				position: "bottom-right",
 				style: { margin: "1rem" },

--- a/src/components/SQLQueryBuilder/properties-tree.tsx
+++ b/src/components/SQLQueryBuilder/properties-tree.tsx
@@ -7,6 +7,7 @@ import {
 import { AlignLeft, Play, Plus, X } from "lucide-react";
 import * as React from "react";
 import { format as formatSQL } from "sql-formatter";
+import { readUrlHistory } from "../../utils/url-history";
 import { useSQLQueryContext } from "./context";
 import {
 	type ResolvedParameter,
@@ -20,7 +21,8 @@ import {
 	type SQLDependsOn,
 	type SQLParameter,
 } from "./types";
-import { addUrlToHistory, readUrlHistory } from "./url-history";
+
+const URL_HISTORY_KEY = "sqlquery-library-url-history";
 
 type ItemMeta = {
 	type:
@@ -149,8 +151,9 @@ function labelView(item: ItemInstance<TreeViewItem<ItemMeta>>) {
 		? "text-text-info-primary px-1!"
 		: "text-text-info-primary bg-bg-info-primary";
 
-	const onLabelClickFn = () => {
+	const onLabelClickFn = (e: React.MouseEvent) => {
 		if (!isFolder) return;
+		e.stopPropagation();
 		if (item.isExpanded()) item.collapse();
 		else item.expand();
 	};
@@ -336,10 +339,6 @@ export function PropertiesTree() {
 	const { library, updateLibrary, paramValues, setParamValue, missingParams } =
 		useSQLQueryContext();
 	const treeContainerRef = React.useRef<HTMLDivElement>(null);
-
-	React.useEffect(() => {
-		addUrlToHistory(library.url);
-	}, [library.url]);
 
 	React.useEffect(() => {
 		const el = treeContainerRef.current;
@@ -851,7 +850,7 @@ export function PropertiesTree() {
 		}
 	};
 
-	const urlHistory = readUrlHistory();
+	const urlHistory = readUrlHistory(URL_HISTORY_KEY);
 
 	return (
 		<div ref={treeContainerRef}>

--- a/src/components/ViewDefinition/editor-form-tab-content.tsx
+++ b/src/components/ViewDefinition/editor-form-tab-content.tsx
@@ -44,6 +44,7 @@ import {
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useDebounce, useLocalStorage } from "../../hooks";
 import { generateId } from "../../utils";
+import { readUrlHistory } from "../../utils/url-history";
 import type {
 	FormTreeSelectItem,
 	ViewDefinitionBuilderActions,
@@ -55,6 +56,8 @@ import {
 	ViewDefinitionResourceTypeContext,
 } from "./page";
 import { ResourceTypeSelect } from "./resource-type-select";
+
+const URL_HISTORY_KEY = "viewdefinition-url-history";
 
 // --- De-identification extension support ---
 
@@ -630,11 +633,17 @@ const InputView = ({
 	className,
 	value,
 	onChange,
+	name,
+	autoComplete,
+	list,
 }: {
 	placeholder: string;
 	className?: string;
 	value?: string;
 	onChange?: (value: string) => void;
+	name?: string;
+	autoComplete?: string;
+	list?: string;
 }) => {
 	const [localValue, setLocalValue] = useState(value || "");
 
@@ -675,6 +684,9 @@ const InputView = ({
 			`}
 			placeholder={placeholder}
 			value={localValue}
+			name={name}
+			autoComplete={autoComplete}
+			list={list}
 			onChange={(e) => handleChange(e.target.value)}
 			onClick={(e) => e.stopPropagation()}
 			onMouseDown={handleMouseDown}
@@ -976,6 +988,8 @@ export const FormTabContent = ({
 		key: `viewDefinition-form-collapsed-${viewDefinition?.id || "default"}`,
 		defaultValue: [],
 	});
+
+	const urlHistory = readUrlHistory(URL_HISTORY_KEY);
 
 	const paramPrefix = /^Parameters\.parameter\[\d+\]\.resource\./;
 
@@ -1884,7 +1898,8 @@ export const FormTabContent = ({
 		const isAlwaysExpanded =
 			metaType === "constant" || metaType === "where" || metaType === "select";
 
-		const onLabelClickFn = () => {
+		const onLabelClickFn = (e: React.MouseEvent) => {
+			e.stopPropagation();
 			if (isAlwaysExpanded) return;
 			if (item.isExpanded()) {
 				item.collapse();
@@ -1955,6 +1970,9 @@ export const FormTabContent = ({
 								placeholder="Canonical URL of the ViewDefinition"
 								value={viewDefinition?.url || ""}
 								onChange={(value) => updateUrl(value)}
+								name="viewdefinition-url"
+								autoComplete="on"
+								list={URL_HISTORY_KEY}
 							/>
 						</div>
 					</div>
@@ -2500,6 +2518,11 @@ export const FormTabContent = ({
 
 	return (
 		<FhirPathLspProvider>
+			<datalist id={URL_HISTORY_KEY}>
+				{urlHistory.map((u) => (
+					<option key={u} value={u} />
+				))}
+			</datalist>
 			<TreeView
 				itemLabelClassFn={(item: ItemInstance<TreeViewItem<ItemMeta>>) => {
 					const metaType = item.getItemData()?.meta?.type;

--- a/src/components/ViewDefinition/editor-panel-content.tsx
+++ b/src/components/ViewDefinition/editor-panel-content.tsx
@@ -23,6 +23,7 @@ import React from "react";
 import { type AidboxClientR5, useAidboxClient } from "../../AidboxClient";
 import * as Utils from "../../api/utils";
 import { useLocalStorage } from "../../hooks";
+import { addUrlToHistory } from "../../utils/url-history";
 import { useWebMCPViewDefinition } from "../../webmcp/view-definition";
 import type { ViewDefinitionBuilderActions } from "../../webmcp/view-definition-context";
 import { FormTabContent } from "./editor-form-tab-content";
@@ -33,6 +34,8 @@ import {
 } from "./page";
 import { ResultPanel } from "./result-panel-content";
 import type * as Types from "./types";
+
+const URL_HISTORY_KEY = "viewdefinition-url-history";
 
 const cleanEmptyValues = <T,>(obj: T): T => {
 	if (Array.isArray(obj)) {
@@ -306,6 +309,7 @@ export const useViewDefinitionActions = (
 			viewDefinitionContext.setRunError(undefined);
 			viewDefinitionContext.setIsDirty(false);
 			invalidateSidebar();
+			addUrlToHistory(URL_HISTORY_KEY, viewDefinitionResource?.url);
 			HSComp.toast.success("ViewDefinition saved successfully", {
 				position: "bottom-right",
 				style: { margin: "1rem" },
@@ -332,6 +336,7 @@ export const useViewDefinitionActions = (
 			viewDefinitionContext.setRunError(undefined);
 			viewDefinitionContext.setIsDirty(false);
 			invalidateSidebar();
+			addUrlToHistory(URL_HISTORY_KEY, result.value.resource.url);
 			const id = result.value.resource.id;
 			if (!id)
 				return Utils.toastError(

--- a/src/components/empty-state.tsx
+++ b/src/components/empty-state.tsx
@@ -4,10 +4,12 @@ export const EmptyState = ({
 	title,
 	description,
 	grayscale,
+	action,
 }: {
 	title: ReactNode;
 	description?: ReactNode;
 	grayscale?: boolean;
+	action?: ReactNode;
 }) => {
 	return (
 		<div className="flex items-center justify-center h-full overflow-auto min-h-0">
@@ -23,6 +25,7 @@ export const EmptyState = ({
 						<span className="text-text-secondary">{description}</span>
 					)}
 				</div>
+				{action}
 			</div>
 		</div>
 	);

--- a/src/layout/sidebar.tsx
+++ b/src/layout/sidebar.tsx
@@ -11,10 +11,10 @@ import {
 } from "@health-samurai/react-components";
 import { Link, useRouterState } from "@tanstack/react-router";
 import {
+	ChartNoAxesCombined,
 	ClipboardList,
 	Columns3Cog,
 	Database,
-	FileChartPie,
 	Package,
 	PanelLeftClose,
 	PanelLeftOpen,
@@ -71,7 +71,7 @@ const mainMenuItems: {
 		title: "Analytics",
 		link: (
 			<Link to="/analytics">
-				<FileChartPie />
+				<ChartNoAxesCombined />
 				Analytics
 			</Link>
 		),

--- a/src/routes/analytics.index.tsx
+++ b/src/routes/analytics.index.tsx
@@ -12,6 +12,7 @@ import {
 	Search,
 	Table,
 	Trash2,
+	X,
 } from "lucide-react";
 import * as React from "react";
 import { useAidboxClient } from "../AidboxClient";
@@ -168,24 +169,107 @@ function useRecentQueries() {
 
 type LookupByUrl = (url: string) => RecentItem | undefined;
 
-function Badge({ text, accentClass }: { text: string; accentClass: string }) {
-	return (
-		<span
-			className={`shrink-0 text-[11px] leading-4 normal-case whitespace-nowrap ${accentClass}`}
-		>
-			#{text}
-		</span>
-	);
+function tagSlug(text: string): string {
+	return text.toLowerCase().replace(/\s+/g, "-");
+}
+
+function parseQuery(q: string): { chips: string[]; text: string } {
+	const tokens = q.split(/\s+/).filter(Boolean);
+	const chips: string[] = [];
+	const textTokens: string[] = [];
+	for (const t of tokens) {
+		if (t.startsWith("#") && t.length > 1) chips.push(t.slice(1));
+		else textTokens.push(t);
+	}
+	return { chips, text: textTokens.join(" ") };
+}
+
+function buildQuery(chips: string[], text: string): string {
+	const chipStr = chips.map((c) => `#${c}`).join(" ");
+	const trimmedText = text.trim();
+	if (chipStr && trimmedText) return `${chipStr} ${trimmedText}`;
+	return chipStr || trimmedText;
+}
+
+function getItemTagSlugs(item: RecentItem, lookup: LookupByUrl): string[] {
+	const slugs: string[] = [tagSlug(item.label)];
+	if (item.resource) slugs.push(tagSlug(item.resource));
+	if (item.relatedArtifacts) {
+		for (const ra of item.relatedArtifacts) {
+			const linked = lookup(ra.url);
+			const text = linked?.label ?? ra.label ?? ra.url;
+			slugs.push(tagSlug(text));
+		}
+	}
+	return slugs;
+}
+
+function filterByTags(
+	items: RecentItem[],
+	tagTokens: string[],
+	lookup: LookupByUrl,
+): RecentItem[] {
+	if (tagTokens.length === 0) return items;
+	return items.filter((item) => {
+		const slugs = getItemTagSlugs(item, lookup);
+		return tagTokens.every((tag) => slugs.some((slug) => slug === tag));
+	});
+}
+
+function chipStyleFor(slug: string, items: RecentItem[]): string {
+	for (const item of items) {
+		if (tagSlug(item.label) === slug) {
+			return item.kind === "view"
+				? "bg-blue-50 text-text-info-primary"
+				: "bg-yellow-50 text-text-warning-primary";
+		}
+	}
+	for (const item of items) {
+		if (item.resource && tagSlug(item.resource) === slug) {
+			return "bg-green-50 text-text-success-primary";
+		}
+	}
+	return "bg-bg-tertiary text-text-primary";
+}
+
+function Badge({
+	text,
+	accentClass,
+	onClick,
+}: {
+	text: string;
+	accentClass: string;
+	onClick?: () => void;
+}) {
+	const base = `shrink-0 text-[11px] leading-4 normal-case whitespace-nowrap ${accentClass}`;
+	if (onClick) {
+		return (
+			<button
+				type="button"
+				onClick={(e) => {
+					e.preventDefault();
+					e.stopPropagation();
+					onClick();
+				}}
+				className={`${base} cursor-pointer hover:underline`}
+			>
+				#{text}
+			</button>
+		);
+	}
+	return <span className={base}>#{text}</span>;
 }
 
 function ItemRow({
 	item,
 	lookup,
 	showKindLabel = true,
+	onTagClick,
 }: {
 	item: RecentItem;
 	lookup: LookupByUrl;
 	showKindLabel?: boolean;
+	onTagClick?: (text: string) => void;
 }) {
 	const isView = item.kind === "view";
 	const Icon = isView ? Table : FileCode2;
@@ -195,11 +279,13 @@ function ItemRow({
 		: "text-text-warning-primary";
 	const badges: React.ReactNode[] = [];
 	if (isView && item.resource) {
+		const resourceText = item.resource;
 		badges.push(
 			<Badge
 				key="resource"
-				text={item.resource}
+				text={resourceText}
 				accentClass="text-text-success-primary"
+				onClick={onTagClick ? () => onTagClick(resourceText) : undefined}
 			/>,
 		);
 	}
@@ -208,21 +294,23 @@ function ItemRow({
 			const linked = lookup(ra.url);
 			const isLinkedView =
 				linked?.kind === "view" || ra.url.includes("/ViewDefinition/");
+			const text = linked?.label ?? ra.label ?? ra.url;
 			badges.push(
 				<Badge
 					key={ra.url}
-					text={linked?.label ?? ra.label ?? ra.url}
+					text={text}
 					accentClass={
 						isLinkedView
 							? "text-text-info-primary"
 							: "text-text-warning-primary"
 					}
+					onClick={onTagClick ? () => onTagClick(text) : undefined}
 				/>,
 			);
 		}
 	}
 	return (
-		<div className="flex flex-col pl-7 pr-4 py-3 min-w-0">
+		<div className="flex flex-col pl-3 pr-4 py-3 min-w-0">
 			{showKindLabel && (
 				<div
 					className={`flex items-center gap-1.5 typo-label-tiny uppercase tracking-wide ${accentClass}`}
@@ -237,7 +325,7 @@ function ItemRow({
 				{highlight(item.label, item.labelMatches)}
 			</div>
 			{item.description && (
-				<div className="typo-body-xs text-text-secondary mt-0.5 line-clamp-1">
+				<div className="typo-body-xs text-text-secondary mt-0.5">
 					{highlight(item.description, item.descriptionMatches)}
 				</div>
 			)}
@@ -260,6 +348,70 @@ const QUERY_CREATE_SEARCH = {
 	mode: "json" as const,
 	builderTab: "form" as const,
 };
+
+function SearchBar({
+	chips,
+	textPart,
+	placeholder,
+	allItems,
+	inputRef,
+	onTextChange,
+	onRemoveChip,
+	onClear,
+}: {
+	chips: string[];
+	textPart: string;
+	placeholder: string;
+	allItems: RecentItem[];
+	inputRef: (el: HTMLInputElement | null) => void;
+	onTextChange: (next: string) => void;
+	onRemoveChip: (slug: string) => void;
+	onClear: () => void;
+}) {
+	return (
+		<div className="flex flex-1 items-center gap-2 min-h-9 px-3 py-1 rounded-lg border border-border-primary bg-bg-primary flex-wrap">
+			<Search className="size-4 text-text-tertiary shrink-0" />
+			{chips.map((chip) => (
+				<span
+					key={chip}
+					className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[11px] leading-4 whitespace-nowrap ${chipStyleFor(chip, allItems)}`}
+				>
+					#{chip}
+					<button
+						type="button"
+						aria-label={`Remove tag ${chip}`}
+						onClick={() => onRemoveChip(chip)}
+						className="flex items-center justify-center rounded opacity-70 hover:opacity-100"
+					>
+						<X className="size-3" />
+					</button>
+				</span>
+			))}
+			<input
+				ref={inputRef}
+				value={textPart}
+				onChange={(e) => onTextChange(e.target.value)}
+				onKeyDown={(e) => {
+					const last = chips[chips.length - 1];
+					if (e.key === "Backspace" && textPart === "" && last) {
+						e.preventDefault();
+						onRemoveChip(last);
+					}
+				}}
+				placeholder={chips.length === 0 ? placeholder : ""}
+				className="flex-1 min-w-[80px] bg-transparent outline-none typo-body text-text-primary placeholder:text-text-tertiary"
+			/>
+			{(chips.length > 0 || textPart.length > 0) && (
+				<HSComp.IconButton
+					variant="link"
+					aria-label="Clear"
+					onClick={onClear}
+					icon={<X />}
+				/>
+			)}
+		</div>
+	);
+}
 
 export function AnalyticsListPage({
 	kind,
@@ -357,18 +509,25 @@ export function AnalyticsListPage({
 		}
 		return (url: string) => map.get(url);
 	}, [views.data, queries.data]);
-	const needle = searchQ.trim();
+	const { chips, text: textPart } = parseQuery(searchQ);
+	const tagTokens = chips.map((c) => c.toLowerCase());
+	const textQuery = textPart;
+
+	const tagFiltered = filterByTags(allItems, tagTokens, lookup);
+
 	const fuse = React.useMemo(
 		() =>
-			new Fuse(allItems, {
+			new Fuse(tagFiltered, {
 				keys: ["label", "description"],
 				includeMatches: true,
 				threshold: 0.3,
 				ignoreLocation: true,
 				minMatchCharLength: 1,
 			}),
-		[allItems],
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[tagFiltered],
 	);
+	const needle = textQuery;
 	const minHighlight = Math.min(Math.max(needle.length, 1), 3);
 	const items: RecentItem[] = needle
 		? fuse.search(needle).map((r) => {
@@ -390,7 +549,7 @@ export function AnalyticsListPage({
 					),
 				};
 			})
-		: allItems;
+		: tagFiltered;
 
 	if (loading) {
 		return (
@@ -423,21 +582,37 @@ export function AnalyticsListPage({
 		navigate({ to: "/analytics/views/create", search: VIEW_CREATE_SEARCH });
 	const createQuery = () =>
 		navigate({ to: "/analytics/queries/create", search: QUERY_CREATE_SEARCH });
+	const handleTagClick = (tagText: string) => {
+		const slug = tagSlug(tagText);
+		if (chips.includes(slug)) return;
+		setSearchQ(buildQuery([...chips, slug], textPart));
+	};
+	const removeChip = (slug: string) => {
+		setSearchQ(
+			buildQuery(
+				chips.filter((c) => c !== slug),
+				textPart,
+			),
+		);
+	};
+	const updateTextPart = (next: string) => {
+		setSearchQ(buildQuery(chips, next));
+	};
 
 	return (
 		<div className="h-full overflow-y-auto pb-[250px]">
-			<div className="sticky top-0 z-10 bg-bg-primary border-b border-border-default px-4 py-3">
-				<div className="flex items-center gap-2">
-					<div className="flex flex-1 items-center gap-2 h-9 px-3 rounded-lg border border-border-primary bg-bg-primary">
-						<Search className="size-4 text-text-tertiary shrink-0" />
-						<input
-							ref={setSearchInputRef}
-							value={searchQ}
-							onChange={(e) => setSearchQ(e.target.value)}
-							placeholder={placeholder}
-							className="flex-1 bg-transparent outline-none typo-body text-text-primary placeholder:text-text-tertiary"
-						/>
-					</div>
+			<div className="sticky top-0 z-10 bg-bg-primary py-4 shadow-[0_10px_10px_0_var(--color-bg-primary)]">
+				<div className="mx-auto max-w-[990px] px-8 flex items-center gap-2">
+					<SearchBar
+						chips={chips}
+						textPart={textPart}
+						placeholder={placeholder}
+						allItems={allItems}
+						inputRef={setSearchInputRef}
+						onTextChange={updateTextPart}
+						onRemoveChip={removeChip}
+						onClear={() => setSearchQ("")}
+					/>
 					{kind === "view" ? (
 						<HSComp.Button variant="secondary" onClick={createView}>
 							<Plus className="size-4 text-text-info-primary" />
@@ -477,11 +652,11 @@ export function AnalyticsListPage({
 				</div>
 			</div>
 			{items.length === 0 ? (
-				<div className="px-4 py-6 typo-body-xs text-text-tertiary italic">
+				<div className="mx-auto max-w-[990px] px-8 py-6 typo-body-xs text-text-tertiary italic">
 					Nothing matches “{searchQ}”.
 				</div>
 			) : (
-				<ul className="divide-y divide-border-default bg-bg-primary">
+				<ul className="mx-auto max-w-[990px] px-8 bg-bg-primary divide-y divide-border-default">
 					{items.map((it) => {
 						const itemKey = `${it.kind}-${it.id}`;
 						const isMenuOpen = openMenuKey === itemKey;
@@ -497,7 +672,12 @@ export function AnalyticsListPage({
 										search={VIEW_EDIT_SEARCH}
 										className="block"
 									>
-										<ItemRow item={it} lookup={lookup} showKindLabel={!kind} />
+										<ItemRow
+											item={it}
+											lookup={lookup}
+											showKindLabel={!kind}
+											onTagClick={handleTagClick}
+										/>
 									</Link>
 								) : (
 									<Link
@@ -506,7 +686,12 @@ export function AnalyticsListPage({
 										search={QUERY_EDIT_SEARCH}
 										className="block"
 									>
-										<ItemRow item={it} lookup={lookup} showKindLabel={!kind} />
+										<ItemRow
+											item={it}
+											lookup={lookup}
+											showKindLabel={!kind}
+											onTagClick={handleTagClick}
+										/>
 									</Link>
 								)}
 								<div

--- a/src/routes/analytics.index.tsx
+++ b/src/routes/analytics.index.tsx
@@ -17,6 +17,7 @@ import {
 import * as React from "react";
 import { useAidboxClient } from "../AidboxClient";
 import { EmptyState } from "../components/empty-state";
+import { buildQuery, parseQuery, tagSlug } from "../utils/tag-search";
 
 type MatchRange = readonly [number, number];
 
@@ -168,28 +169,6 @@ function useRecentQueries() {
 }
 
 type LookupByUrl = (url: string) => RecentItem | undefined;
-
-function tagSlug(text: string): string {
-	return text.toLowerCase().replace(/\s+/g, "-");
-}
-
-function parseQuery(q: string): { chips: string[]; text: string } {
-	const tokens = q.split(/\s+/).filter(Boolean);
-	const chips: string[] = [];
-	const textTokens: string[] = [];
-	for (const t of tokens) {
-		if (t.startsWith("#") && t.length > 1) chips.push(t.slice(1));
-		else textTokens.push(t);
-	}
-	return { chips, text: textTokens.join(" ") };
-}
-
-function buildQuery(chips: string[], text: string): string {
-	const chipStr = chips.map((c) => `#${c}`).join(" ");
-	const trimmedText = text.trim();
-	if (chipStr && trimmedText) return `${chipStr} ${trimmedText}`;
-	return chipStr || trimmedText;
-}
 
 function getItemTagSlugs(item: RecentItem, lookup: LookupByUrl): string[] {
 	const slugs: string[] = [tagSlug(item.label)];

--- a/src/routes/analytics.index.tsx
+++ b/src/routes/analytics.index.tsx
@@ -17,7 +17,7 @@ import {
 import * as React from "react";
 import { useAidboxClient } from "../AidboxClient";
 import { EmptyState } from "../components/empty-state";
-import { buildQuery, parseQuery, tagSlug } from "../utils/tag-search";
+import { parseQuery, tagSlug } from "../utils/tag-search";
 
 type MatchRange = readonly [number, number];
 
@@ -30,7 +30,7 @@ function highlight(text: string, ranges: readonly MatchRange[] | undefined) {
 		if (start < cursor) return;
 		if (start > cursor) parts.push(text.slice(cursor, start));
 		parts.push(
-			<span key={`${start}-${end}`} className="text-text-link">
+			<span key={`${start}-${end}`} className="font-medium">
 				{text.slice(start, end + 1)}
 			</span>,
 		);
@@ -195,7 +195,8 @@ function filterByTags(
 	});
 }
 
-function chipStyleFor(slug: string, items: RecentItem[]): string {
+function chipStyleFor(tag: string, items: RecentItem[]): string {
+	const slug = tagSlug(tag);
 	for (const item of items) {
 		if (tagSlug(item.label) === slug) {
 			return item.kind === "view"
@@ -289,7 +290,7 @@ function ItemRow({
 		}
 	}
 	return (
-		<div className="flex flex-col pl-3 pr-4 py-3 min-w-0">
+		<div className="flex flex-col pl-3.5 pr-4 py-3 min-w-0">
 			{showKindLabel && (
 				<div
 					className={`flex items-center gap-1.5 typo-label-tiny uppercase tracking-wide ${accentClass}`}
@@ -344,27 +345,23 @@ function SearchBar({
 	allItems: RecentItem[];
 	inputRef: (el: HTMLInputElement | null) => void;
 	onTextChange: (next: string) => void;
-	onRemoveChip: (slug: string) => void;
+	onRemoveChip: (tag: string) => void;
 	onClear: () => void;
 }) {
 	return (
 		<div className="flex flex-1 items-center gap-2 min-h-9 px-3 py-1 rounded-lg border border-border-primary bg-bg-primary flex-wrap">
 			<Search className="size-4 text-text-tertiary shrink-0" />
 			{chips.map((chip) => (
-				<span
+				<button
 					key={chip}
-					className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[11px] leading-4 whitespace-nowrap ${chipStyleFor(chip, allItems)}`}
+					type="button"
+					aria-label={`Remove tag ${chip}`}
+					onClick={() => onRemoveChip(chip)}
+					className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[11px] leading-4 whitespace-nowrap cursor-pointer ${chipStyleFor(chip, allItems)}`}
 				>
 					#{chip}
-					<button
-						type="button"
-						aria-label={`Remove tag ${chip}`}
-						onClick={() => onRemoveChip(chip)}
-						className="flex items-center justify-center rounded opacity-70 hover:opacity-100"
-					>
-						<X className="size-3" />
-					</button>
-				</span>
+					<X className="size-3 opacity-70" />
+				</button>
 			))}
 			<input
 				ref={inputRef}
@@ -392,14 +389,19 @@ function SearchBar({
 	);
 }
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: list page combines search/filter/grouping logic
 export function AnalyticsListPage({
 	kind,
-	searchQ,
-	setSearchQ,
+	tags,
+	text,
+	setTags,
+	setText,
 }: {
 	kind?: AnalyticsListKind;
-	searchQ: string;
-	setSearchQ: (next: string) => void;
+	tags: string[];
+	text: string;
+	setTags: (next: string[]) => void;
+	setText: (next: string) => void;
 }) {
 	const views = useRecentViews();
 	const queries = useRecentQueries();
@@ -488,9 +490,8 @@ export function AnalyticsListPage({
 		}
 		return (url: string) => map.get(url);
 	}, [views.data, queries.data]);
-	const { chips, text: textPart } = parseQuery(searchQ);
-	const tagTokens = chips.map((c) => c.toLowerCase());
-	const textQuery = textPart;
+	const tagTokens = tags.map(tagSlug);
+	const textQuery = text;
 
 	const tagFiltered = filterByTags(allItems, tagTokens, lookup);
 
@@ -540,16 +541,9 @@ export function AnalyticsListPage({
 		);
 	}
 
-	if (allItems.length === 0 && !searchQ) {
-		const noun =
-			kind === "view" ? "view" : kind === "query" ? "query" : "view or query";
-		return (
-			<EmptyState
-				title="Analytics"
-				description={`Create your first ${noun} from the sidebar.`}
-			/>
-		);
-	}
+	const noun =
+		kind === "view" ? "view" : kind === "query" ? "query" : "view or query";
+	const isEmpty = allItems.length === 0 && tags.length === 0 && !text;
 
 	const placeholder =
 		kind === "view"
@@ -563,34 +557,48 @@ export function AnalyticsListPage({
 		navigate({ to: "/analytics/queries/create", search: QUERY_CREATE_SEARCH });
 	const handleTagClick = (tagText: string) => {
 		const slug = tagSlug(tagText);
-		if (chips.includes(slug)) return;
-		setSearchQ(buildQuery([...chips, slug], textPart));
+		if (tags.some((t) => tagSlug(t) === slug)) return;
+		setTags([...tags, tagText]);
 	};
-	const removeChip = (slug: string) => {
-		setSearchQ(
-			buildQuery(
-				chips.filter((c) => c !== slug),
-				textPart,
-			),
-		);
+	const removeChip = (tag: string) => {
+		setTags(tags.filter((t) => t !== tag));
 	};
 	const updateTextPart = (next: string) => {
-		setSearchQ(buildQuery(chips, next));
+		const parsed = parseQuery(next);
+		if (parsed.chips.length > 0) {
+			const seen = new Set(tags.map(tagSlug));
+			const extra: string[] = [];
+			for (const c of parsed.chips) {
+				const s = tagSlug(c);
+				if (!seen.has(s)) {
+					extra.push(c);
+					seen.add(s);
+				}
+			}
+			if (extra.length > 0) setTags([...tags, ...extra]);
+			setText(parsed.text);
+		} else {
+			setText(next);
+		}
+	};
+	const onClear = () => {
+		setTags([]);
+		setText("");
 	};
 
 	return (
-		<div className="h-full overflow-y-auto pb-[250px]">
-			<div className="sticky top-0 z-10 bg-bg-primary py-4 shadow-[0_10px_10px_0_var(--color-bg-primary)]">
+		<div className="h-full flex flex-col">
+			<div className="bg-bg-primary py-4 shadow-[0_10px_10px_0_var(--color-bg-primary)]">
 				<div className="mx-auto max-w-[990px] px-8 flex items-center gap-2">
 					<SearchBar
-						chips={chips}
-						textPart={textPart}
+						chips={tags}
+						textPart={text}
 						placeholder={placeholder}
-						allItems={allItems}
+						allItems={combined}
 						inputRef={setSearchInputRef}
 						onTextChange={updateTextPart}
 						onRemoveChip={removeChip}
-						onClear={() => setSearchQ("")}
+						onClear={onClear}
 					/>
 					{kind === "view" ? (
 						<HSComp.Button variant="secondary" onClick={createView}>
@@ -630,89 +638,135 @@ export function AnalyticsListPage({
 					)}
 				</div>
 			</div>
-			{items.length === 0 ? (
-				<div className="mx-auto max-w-[990px] px-8 py-6 typo-body-xs text-text-tertiary italic">
-					Nothing matches “{searchQ}”.
-				</div>
-			) : (
-				<ul className="mx-auto max-w-[990px] px-8 bg-bg-primary divide-y divide-border-default">
-					{items.map((it) => {
-						const itemKey = `${it.kind}-${it.id}`;
-						const isMenuOpen = openMenuKey === itemKey;
-						return (
-							<li
-								key={itemKey}
-								className="relative group/row transition-colors hover:bg-bg-secondary"
-							>
-								{it.kind === "view" ? (
-									<Link
-										to="/analytics/views/edit/$id"
-										params={{ id: it.id }}
-										search={VIEW_EDIT_SEARCH}
-										className="block"
-									>
-										<ItemRow
-											item={it}
-											lookup={lookup}
-											showKindLabel={!kind}
-											onTagClick={handleTagClick}
-										/>
-									</Link>
-								) : (
-									<Link
-										to="/analytics/queries/edit/$id"
-										params={{ id: it.id }}
-										search={QUERY_EDIT_SEARCH}
-										className="block"
-									>
-										<ItemRow
-											item={it}
-											lookup={lookup}
-											showKindLabel={!kind}
-											onTagClick={handleTagClick}
-										/>
-									</Link>
-								)}
-								<div
-									className={`${isMenuOpen ? "block" : "hidden group-hover/row:block focus-within:block"} absolute top-2 right-2`}
+			<div className="flex-1 min-h-0 overflow-y-auto pb-[250px]">
+				{isEmpty ? (
+					<EmptyState
+						title="Analytics"
+						description={`Create your first ${noun}.`}
+						action={
+							kind === "view" ? (
+								<HSComp.Button variant="secondary" onClick={createView}>
+									<Plus className="size-4 text-text-info-primary" />
+									Create
+								</HSComp.Button>
+							) : kind === "query" ? (
+								<HSComp.Button variant="secondary" onClick={createQuery}>
+									<Plus className="size-4 text-text-info-primary" />
+									Create
+								</HSComp.Button>
+							) : (
+								<HSComp.DropdownMenu>
+									<HSComp.DropdownMenuTrigger asChild>
+										<HSComp.Button variant="secondary">
+											<Plus className="size-4 text-text-info-primary" />
+											Create
+										</HSComp.Button>
+									</HSComp.DropdownMenuTrigger>
+									<HSComp.DropdownMenuContent align="end">
+										<HSComp.DropdownMenuItem
+											className="justify-start! text-text-info-primary!"
+											onSelect={createView}
+										>
+											<Table className="size-4 text-text-info-primary" />
+											View
+										</HSComp.DropdownMenuItem>
+										<HSComp.DropdownMenuItem
+											className="justify-start! text-text-warning-primary!"
+											onSelect={createQuery}
+										>
+											<FileCode2 className="size-4 text-text-warning-primary" />
+											Query
+										</HSComp.DropdownMenuItem>
+									</HSComp.DropdownMenuContent>
+								</HSComp.DropdownMenu>
+							)
+						}
+					/>
+				) : items.length === 0 ? (
+					<div className="mx-auto max-w-[990px] px-8 py-6 typo-body-xs text-text-tertiary italic">
+						Nothing matches “
+						{[...tags.map((t) => `#${t}`), text].filter(Boolean).join(" ")}”.
+					</div>
+				) : (
+					<ul className="mx-auto max-w-[990px] px-8 bg-bg-primary divide-y divide-border-default">
+						{items.map((it) => {
+							const itemKey = `${it.kind}-${it.id}`;
+							const isMenuOpen = openMenuKey === itemKey;
+							return (
+								<li
+									key={itemKey}
+									className="relative group/row transition-colors hover:bg-bg-secondary first:rounded-t-lg last:rounded-b-lg"
 								>
-									<HSComp.DropdownMenu
-										open={isMenuOpen}
-										onOpenChange={(o) => setOpenMenuKey(o ? itemKey : null)}
+									{it.kind === "view" ? (
+										<Link
+											to="/analytics/views/edit/$id"
+											params={{ id: it.id }}
+											search={VIEW_EDIT_SEARCH}
+											className="block"
+										>
+											<ItemRow
+												item={it}
+												lookup={lookup}
+												showKindLabel={!kind}
+												onTagClick={handleTagClick}
+											/>
+										</Link>
+									) : (
+										<Link
+											to="/analytics/queries/edit/$id"
+											params={{ id: it.id }}
+											search={QUERY_EDIT_SEARCH}
+											className="block"
+										>
+											<ItemRow
+												item={it}
+												lookup={lookup}
+												showKindLabel={!kind}
+												onTagClick={handleTagClick}
+											/>
+										</Link>
+									)}
+									<div
+										className={`${isMenuOpen ? "block" : "hidden group-hover/row:block focus-within:block"} absolute top-2 right-2`}
 									>
-										<HSComp.DropdownMenuTrigger asChild>
-											<button
-												type="button"
-												aria-label="More actions"
-												className="size-7 flex items-center justify-center rounded hover:bg-bg-tertiary text-text-secondary"
-											>
-												<EllipsisVertical className="size-4" />
-											</button>
-										</HSComp.DropdownMenuTrigger>
-										<HSComp.DropdownMenuContent align="end">
-											<HSComp.DropdownMenuItem
-												className="justify-start!"
-												onSelect={() => openLineage(it)}
-											>
-												<GitBranch className="size-4" />
-												Lineage
-											</HSComp.DropdownMenuItem>
-											<HSComp.DropdownMenuItem
-												className="justify-start!"
-												variant="destructive"
-												onSelect={() => setConfirmingDelete(it)}
-											>
-												<Trash2 className="size-4" />
-												Delete
-											</HSComp.DropdownMenuItem>
-										</HSComp.DropdownMenuContent>
-									</HSComp.DropdownMenu>
-								</div>
-							</li>
-						);
-					})}
-				</ul>
-			)}
+										<HSComp.DropdownMenu
+											open={isMenuOpen}
+											onOpenChange={(o) => setOpenMenuKey(o ? itemKey : null)}
+										>
+											<HSComp.DropdownMenuTrigger asChild>
+												<button
+													type="button"
+													aria-label="More actions"
+													className="size-7 flex items-center justify-center rounded hover:bg-bg-tertiary text-text-secondary"
+												>
+													<EllipsisVertical className="size-4" />
+												</button>
+											</HSComp.DropdownMenuTrigger>
+											<HSComp.DropdownMenuContent align="end">
+												<HSComp.DropdownMenuItem
+													className="justify-start!"
+													onSelect={() => openLineage(it)}
+												>
+													<GitBranch className="size-4" />
+													Lineage
+												</HSComp.DropdownMenuItem>
+												<HSComp.DropdownMenuItem
+													className="justify-start!"
+													variant="destructive"
+													onSelect={() => setConfirmingDelete(it)}
+												>
+													<Trash2 className="size-4" />
+													Delete
+												</HSComp.DropdownMenuItem>
+											</HSComp.DropdownMenuContent>
+										</HSComp.DropdownMenu>
+									</div>
+								</li>
+							);
+						})}
+					</ul>
+				)}
+			</div>
 			<HSComp.AlertDialog
 				open={!!confirmingDelete}
 				onOpenChange={(o) => {
@@ -752,18 +806,44 @@ export function AnalyticsListPage({
 
 export const validateAnalyticsSearch = (search: {
 	q?: unknown;
-}): { q?: string } =>
-	typeof search.q === "string" && search.q.length > 0 ? { q: search.q } : {};
+	tags?: unknown;
+}): { q?: string; tags?: string[] } => {
+	const out: { q?: string; tags?: string[] } = {};
+	if (typeof search.q === "string" && search.q.length > 0) out.q = search.q;
+	if (Array.isArray(search.tags)) {
+		const tags = search.tags.filter(
+			(t): t is string => typeof t === "string" && t.length > 0,
+		);
+		if (tags.length > 0) out.tags = tags;
+	} else if (typeof search.tags === "string" && search.tags.length > 0) {
+		out.tags = [search.tags];
+	}
+	return out;
+};
 
 function AnalyticsHomeRoute() {
-	const { q: searchQ = "" } = Route.useSearch();
+	const search = Route.useSearch();
+	const text = search.q ?? "";
+	const tags = search.tags ?? [];
 	const navigate = useNavigate({ from: "/analytics/" });
-	const setSearchQ = (next: string) =>
+	const setText = (next: string) =>
 		navigate({
 			search: (prev) => ({ ...prev, q: next || undefined }),
 			replace: true,
 		});
-	return <AnalyticsListPage searchQ={searchQ} setSearchQ={setSearchQ} />;
+	const setTags = (next: string[]) =>
+		navigate({
+			search: (prev) => ({ ...prev, tags: next.length > 0 ? next : undefined }),
+			replace: true,
+		});
+	return (
+		<AnalyticsListPage
+			text={text}
+			tags={tags}
+			setText={setText}
+			setTags={setTags}
+		/>
+	);
 }
 
 export const Route = createFileRoute("/analytics/")({

--- a/src/routes/analytics.queries.index.tsx
+++ b/src/routes/analytics.queries.index.tsx
@@ -2,15 +2,28 @@ import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { AnalyticsListPage, validateAnalyticsSearch } from "./analytics.index";
 
 function QueriesRoute() {
-	const { q: searchQ = "" } = Route.useSearch();
+	const search = Route.useSearch();
+	const text = search.q ?? "";
+	const tags = search.tags ?? [];
 	const navigate = useNavigate({ from: "/analytics/queries/" });
-	const setSearchQ = (next: string) =>
+	const setText = (next: string) =>
 		navigate({
 			search: (prev) => ({ ...prev, q: next || undefined }),
 			replace: true,
 		});
+	const setTags = (next: string[]) =>
+		navigate({
+			search: (prev) => ({ ...prev, tags: next.length > 0 ? next : undefined }),
+			replace: true,
+		});
 	return (
-		<AnalyticsListPage kind="query" searchQ={searchQ} setSearchQ={setSearchQ} />
+		<AnalyticsListPage
+			kind="query"
+			text={text}
+			tags={tags}
+			setText={setText}
+			setTags={setTags}
+		/>
 	);
 }
 

--- a/src/routes/analytics.views.index.tsx
+++ b/src/routes/analytics.views.index.tsx
@@ -2,15 +2,28 @@ import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { AnalyticsListPage, validateAnalyticsSearch } from "./analytics.index";
 
 function ViewsRoute() {
-	const { q: searchQ = "" } = Route.useSearch();
+	const search = Route.useSearch();
+	const text = search.q ?? "";
+	const tags = search.tags ?? [];
 	const navigate = useNavigate({ from: "/analytics/views/" });
-	const setSearchQ = (next: string) =>
+	const setText = (next: string) =>
 		navigate({
 			search: (prev) => ({ ...prev, q: next || undefined }),
 			replace: true,
 		});
+	const setTags = (next: string[]) =>
+		navigate({
+			search: (prev) => ({ ...prev, tags: next.length > 0 ? next : undefined }),
+			replace: true,
+		});
 	return (
-		<AnalyticsListPage kind="view" searchQ={searchQ} setSearchQ={setSearchQ} />
+		<AnalyticsListPage
+			kind="view"
+			text={text}
+			tags={tags}
+			setText={setText}
+			setTags={setTags}
+		/>
 	);
 }
 

--- a/src/utils/tag-search.ts
+++ b/src/utils/tag-search.ts
@@ -1,0 +1,21 @@
+export function tagSlug(text: string): string {
+	return text.toLowerCase().replace(/&amp;/g, "&").replace(/\s+/g, "-");
+}
+
+export function parseQuery(q: string): { chips: string[]; text: string } {
+	const tokens = q.split(/\s+/).filter(Boolean);
+	const chips: string[] = [];
+	const textTokens: string[] = [];
+	for (const t of tokens) {
+		if (t.startsWith("#") && t.length > 1) chips.push(t.slice(1));
+		else textTokens.push(t);
+	}
+	return { chips, text: textTokens.join(" ") };
+}
+
+export function buildQuery(chips: string[], text: string): string {
+	const chipStr = chips.map((c) => `#${c}`).join(" ");
+	const trimmedText = text.trim();
+	if (chipStr && trimmedText) return `${chipStr} ${trimmedText}`;
+	return chipStr || trimmedText;
+}

--- a/src/utils/url-history.ts
+++ b/src/utils/url-history.ts
@@ -1,9 +1,8 @@
-const KEY = "sqlquery-library-url-history";
 const MAX_ENTRIES = 20;
 
-export function readUrlHistory(): string[] {
+export function readUrlHistory(key: string): string[] {
 	try {
-		const raw = window.localStorage.getItem(KEY);
+		const raw = window.localStorage.getItem(key);
 		if (!raw) return [];
 		const parsed = JSON.parse(raw);
 		if (Array.isArray(parsed)) {
@@ -15,15 +14,18 @@ export function readUrlHistory(): string[] {
 	return [];
 }
 
-export function addUrlToHistory(url: string | undefined | null): void {
+export function addUrlToHistory(
+	key: string,
+	url: string | undefined | null,
+): void {
 	if (!url) return;
 	try {
-		const current = readUrlHistory();
+		const current = readUrlHistory(key);
 		const next = [url, ...current.filter((u) => u !== url)].slice(
 			0,
 			MAX_ENTRIES,
 		);
-		window.localStorage.setItem(KEY, JSON.stringify(next));
+		window.localStorage.setItem(key, JSON.stringify(next));
 	} catch {
 		// ignore
 	}


### PR DESCRIPTION
## Summary
- **Analytics list**: empty state with inline Create CTA, header (search + Create) always visible, click-to-remove chips, `?tags=[...]` query format that preserves original case/spaces, badge color resolution uses combined views+queries set, row padding/rounded corners, subtler fuzzy-match emphasis (`font-medium`).
- **ResourceBrowser**: card list aligned with analytics layout, clickable tag chips.
- **Builder (ViewDefinition + SQLQuery)**: canonical URL datalist (shared `utils/url-history.ts`, separate stores per resource), URL saved on save success only, expand/collapse fix for section labels (stopPropagation in label button).
- Sidebar: `/analytics/**` pages use full width via plain `<Outlet />`; Analytics icon swapped to `ChartNoAxesCombined`.

## Test plan
- [ ] `/u/analytics` (and `/views`, `/queries`): empty state shows Create button; header stays visible when list non-empty.
- [ ] Click a row badge → chip appears in search bar with original text (e.g. `#Patient names`).
- [ ] Click chip → removed. X icon still shown.
- [ ] On `/u/analytics/queries`, chips for `#Patient`, `#<ViewLabel>` get coloured (combined lookup).
- [ ] `/u/analytics/views/create`: type a canonical URL, **Save** → reopen the form → URL appears in the input's datalist suggestions. URLs typed but not saved should NOT appear.
- [ ] Same for `/u/analytics/queries/create` (separate history).
- [ ] In both create pages, clicking the section labels (PROPERTIES, DEPENDS ON, PARAMETERS, SQL, etc.) toggles expand/collapse on every click.
- [ ] `/u/resource`: card list renders with chips; search/filter behaves like analytics.