### PR TITLE
Show getResourceKey on large instances; drop analytics skeleton

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"main": "index.js",
 	"type": "module",
 	"scripts": {
-		"preinstall": "cd aidbox-ts-sdk/packages/aidbox-client && pnpm install && pnpm build && cd ../react-components && pnpm install && pnpm build",
+		"preinstall": "cd aidbox-ts-sdk/packages/aidbox-client && pnpm install && pnpm build && cd ../react-components && pnpm install && pnpm build && cd ../aidbox-fhirpath-lsp && pnpm install && pnpm build",
 		"dev": "vite",
 		"rc:build": "cd aidbox-ts-sdk/packages/react-components && pnpm build && cd ../../.. && pnpm install && rm -rf node_modules/.vite",
 		"client:build": "cd aidbox-ts-sdk/packages/aidbox-client && pnpm build && cd ../../.. && pnpm install && rm -rf node_modules/.vite",
@@ -57,14 +57,15 @@
 			"diff": "^8.0.3",
 			"postcss@<8.5.10": ">=8.5.10",
 			"@codemirror/view": "^6.42.0",
-			"@codemirror/autocomplete": "6.20.2"
+			"@codemirror/autocomplete": "6.20.2",
+			"@health-samurai/aidbox-client": "file:./aidbox-ts-sdk/packages/aidbox-client"
 		}
 	},
 	"dependencies": {
 		"@git-diff-view/file": "^0.0.30",
 		"@git-diff-view/react": "^0.0.30",
 		"@health-samurai/aidbox-client": "file:aidbox-ts-sdk/packages/aidbox-client",
-		"@health-samurai/aidbox-fhirpath-lsp": "0.0.0-alpha.7",
+		"@health-samurai/aidbox-fhirpath-lsp": "file:aidbox-ts-sdk/packages/aidbox-fhirpath-lsp",
 		"@health-samurai/react-components": "file:aidbox-ts-sdk/packages/react-components",
 		"@mcp-b/global": "^2.1.0",
 		"@replit/codemirror-vim": "^6.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,7 @@ overrides:
   postcss@<8.5.10: '>=8.5.10'
   '@codemirror/view': ^6.42.0
   '@codemirror/autocomplete': 6.20.2
+  '@health-samurai/aidbox-client': file:./aidbox-ts-sdk/packages/aidbox-client
 
 importers:
 
@@ -29,8 +30,8 @@ importers:
         specifier: file:aidbox-ts-sdk/packages/aidbox-client
         version: file:aidbox-ts-sdk/packages/aidbox-client
       '@health-samurai/aidbox-fhirpath-lsp':
-        specifier: 0.0.0-alpha.7
-        version: 0.0.0-alpha.7(@codemirror/lsp-client@6.2.2)(@codemirror/state@6.6.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+        specifier: file:aidbox-ts-sdk/packages/aidbox-fhirpath-lsp
+        version: file:aidbox-ts-sdk/packages/aidbox-fhirpath-lsp(@codemirror/lsp-client@6.2.2)(@codemirror/state@6.6.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@health-samurai/react-components':
         specifier: file:aidbox-ts-sdk/packages/react-components
         version: file:aidbox-ts-sdk/packages/react-components(@types/react-dom@19.2.0(@types/react@19.2.0))(@types/react@19.2.0)(react-is@19.2.4)(redux@5.0.1)
@@ -577,14 +578,11 @@ packages:
       react: '*'
       react-dom: '*'
 
-  '@health-samurai/aidbox-client@0.0.0-alpha.5':
-    resolution: {integrity: sha512-WYXfTgMAMRRvJPhnSjB7KiOMhgQ7CDEOS7IUJDvPsjWUbIrRVzfjl89UzyDw6Rv/kum3nDIcVZHyHjVoWbms6g==}
-
   '@health-samurai/aidbox-client@file:aidbox-ts-sdk/packages/aidbox-client':
     resolution: {directory: aidbox-ts-sdk/packages/aidbox-client, type: directory}
 
-  '@health-samurai/aidbox-fhirpath-lsp@0.0.0-alpha.7':
-    resolution: {integrity: sha512-AX3f07EMoZg8OWduVWq6rx5HOk+h7ISj6dIgMmaHLLZJ3wcH+LHjAfPv1H6Q/Hc1kqMx+xyfX68z1AOaqGnANw==}
+  '@health-samurai/aidbox-fhirpath-lsp@file:aidbox-ts-sdk/packages/aidbox-fhirpath-lsp':
+    resolution: {directory: aidbox-ts-sdk/packages/aidbox-fhirpath-lsp, type: directory}
     peerDependencies:
       '@codemirror/lsp-client': ^6.2.0
       '@codemirror/state': ^6.5.2
@@ -2982,7 +2980,7 @@ snapshots:
       '@codemirror/autocomplete': 6.20.2
       '@codemirror/commands': 6.10.3
       '@codemirror/language': 6.12.2
-      '@codemirror/lint': 6.9.5
+      '@codemirror/lint': 6.9.6
       '@codemirror/search': 6.6.0
       '@codemirror/state': 6.6.0
       '@codemirror/theme-one-dark': 6.1.3
@@ -3404,25 +3402,19 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@health-samurai/aidbox-client@0.0.0-alpha.5':
-    dependencies:
-      '@types/json-patch': 0.0.33
-      oauth4webapi: 3.8.5
-      yaml: 2.8.3
-
   '@health-samurai/aidbox-client@file:aidbox-ts-sdk/packages/aidbox-client':
     dependencies:
       '@types/json-patch': 0.0.33
       oauth4webapi: 3.8.5
       yaml: 2.8.3
 
-  '@health-samurai/aidbox-fhirpath-lsp@0.0.0-alpha.7(@codemirror/lsp-client@6.2.2)(@codemirror/state@6.6.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
+  '@health-samurai/aidbox-fhirpath-lsp@file:aidbox-ts-sdk/packages/aidbox-fhirpath-lsp(@codemirror/lsp-client@6.2.2)(@codemirror/state@6.6.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
     dependencies:
       '@atomic-ehr/fhirpath': 0.1.4(typescript@5.9.3)
       '@atomic-ehr/fhirpath-lsp': 0.0.7(typescript@5.9.3)
       '@codemirror/lsp-client': 6.2.2
       '@codemirror/state': 6.6.0
-      '@health-samurai/aidbox-client': 0.0.0-alpha.5
+      '@health-samurai/aidbox-client': file:aidbox-ts-sdk/packages/aidbox-client
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     transitivePeerDependencies:
@@ -4979,7 +4971,7 @@ snapshots:
       '@codemirror/autocomplete': 6.20.2
       '@codemirror/commands': 6.10.3
       '@codemirror/language': 6.12.2
-      '@codemirror/lint': 6.9.5
+      '@codemirror/lint': 6.9.6
       '@codemirror/search': 6.6.0
       '@codemirror/state': 6.6.0
       '@codemirror/view': 6.42.1

--- a/src/routes/analytics.index.tsx
+++ b/src/routes/analytics.index.tsx
@@ -460,12 +460,6 @@ export function AnalyticsListPage({
 		}
 	}, []);
 
-	const loading =
-		kind === "view"
-			? views.isLoading
-			: kind === "query"
-				? queries.isLoading
-				: views.isLoading || queries.isLoading;
 	const combined: RecentItem[] = [
 		...(views.data ?? []),
 		...(queries.data ?? []),
@@ -530,16 +524,6 @@ export function AnalyticsListPage({
 				};
 			})
 		: tagFiltered;
-
-	if (loading) {
-		return (
-			<div className="h-full overflow-y-auto p-6 space-y-2">
-				<HSComp.Skeleton className="h-14 w-full" />
-				<HSComp.Skeleton className="h-14 w-full" />
-				<HSComp.Skeleton className="h-14 w-full" />
-			</div>
-		);
-	}
 
 	const noun =
 		kind === "view" ? "view" : kind === "query" ? "query" : "view or query";


### PR DESCRIPTION
## Summary
- Bump submodule `aidbox-ts-sdk` to pick up `aidbox-fhirpath-lsp` search pagination fix (HealthSamurai/aidbox-ts-sdk#125). On production-sized boxes (>100 `StructureDefinition`s), `/fhir/StructureDefinition?kind=resource` returns only the first 100 entries with no `link.next`, so the LSP's `getResourceTypes()` did not see e.g. `Patient`/`Resource`. As a result FHIRPath completion hid `getResourceKey`/`getReferenceKey` in the ViewDefinition Builder.
- Wire the dependency to `file:aidbox-ts-sdk/packages/aidbox-fhirpath-lsp` so the fix ships now without waiting for an npm release; build the package in `preinstall`; add a pnpm override for `@health-samurai/aidbox-client` so the submodule's `workspace:^` link resolves locally.
- Drop the three-bar `Skeleton` placeholder on `/analytics`, `/analytics/queries`, `/analytics/views`. The recents list now renders empty/data directly without a flicker.

## Test plan
- [ ] On a box with >100 `StructureDefinition` resources, open `/u/analytics/views/create` → type `get` in a COLUMN path; `getResourceKey` and `getReferenceKey` should appear.
- [ ] Visit `/u/analytics`, `/u/analytics/queries`, `/u/analytics/views`; no skeleton placeholder is shown during the initial load.
- [ ] `pnpm install` from a clean checkout succeeds (preinstall builds aidbox-client, react-components, and aidbox-fhirpath-lsp).
- [ ] `make build-aidbox-ui` in `sansara/box` produces a working bundle.

## Dependencies
- Depends on HealthSamurai/aidbox-ts-sdk#125 being merged into `development`.