### PR TITLE
[sansara#7679] Use generateId() instead of direct crypto.randomUUID()

### DIFF
--- a/src/components/DataLineage/sidebar.tsx
+++ b/src/components/DataLineage/sidebar.tsx
@@ -7,6 +7,7 @@ import { ChevronRight, Plus } from "lucide-react";
 import * as React from "react";
 import { type AidboxClientR5, useAidboxClient } from "../../AidboxClient";
 import { useLocalStorage } from "../../hooks";
+import { generateId } from "../../utils";
 
 const SQL_QUERY_TYPE_TOKEN =
 	"https://sql-on-fhir.org/ig/CodeSystem/LibraryTypesCodes|sql-query";
@@ -57,7 +58,7 @@ function SkeletonRows({ count }: { count: number }) {
 	const rows = React.useMemo(
 		() =>
 			Array.from({ length: count }, () => ({
-				id: crypto.randomUUID(),
+				id: generateId(),
 				width:
 					SKELETON_WIDTHS[Math.floor(Math.random() * SKELETON_WIDTHS.length)],
 			})),

--- a/src/routes/rest.tsx
+++ b/src/routes/rest.tsx
@@ -363,7 +363,7 @@ function upsertHeader(
 		return;
 	}
 	const newHeader = {
-		id: crypto.randomUUID(),
+		id: generateId(),
 		name: headerName,
 		value,
 		enabled: true,


### PR DESCRIPTION
## Summary

Two call sites used \`crypto.randomUUID()\` directly, which throws \`TypeError: crypto.randomUUID is not a function\` in non-secure contexts (plain HTTP, not localhost):

- \`src/routes/rest.tsx:366\` — REST console \`upsertHeader\` (the original case reported in the issue).
- \`src/components/DataLineage/sidebar.tsx:60\` — \`SkeletonRows\` loading state.

Both are switched to the existing safe \`generateId()\` wrapper in \`utils.ts\`, which falls back to a \`Math.random\`-based UUIDv4 string when \`crypto.randomUUID\` is unavailable.

REST regression originally introduced by \`57aa46ab\` (\"Reduce cognitive complexity across 8 files\"), which re-introduced the direct call after \`ab16111\` had already removed all such usages.

## Test plan
- [ ] Open REST console over plain HTTP (e.g. \`http://<host>/u/rest\`); add or paste a request that triggers \`upsertHeader\` — no console error, headers row appears.
- [ ] Open DataLineage sidebar over plain HTTP while data is loading — skeleton rows render without error.
- [ ] Same scenarios still work on HTTPS / localhost.
- [ ] \`pnpm typecheck\` / \`pnpm lint:fix\` green.

Closes HealthSamurai/sansara#7679.