### PR TITLE
Navbar: fix New UI switch crash in Firefox/Safari

### DIFF
--- a/src/layout/navbar.tsx
+++ b/src/layout/navbar.tsx
@@ -37,6 +37,7 @@ const ClaudeChatToggle = import.meta.env.DEV
 
 import { PREFERRED_UI_KEY, THEME_KEY, VIM_MODE_KEY } from "../shared/const";
 import { getAidboxBaseURL } from "../utils";
+import { setCookie } from "../utils/cookie";
 
 function inferResourceTypeFromPath(path: string): string | null {
 	if (/^\/analytics\/views\/edit\//.test(path)) return "ViewDefinition";
@@ -148,11 +149,9 @@ function NavbarButtons() {
 					checked={true}
 					onCheckedChange={(checked) => {
 						if (!checked) {
-							cookieStore.set({
-								name: PREFERRED_UI_KEY,
-								value: "old",
+							setCookie(PREFERRED_UI_KEY, "old", {
 								path: "/",
-								expires: Date.now() + 365 * 24 * 60 * 60 * 1000,
+								maxAgeSeconds: 365 * 24 * 60 * 60,
 							});
 							window.location.href = getAidboxBaseURL();
 						}

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -2,3 +2,35 @@ export function getCookie(name: string): string | null {
 	const match = document.cookie.match(new RegExp(`(?:^|; )${name}=([^;]*)`));
 	return match?.[1] ? decodeURIComponent(match[1]) : null;
 }
+
+type CookieStore = {
+	set: (options: {
+		name: string;
+		value: string;
+		path?: string;
+		expires?: number;
+	}) => Promise<void>;
+};
+
+export function setCookie(
+	name: string,
+	value: string,
+	options: { path?: string; maxAgeSeconds?: number } = {},
+): void {
+	const path = options.path ?? "/";
+	const maxAge = options.maxAgeSeconds;
+	const store = (globalThis as { cookieStore?: CookieStore }).cookieStore;
+	if (store) {
+		store.set({
+			name,
+			value,
+			path,
+			expires: maxAge !== undefined ? Date.now() + maxAge * 1000 : undefined,
+		});
+		return;
+	}
+	const parts = [`${name}=${encodeURIComponent(value)}`, `path=${path}`];
+	if (maxAge !== undefined) parts.push(`max-age=${maxAge}`);
+	const cookieKey = "cookie";
+	(document as unknown as Record<string, string>)[cookieKey] = parts.join("; ");
+}


### PR DESCRIPTION
## Summary
- `cookieStore` is a Chromium-only experimental API; toggling the "New UI" switch threw `Uncaught ReferenceError: cookieStore is not defined` in Firefox and Safari.
- Add a `setCookie` helper in `src/utils/cookie.ts` that uses `cookieStore` when available and falls back to `document.cookie` everywhere else.
- Use the helper in `src/layout/navbar.tsx` instead of calling `cookieStore.set` directly.

## Test plan
- [ ] Chrome/Edge: toggle "New UI" off → cookie `aidbox-preferred-ui=old` is set, page redirects to legacy UI.
- [ ] Firefox: toggle "New UI" off → no `ReferenceError` in console, cookie is set, redirect happens.
- [ ] Safari: same as Firefox.