### PR TITLE
Notebooks/REST/Resource Browser: UI polish and perf

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
 		"@replit/codemirror-vim": "^6.3.0",
 		"@tanstack/react-query": "^5.90.21",
 		"@tanstack/react-router": "^1.166.7",
+		"@tanstack/react-virtual": "^3.13.25",
 		"@xyflow/react": "^12.10.2",
 		"fuse.js": "^7.1.0",
 		"js-yaml": "^4.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@tanstack/react-router':
         specifier: ^1.166.7
         version: 1.167.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@tanstack/react-virtual':
+        specifier: ^3.13.25
+        version: 3.13.25(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@xyflow/react':
         specifier: ^12.10.2
         version: 12.10.2(@types/react@19.2.0)(immer@11.1.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1851,6 +1854,12 @@ packages:
       react: '>=16.8'
       react-dom: '>=16.8'
 
+  '@tanstack/react-virtual@3.13.25':
+    resolution: {integrity: sha512-bmNoqMu6gcAW9JGrKVB0Q1tN1i5RONZF8r1fW0bbE4Oyf3DwEGnzzQJ2OW+Ozg1P4s8PyugkHg2ULZoFQN+cqw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@tanstack/router-core@1.167.3':
     resolution: {integrity: sha512-M/CxrTGKk1fsySJjd+Pzpbi3YLDz+cJSutDjSTMy12owWlOgHV/I6kzR0UxyaBlHraM6XgMHNA0XdgsS1fa4Nw==}
     engines: {node: '>=20.19'}
@@ -1890,6 +1899,9 @@ packages:
   '@tanstack/table-core@8.21.3':
     resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
     engines: {node: '>=12'}
+
+  '@tanstack/virtual-core@3.15.0':
+    resolution: {integrity: sha512-0AwPGx0I8QxPYjAxShT/+z+ZOe9u8mW5rsXvivCTjRfRmz9a43+3mRyi4wwlyoUqOC56q/jatKa0Bh9M99BEHQ==}
 
   '@tanstack/virtual-file-routes@1.161.6':
     resolution: {integrity: sha512-EGWs9yvJA821pUkwkiZLQW89CzUumHyJy8NKq229BubyoWXfDw1oWnTJYSS/hhbLiwP9+KpopjeF5wWwnCCyeQ==}
@@ -4959,6 +4971,12 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
+  '@tanstack/react-virtual@3.13.25(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@tanstack/virtual-core': 3.15.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   '@tanstack/router-core@1.167.3':
     dependencies:
       '@tanstack/history': 1.161.6
@@ -5020,6 +5038,8 @@ snapshots:
   '@tanstack/store@0.9.2': {}
 
   '@tanstack/table-core@8.21.3': {}
+
+  '@tanstack/virtual-core@3.15.0': {}
 
   '@tanstack/virtual-file-routes@1.161.6': {}
 

--- a/src/components/ResourceBrowser/browser.tsx
+++ b/src/components/ResourceBrowser/browser.tsx
@@ -2,9 +2,10 @@ import { useLocalStorage } from "@aidbox-ui/hooks/useLocalStorage";
 import * as HSComp from "@health-samurai/react-components";
 import { useQuery } from "@tanstack/react-query";
 import { Link, useNavigate, useSearch } from "@tanstack/react-router";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import Fuse from "fuse.js";
 import { Pin, Search, X } from "lucide-react";
-import React, { useMemo, useRef } from "react";
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import { type AidboxClientR5, useAidboxClient } from "../../AidboxClient";
 import { createFuzzySearch } from "../../utils/fuzzy-search";
 import {
@@ -21,14 +22,6 @@ const CATEGORY_EXT_URL =
 	"http://hl7.org/fhir/StructureDefinition/structuredefinition-category";
 const STATUS_EXT_URL =
 	"http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status";
-
-const STATUS_VALUES = new Set([
-	"normative",
-	"trial-use",
-	"draft",
-	"informative",
-	"deprecated",
-]);
 
 type SDExtension = {
 	url?: string;
@@ -98,13 +91,7 @@ function filterByTags(items: SDItem[], tagTokens: string[]): SDItem[] {
 	});
 }
 
-function chipStyleFor(text: string): string {
-	const slug = tagSlug(text);
-	if (slug === "aidbox") return "bg-bg-brand-secondary text-text-brand-primary";
-	if (slug === "fhir") return "bg-green-50 text-text-success-primary";
-	if (STATUS_VALUES.has(slug)) return "bg-yellow-50 text-text-warning-primary";
-	return "bg-blue-50 text-text-info-primary";
-}
+const CHIP_STYLE = "bg-blue-50 text-text-info-primary";
 
 type StructureDefinitionResource = {
 	resourceType: "StructureDefinition";
@@ -127,7 +114,10 @@ function useStructureDefinitions(client: AidboxClientR5) {
 		queryFn: async () => {
 			const response = await client.rawRequest({
 				method: "GET",
-				url: "/fhir/StructureDefinition?kind=resource&derivation=specialization&_count=1000&_elements=type,name,url,description,extension,publisher",
+				url: "/fhir/StructureDefinition?kind=resource&derivation=specialization&abstract=false&_count=1000&_elements=type,name,url,description,extension,publisher",
+				headers: {
+					"Cache-Control": "max-age=300",
+				},
 			});
 			const bundle: StructureDefinitionBundle = await response.response.json();
 			return (bundle.entry ?? []).flatMap((entry) => {
@@ -168,25 +158,22 @@ function Badge({ text, onClick }: { text: string; onClick: () => void }) {
 	);
 }
 
-function ItemCard({
+const ItemCard = React.memo(function ItemCard({
 	item,
 	isFavorite,
 	onTagClick,
 	onToggleFavorite,
 	focused,
-	rowRef,
 }: {
 	item: SDItem;
 	isFavorite: boolean;
 	onTagClick: (text: string) => void;
-	onToggleFavorite: () => void;
+	onToggleFavorite: (resourceType: string) => void;
 	focused: boolean;
-	rowRef?: React.Ref<HTMLLIElement>;
 }) {
 	return (
 		<li
-			ref={rowRef}
-			className={`relative group/row transition-colors hover:bg-bg-secondary ${focused ? "bg-bg-secondary" : ""}`}
+			className={`relative group/row transition-colors hover:bg-bg-secondary border-b border-border-default ${focused ? "bg-bg-secondary" : ""}`}
 		>
 			<Link
 				to="/resource/$resourceType"
@@ -238,7 +225,7 @@ function ItemCard({
 				onClick={(e) => {
 					e.preventDefault();
 					e.stopPropagation();
-					onToggleFavorite();
+					onToggleFavorite(item.resourceType);
 				}}
 				className={`absolute top-2 right-2 size-7 flex items-center justify-center rounded hover:bg-bg-tertiary transition-opacity ${isFavorite ? "opacity-100 text-text-info-primary" : "opacity-0 group-hover/row:opacity-100 text-text-secondary"}`}
 			>
@@ -246,7 +233,7 @@ function ItemCard({
 			</button>
 		</li>
 	);
-}
+});
 
 function SearchBar({
 	chips,
@@ -274,7 +261,7 @@ function SearchBar({
 					type="button"
 					aria-label={`Remove tag ${chip}`}
 					onClick={() => onRemoveChip(chip)}
-					className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[11px] leading-4 whitespace-nowrap cursor-pointer ${chipStyleFor(chip)}`}
+					className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[11px] leading-4 whitespace-nowrap cursor-pointer ${CHIP_STYLE}`}
 				>
 					#{chip}
 					<X className="size-3 opacity-70" />
@@ -333,25 +320,59 @@ export function Browser() {
 	const search = useSearch({ from: "/resource/" });
 	const navigate = useNavigate();
 
-	const text = search.q ?? "";
+	const urlText = search.q ?? "";
 	const chips = search.tags ?? [];
 	const tagTokens = chips.map(tagSlug);
+
+	// Local input state for instant typing; URL sync is debounced + non-blocking.
+	const [inputText, setInputText] = React.useState(urlText);
+	const text = React.useDeferredValue(inputText);
 	const hasQuery = chips.length > 0 || Boolean(text);
 
-	const setText = (next: string) => {
-		navigate({
-			from: "/resource/",
-			search: (prev) => ({ ...prev, q: next || undefined }),
-			replace: true,
-		});
-	};
-	const setTags = (next: string[]) => {
-		navigate({
-			from: "/resource/",
-			search: (prev) => ({ ...prev, tags: next.length > 0 ? next : undefined }),
-			replace: true,
-		});
-	};
+	// Pull external URL changes (back/forward, navigate from outside) back into local state.
+	const lastUrlTextRef = useRef(urlText);
+	useEffect(() => {
+		if (urlText !== lastUrlTextRef.current) {
+			lastUrlTextRef.current = urlText;
+			setInputText(urlText);
+		}
+	}, [urlText]);
+
+	const urlSyncTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const setText = useCallback(
+		(next: string) => {
+			setInputText(next);
+			if (urlSyncTimerRef.current) clearTimeout(urlSyncTimerRef.current);
+			urlSyncTimerRef.current = setTimeout(() => {
+				lastUrlTextRef.current = next;
+				navigate({
+					from: "/resource/",
+					search: (prev) => ({ ...prev, q: next || undefined }),
+					replace: true,
+				});
+			}, 200);
+		},
+		[navigate],
+	);
+	useEffect(
+		() => () => {
+			if (urlSyncTimerRef.current) clearTimeout(urlSyncTimerRef.current);
+		},
+		[],
+	);
+	const setTags = useCallback(
+		(next: string[]) => {
+			navigate({
+				from: "/resource/",
+				search: (prev) => ({
+					...prev,
+					tags: next.length > 0 ? next : undefined,
+				}),
+				replace: true,
+			});
+		},
+		[navigate],
+	);
 
 	const [favoritesArray, setFavoritesArray] = useLocalStorage<string[]>({
 		key: "resource-browser-favorites",
@@ -399,11 +420,17 @@ export function Browser() {
 		: sortByName(tagFiltered);
 	const items = applyFavorites(textFiltered, favorites, hasQuery);
 
-	const handleTagClick = (tagText: string) => {
-		const slug = tagSlug(tagText);
-		if (chips.some((c) => tagSlug(c) === slug)) return;
-		setTags([...chips, tagText]);
-	};
+	const chipsRef = useRef(chips);
+	chipsRef.current = chips;
+	const handleTagClick = useCallback(
+		(tagText: string) => {
+			const slug = tagSlug(tagText);
+			const current = chipsRef.current;
+			if (current.some((c) => tagSlug(c) === slug)) return;
+			setTags([...current, tagText]);
+		},
+		[setTags],
+	);
 	const removeChip = (tag: string) => {
 		setTags(chips.filter((c) => c !== tag));
 	};
@@ -443,16 +470,19 @@ export function Browser() {
 		setText("");
 	};
 
-	const toggleFavorite = (resourceType: string) => {
-		setFavoritesArray((prev) =>
-			prev.includes(resourceType)
-				? prev.filter((x) => x !== resourceType)
-				: [...prev, resourceType],
-		);
-	};
+	const toggleFavorite = useCallback(
+		(resourceType: string) => {
+			setFavoritesArray((prev) =>
+				prev.includes(resourceType)
+					? prev.filter((x) => x !== resourceType)
+					: [...prev, resourceType],
+			);
+		},
+		[setFavoritesArray],
+	);
 
 	const [focusedIndex, setFocusedIndex] = React.useState(-1);
-	const focusedRowRef = useRef<HTMLLIElement | null>(null);
+	const scrollRef = useRef<HTMLDivElement | null>(null);
 	const didFocus = useRef(false);
 	const setSearchInputRef = React.useCallback((el: HTMLInputElement | null) => {
 		if (el && !didFocus.current) {
@@ -461,10 +491,17 @@ export function Browser() {
 		}
 	}, []);
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: focusedIndex triggers scroll
-	React.useEffect(() => {
-		focusedRowRef.current?.scrollIntoView({ block: "nearest" });
-	}, [focusedIndex]);
+	const rowVirtualizer = useVirtualizer({
+		count: items.length,
+		getScrollElement: () => scrollRef.current,
+		estimateSize: () => 90,
+		overscan: 8,
+	});
+
+	useEffect(() => {
+		if (focusedIndex < 0) return;
+		rowVirtualizer.scrollToIndex(focusedIndex, { align: "auto" });
+	}, [focusedIndex, rowVirtualizer]);
 
 	React.useEffect(() => {
 		if (text && items.length > 0) setFocusedIndex(0);
@@ -539,12 +576,12 @@ export function Browser() {
 	};
 
 	return (
-		<div className="h-full overflow-y-auto pb-[250px]">
+		<div ref={scrollRef} className="h-full overflow-y-auto pb-[250px]">
 			<div className="sticky top-0 z-10 bg-bg-primary py-4 shadow-[0_10px_10px_0_var(--color-bg-primary)]">
 				<div className="mx-auto max-w-[990px] px-8">
 					<SearchBar
 						chips={chips}
-						textPart={text}
+						textPart={inputText}
 						inputRef={setSearchInputRef}
 						onTextChange={updateTextPart}
 						onRemoveChip={removeChip}
@@ -561,19 +598,41 @@ export function Browser() {
 					/>
 				</div>
 			) : (
-				<ul className="mx-auto max-w-[990px] px-8 bg-bg-primary divide-y divide-border-default">
-					{items.map((it, index) => (
-						<ItemCard
-							key={it.resourceType}
-							item={it}
-							isFavorite={favorites.has(it.resourceType)}
-							onTagClick={handleTagClick}
-							onToggleFavorite={() => toggleFavorite(it.resourceType)}
-							focused={index === focusedIndex}
-							rowRef={index === focusedIndex ? focusedRowRef : undefined}
-						/>
-					))}
-				</ul>
+				<div className="mx-auto max-w-[990px] px-8 bg-bg-primary">
+					<ul
+						style={{
+							position: "relative",
+							height: rowVirtualizer.getTotalSize(),
+						}}
+					>
+						{rowVirtualizer.getVirtualItems().map((vi) => {
+							const it = items[vi.index];
+							if (!it) return null;
+							return (
+								<div
+									key={it.resourceType}
+									ref={rowVirtualizer.measureElement}
+									data-index={vi.index}
+									style={{
+										position: "absolute",
+										top: 0,
+										left: 0,
+										right: 0,
+										transform: `translateY(${vi.start}px)`,
+									}}
+								>
+									<ItemCard
+										item={it}
+										isFavorite={favorites.has(it.resourceType)}
+										onTagClick={handleTagClick}
+										onToggleFavorite={toggleFavorite}
+										focused={vi.index === focusedIndex}
+									/>
+								</div>
+							);
+						})}
+					</ul>
+				</div>
 			)}
 		</div>
 	);

--- a/src/components/db-console/result-content.tsx
+++ b/src/components/db-console/result-content.tsx
@@ -712,7 +712,7 @@ export function ResultContent({
 				onValueChange={(v) => setActiveTab(Number(v))}
 				className="flex flex-col flex-1 min-h-0 h-full items-stretch"
 			>
-				<div className="flex-none flex items-center bg-bg-secondary h-10 border-b border-border-default">
+				<div className="flex-none flex items-center bg-bg-secondary h-10 [&_[data-slot=tabs-list]]:h-full">
 					<TabsBrowserList>
 						{results.map((r, i) => {
 							const rowCount = r.result?.length ?? 0;
@@ -740,7 +740,7 @@ export function ResultContent({
 							);
 						})}
 					</TabsBrowserList>
-					<div className="h-full flex items-stretch [&_[data-slot=popover-trigger]]:!px-0 [&_[data-slot=popover-trigger]]:!w-10">
+					<div className="ml-auto h-full flex items-stretch [&_[data-slot=popover-trigger]]:!pr-4">
 						<TabsListDropdown
 							tabs={results.map((r, i) => ({
 								id: String(i),

--- a/src/components/db-console/result-content.tsx
+++ b/src/components/db-console/result-content.tsx
@@ -712,7 +712,7 @@ export function ResultContent({
 				onValueChange={(v) => setActiveTab(Number(v))}
 				className="flex flex-col flex-1 min-h-0 h-full items-stretch"
 			>
-				<div className="flex-none flex items-center bg-bg-secondary h-10">
+				<div className="flex-none flex items-center bg-bg-secondary h-10 border-b border-border-default">
 					<TabsBrowserList>
 						{results.map((r, i) => {
 							const rowCount = r.result?.length ?? 0;

--- a/src/components/db-console/result-content.tsx
+++ b/src/components/db-console/result-content.tsx
@@ -4,29 +4,30 @@ import {
 	DropdownMenuContent,
 	DropdownMenuItem,
 	DropdownMenuTrigger,
-	ResizableHandle,
-	ResizablePanel,
-	ResizablePanelGroup,
 	Table,
 	TableBody,
 	TableCell,
 	TableHead,
 	TableHeader,
 	TableRow,
+	Tabs,
+	TabsBrowserList,
+	TabsContent,
+	TabsListDropdown,
+	TabsTrigger,
 	Tooltip,
 	TooltipContent,
 	TooltipTrigger,
 } from "@health-samurai/react-components";
 import {
+	AlertCircle,
 	Check,
 	ChevronDown,
 	Download,
 	Loader2,
-	Maximize2,
-	Minimize2,
 } from "lucide-react";
 import type React from "react";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import type { QueryResultItem } from "../../webmcp/db-console-context";
 import { LIMIT_PRESETS, TIMEOUT_PRESETS } from "./utils";
 
@@ -203,52 +204,13 @@ function downloadFile(content: string, filename: string, mimeType: string) {
 	URL.revokeObjectURL(url);
 }
 
-// QueryResultHeader (33px) + Table header h-8 (32px) + 3 rows h-7 (3 * 28 = 84px)
-const MIN_PANEL_PX = 33 + 32 + 3 * 28;
-
 // ── Components ──
-
-function QueryResultHeader({
-	index,
-	isMaximized,
-	onToggleMaximize,
-}: {
-	index: number;
-	isMaximized: boolean;
-	onToggleMaximize: () => void;
-}) {
-	return (
-		<div className="flex-none flex items-center justify-between px-4 py-1 border-b bg-bg-secondary">
-			<span className="text-xs text-text-tertiary">Query {index + 1}</span>
-			<Tooltip>
-				<TooltipTrigger asChild>
-					<Button variant="ghost" size="small" onClick={onToggleMaximize}>
-						{isMaximized ? (
-							<Minimize2 className="w-3.5 h-3.5" />
-						) : (
-							<Maximize2 className="w-3.5 h-3.5" />
-						)}
-					</Button>
-				</TooltipTrigger>
-				<TooltipContent>{isMaximized ? "Minimize" : "Maximize"}</TooltipContent>
-			</Tooltip>
-		</div>
-	);
-}
 
 function QueryResult({
 	result,
-	index,
-	totalCount,
-	isMaximized,
-	onToggleMaximize,
 	viewMode = "table",
 }: {
 	result: QueryResultItem;
-	index: number;
-	totalCount: number;
-	isMaximized: boolean;
-	onToggleMaximize: () => void;
 	viewMode?: "table" | "list";
 }) {
 	const rows = result.result ?? [];
@@ -260,13 +222,6 @@ function QueryResult({
 	if (result.error) {
 		return (
 			<div className="flex flex-col h-full">
-				{totalCount > 1 && (
-					<QueryResultHeader
-						index={index}
-						isMaximized={isMaximized}
-						onToggleMaximize={onToggleMaximize}
-					/>
-				)}
 				<div className="p-6">
 					<pre className="text-sm text-text-error-primary whitespace-pre-wrap font-mono">
 						{result.error}
@@ -278,13 +233,6 @@ function QueryResult({
 
 	return (
 		<div className="flex flex-col h-full min-h-0 overflow-hidden">
-			{totalCount > 1 && (
-				<QueryResultHeader
-					index={index}
-					isMaximized={isMaximized}
-					onToggleMaximize={onToggleMaximize}
-				/>
-			)}
 			{rows.length === 0 ? (
 				<div className="flex items-center justify-center h-full text-text-secondary bg-bg-secondary">
 					<div className="text-center">
@@ -694,7 +642,8 @@ export function ResultContent({
 	onCancel: () => void;
 	viewMode?: "table" | "list";
 }) {
-	const [maximizedIndex, setMaximizedIndex] = useState<number | null>(null);
+	const [activeTab, setActiveTab] = useState(0);
+	const triggerRefs = useRef<Map<number, HTMLButtonElement>>(new Map());
 
 	if (isLoading) {
 		return (
@@ -741,73 +690,94 @@ export function ResultContent({
 		);
 	}
 
-	if (maximizedIndex !== null && results[maximizedIndex]) {
-		return (
-			<div className="flex flex-col flex-1 min-h-0 overflow-hidden">
-				<div className="flex-1 min-h-0">
-					<QueryResult
-						result={results[maximizedIndex]}
-						index={maximizedIndex}
-						totalCount={results.length}
-						isMaximized
-						onToggleMaximize={() => setMaximizedIndex(null)}
-						viewMode={viewMode}
-					/>
-				</div>
-			</div>
-		);
-	}
-
 	if (results.length === 1) {
 		const singleResult = results[0];
 		if (!singleResult) return null;
 		return (
 			<div className="flex flex-col flex-1 min-h-0 overflow-hidden">
 				<div className="flex-1 min-h-0">
-					<QueryResult
-						result={singleResult}
-						index={0}
-						totalCount={1}
-						isMaximized={false}
-						onToggleMaximize={() => {}}
-						viewMode={viewMode}
-					/>
+					<QueryResult result={singleResult} viewMode={viewMode} />
 				</div>
 			</div>
 		);
 	}
 
-	const n = results.length;
+	const safeActive = Math.min(activeTab, results.length - 1);
 
 	return (
 		<div className="flex flex-col flex-1 min-h-0 overflow-hidden">
-			<div className="flex-1 min-h-0 overflow-auto">
-				<ResizablePanelGroup
-					direction="vertical"
-					style={{ minHeight: `${n * MIN_PANEL_PX}px` }}
-				>
-					{results.flatMap((result, index) => {
-						const key = `${result.query}-${index}`;
-						const panel = (
-							<ResizablePanel
-								key={`panel-${key}`}
-								style={{ minHeight: `${MIN_PANEL_PX}px` }}
-							>
-								<QueryResult
-									result={result}
-									index={index}
-									totalCount={n}
-									isMaximized={false}
-									onToggleMaximize={() => setMaximizedIndex(index)}
-									viewMode={viewMode}
-								/>
-							</ResizablePanel>
-						);
-						if (index === 0) return [panel];
-						return [<ResizableHandle key={`handle-${key}`} />, panel];
-					})}
-				</ResizablePanelGroup>
-			</div>
+			<Tabs
+				variant="browser"
+				value={String(safeActive)}
+				onValueChange={(v) => setActiveTab(Number(v))}
+				className="flex flex-col flex-1 min-h-0 h-full items-stretch"
+			>
+				<div className="flex-none flex items-center bg-bg-secondary h-10">
+					<TabsBrowserList>
+						{results.map((r, i) => {
+							const rowCount = r.result?.length ?? 0;
+							const ariaLabel = r.error
+								? `Query ${i + 1}, error`
+								: `Query ${i + 1}, ${rowCount} rows`;
+							return (
+								<TabsTrigger
+									key={`${r.query}-${i}`}
+									value={String(i)}
+									aria-label={ariaLabel}
+									ref={(el) => {
+										if (el) triggerRefs.current.set(i, el);
+										else triggerRefs.current.delete(i);
+									}}
+								>
+									<span>Query {i + 1}</span>
+									{r.error && (
+										<span className="flex items-center gap-1 text-text-error-primary text-xs ml-2">
+											<AlertCircle className="w-3 h-3" />
+											error
+										</span>
+									)}
+								</TabsTrigger>
+							);
+						})}
+					</TabsBrowserList>
+					<div className="h-full flex items-stretch [&_[data-slot=popover-trigger]]:!rounded-none [&_[data-slot=popover-trigger]]:!border-l [&_[data-slot=popover-trigger]]:!px-0 [&_[data-slot=popover-trigger]]:!w-10">
+						<TabsListDropdown
+							tabs={results.map((r, i) => ({
+								id: String(i),
+								content: (
+									<span className="flex items-center gap-2">
+										Query {i + 1}
+										{r.error && (
+											<span className="flex items-center gap-1 text-text-error-primary text-xs">
+												<AlertCircle className="w-3 h-3" />
+												error
+											</span>
+										)}
+									</span>
+								),
+							}))}
+							handleTabSelect={(tabId) => {
+								const idx = Number(tabId);
+								setActiveTab(idx);
+								triggerRefs.current.get(idx)?.scrollIntoView({
+									behavior: "smooth",
+									block: "nearest",
+									inline: "nearest",
+								});
+							}}
+						/>
+					</div>
+				</div>
+				{results.map((r, i) => (
+					<TabsContent
+						key={`${r.query}-${i}`}
+						value={String(i)}
+						className="flex-1 min-h-0 overflow-hidden"
+					>
+						<QueryResult result={r} viewMode={viewMode} />
+					</TabsContent>
+				))}
+			</Tabs>
 		</div>
 	);
 }

--- a/src/components/db-console/result-content.tsx
+++ b/src/components/db-console/result-content.tsx
@@ -740,7 +740,7 @@ export function ResultContent({
 							);
 						})}
 					</TabsBrowserList>
-					<div className="h-full flex items-stretch [&_[data-slot=popover-trigger]]:!rounded-none [&_[data-slot=popover-trigger]]:!border-l [&_[data-slot=popover-trigger]]:!px-0 [&_[data-slot=popover-trigger]]:!w-10">
+					<div className="h-full flex items-stretch [&_[data-slot=popover-trigger]]:!px-0 [&_[data-slot=popover-trigger]]:!w-10">
 						<TabsListDropdown
 							tabs={results.map((r, i) => ({
 								id: String(i),

--- a/src/components/notebook-editor.tsx
+++ b/src/components/notebook-editor.tsx
@@ -1,15 +1,21 @@
 import * as HSComp from "@health-samurai/react-components";
 import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { Loader2, Plus, Save, Trash2, User } from "lucide-react";
+import {
+	Eye,
+	Loader2,
+	Plus,
+	Save,
+	TextInitial,
+	Trash2,
+	User,
+	X,
+} from "lucide-react";
 import { useEffect, useState } from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 import { useAidboxClient } from "../AidboxClient";
 import {
 	type Cell,
-	MD_COMPONENTS,
-	normalizeMarkdown,
+	CellView,
 	RestCellView,
 	SqlCellView,
 	SqlQueryCellView,
@@ -51,7 +57,7 @@ const CELL_TYPES: { value: CellType; label: string }[] = [
 ];
 
 const DEFAULT_CELL_VALUE: Record<CellType, string> = {
-	rest: "GET /fhir/Patient",
+	rest: "GET /fhir/Patient\nContent-Type: application/json\nAccept: application/json",
 	rpc: "POST /rpc\ncontent-type: application/json\n\n{}",
 	sql: "SELECT 1;",
 	markdown: "",
@@ -110,47 +116,24 @@ function MarkdownEditCell({
 	onChange: (value: string) => void;
 }) {
 	const [value, setValue] = useState(cell.value);
-	const [mode, setMode] = useState<"edit" | "preview">("edit");
 	const update = (v: string) => {
 		setValue(v);
 		onChange(v);
 	};
 	return (
 		<div className="group/cell -mx-3 mt-4 mb-4 rounded-lg border border-border-default bg-bg-primary overflow-hidden">
-			<HSComp.Tabs
-				value={mode}
-				onValueChange={(v) => setMode(v as "edit" | "preview")}
-				className="flex flex-col"
-			>
-				<div className="flex items-center justify-between bg-bg-secondary pl-3 pr-4 border-b border-border-default h-10">
-					<div className="flex items-center gap-3">
-						<span className="text-sm font-medium text-text-secondary w-[70px] shrink-0">
-							Markdown
-						</span>
-						<HSComp.TabsList>
-							<HSComp.TabsTrigger value="edit">Edit</HSComp.TabsTrigger>
-							<HSComp.TabsTrigger value="preview">Preview</HSComp.TabsTrigger>
-						</HSComp.TabsList>
-					</div>
-				</div>
-				{mode === "edit" ? (
-					<textarea
-						value={value}
-						onChange={(e) => update(e.target.value)}
-						placeholder="# Markdown…"
-						className="w-full min-h-[150px] max-h-[400px] px-3 py-2 typo-code outline-none resize-y bg-bg-primary text-text-primary"
-					/>
-				) : (
-					<div className="px-3 py-2 text-text-primary min-h-[150px] max-h-[400px] overflow-auto">
-						<ReactMarkdown
-							remarkPlugins={[remarkGfm]}
-							components={MD_COMPONENTS}
-						>
-							{normalizeMarkdown(value || "")}
-						</ReactMarkdown>
-					</div>
-				)}
-			</HSComp.Tabs>
+			<div className="flex items-center justify-between bg-bg-secondary pl-3 pr-4 border-b border-border-default h-10">
+				<span className="text-sm font-medium text-text-secondary w-[110px] shrink-0 flex items-center gap-1.5">
+					<TextInitial className="size-4 shrink-0" />
+					Markdown
+				</span>
+			</div>
+			<textarea
+				value={value}
+				onChange={(e) => update(e.target.value)}
+				placeholder="# Markdown…"
+				className="w-full min-h-[150px] max-h-[400px] px-3 py-2 typo-code outline-none resize-y bg-bg-primary text-text-primary"
+			/>
 		</div>
 	);
 }
@@ -209,7 +192,7 @@ function CellWrapper({
 				type="button"
 				onClick={() => onDelete(cell.id)}
 				aria-label="Delete cell"
-				className="absolute top-0 -left-14 inline-flex items-center justify-center size-10 rounded text-critical-default hover:text-critical-hover opacity-0 group-hover/cellwrap:opacity-100 transition-opacity cursor-pointer after:absolute after:top-0 after:bottom-0 after:left-full after:w-4 after:content-['']"
+				className="absolute top-0 -right-14 inline-flex items-center justify-center size-10 rounded text-text-disabled hover:text-text-primary opacity-0 group-hover/cellwrap:opacity-100 transition-opacity cursor-pointer after:absolute after:top-0 after:bottom-0 after:right-full after:w-4 after:content-['']"
 			>
 				<Trash2 className="size-6" />
 			</button>
@@ -230,6 +213,7 @@ export function NotebookEditor({
 	const navigate = useNavigate();
 	const [notebook, setNotebook] = useState<EditableNotebook>(initial);
 	const [dirty, setDirty] = useState(isNew);
+	const [previewMode, setPreviewMode] = useState(false);
 
 	useEffect(() => {
 		if (!dirty) return;
@@ -379,89 +363,162 @@ export function NotebookEditor({
 
 	const saveDisabled = !notebook.name?.trim() || saveMut.isPending;
 
-	return (
-		<>
-			<div className="h-full flex flex-col">
-				<div className="flex items-center bg-bg-secondary flex-none h-10 border-b border-border-default">
-					<div className="mx-auto max-w-[990px] w-full flex items-center gap-4 px-8">
+	const editorBody = (
+		<div className="flex flex-col h-full">
+			<div className="flex items-center bg-bg-secondary flex-none h-10 border-b border-border-default">
+				<div className="mx-auto max-w-[990px] w-full flex items-center gap-4 px-8">
+					<HSComp.Button
+						variant="ghost"
+						size="small"
+						className="px-0! text-text-link"
+						disabled={saveDisabled}
+						onClick={() => saveMut.mutate(undefined)}
+					>
+						<Save className="size-4" />
+						Save
+					</HSComp.Button>
+					{!isNew && notebook.id && (
 						<HSComp.Button
 							variant="ghost"
 							size="small"
-							className="px-0! text-text-link"
-							disabled={saveDisabled}
-							onClick={() => saveMut.mutate(undefined)}
+							className="px-0!"
+							disabled={deleteMut.isPending}
+							onClick={() => setDeleteOpen(true)}
 						>
-							<Save className="size-4" />
-							Save
+							{deleteMut.isPending ? (
+								<Loader2 className="size-4 animate-spin" />
+							) : (
+								<Trash2 className="size-4" />
+							)}
+							Delete
 						</HSComp.Button>
-						{!isNew && notebook.id && (
-							<HSComp.Button
-								variant="ghost"
-								size="small"
-								className="px-0!"
-								disabled={deleteMut.isPending}
-								onClick={() => setDeleteOpen(true)}
-							>
-								{deleteMut.isPending ? (
-									<Loader2 className="size-4 animate-spin" />
-								) : (
-									<Trash2 className="size-4" />
-								)}
-								Delete
-							</HSComp.Button>
-						)}
-					</div>
+					)}
+					{!previewMode && (
+						<HSComp.Toggle
+							variant="outline"
+							className="ml-auto"
+							pressed={previewMode}
+							onPressedChange={setPreviewMode}
+						>
+							<Eye className="size-4" />
+							Preview
+						</HSComp.Toggle>
+					)}
 				</div>
-				<div className="flex-1 min-h-0 overflow-y-auto pb-[400px]">
-					<div className="mx-auto max-w-[990px] px-8 py-8">
-						<div className="flex flex-col">
-							<div className="flex flex-col gap-1">
-								<div className="flex items-center gap-1.5 typo-label-tiny uppercase tracking-wide text-text-warning-primary">
-									<User className="size-3.5" />
-									<span>Personal</span>
+			</div>
+			<div className="flex-1 overflow-y-auto pb-[400px]">
+				<div className="mx-auto max-w-[990px] px-8 py-8">
+					<div className="flex flex-col">
+						<div className="flex flex-col gap-1">
+							<div className="flex items-center gap-1.5 typo-label-tiny uppercase tracking-wide text-text-warning-primary">
+								<User className="size-3.5" />
+								<span>Personal</span>
+							</div>
+							<input
+								value={notebook.name ?? ""}
+								onChange={(e) => updateField("name", e.target.value)}
+								placeholder="Untitled notebook"
+								// biome-ignore lint/a11y/noAutofocus: focus the title input only on the New notebook page
+								autoFocus={isNew}
+								className="typo-page-header text-text-primary bg-transparent outline-none w-full"
+							/>
+							<input
+								value={notebook.description ?? ""}
+								onChange={(e) => updateField("description", e.target.value)}
+								placeholder="Description"
+								className="typo-body text-text-secondary bg-transparent outline-none"
+							/>
+							{saveMut.isError && (
+								<p className="typo-body-xs text-critical-default">
+									{saveMut.error.message}
+								</p>
+							)}
+							{deleteMut.isError && (
+								<p className="typo-body-xs text-critical-default">
+									{deleteMut.error.message}
+								</p>
+							)}
+						</div>
+						<div className="flex flex-col mt-7">
+							<AddCellDivider onAdd={(t) => addCellAt(0, t)} />
+							{notebook.cells.map((cell, idx) => (
+								<div key={cell.id}>
+									<CellWrapper
+										cell={cell}
+										onValueChange={updateCellValue}
+										onResultChange={updateCellResult}
+										onDelete={deleteCell}
+									/>
+									<AddCellDivider onAdd={(t) => addCellAt(idx + 1, t)} />
 								</div>
-								<input
-									value={notebook.name ?? ""}
-									onChange={(e) => updateField("name", e.target.value)}
-									placeholder="Untitled notebook"
-									// biome-ignore lint/a11y/noAutofocus: focus the title input only on the New notebook page
-									autoFocus={isNew}
-									className="typo-page-header text-text-primary bg-transparent outline-none w-full"
-								/>
-								<input
-									value={notebook.description ?? ""}
-									onChange={(e) => updateField("description", e.target.value)}
-									placeholder="Description"
-									className="typo-body text-text-secondary bg-transparent outline-none"
-								/>
-								{saveMut.isError && (
-									<p className="typo-body-xs text-critical-default">
-										{saveMut.error.message}
-									</p>
-								)}
-								{deleteMut.isError && (
-									<p className="typo-body-xs text-critical-default">
-										{deleteMut.error.message}
-									</p>
-								)}
-							</div>
-							<div className="flex flex-col mt-7">
-								<AddCellDivider onAdd={(t) => addCellAt(0, t)} />
-								{notebook.cells.map((cell, idx) => (
-									<div key={cell.id}>
-										<CellWrapper
-											cell={cell}
-											onValueChange={updateCellValue}
-											onResultChange={updateCellResult}
-											onDelete={deleteCell}
-										/>
-										<AddCellDivider onAdd={(t) => addCellAt(idx + 1, t)} />
-									</div>
-								))}
-							</div>
+							))}
 						</div>
 					</div>
 				</div>
+			</div>
+		</div>
+	);
+
+	const previewBody = (
+		<div className="flex flex-col h-full">
+			<div className="flex items-center justify-between bg-bg-secondary px-4 border-b h-10! min-h-10 shrink-0">
+				<span className="typo-label text-text-secondary">Preview</span>
+				<HSComp.IconButton
+					variant="ghost"
+					aria-label="Close preview"
+					icon={<X className="w-4 h-4" />}
+					onClick={() => setPreviewMode(false)}
+				/>
+			</div>
+			<div className="flex-1 overflow-y-auto pb-[400px]">
+				<div className="mx-auto max-w-[990px] px-8 py-8">
+					{notebook.name && (
+						<h1 className="typo-page-header text-text-primary">
+							{notebook.name}
+						</h1>
+					)}
+					{notebook.description && (
+						<p className="typo-body text-text-secondary mt-2">
+							{notebook.description}
+						</p>
+					)}
+					<div className="flex flex-col mt-7">
+						{notebook.cells.map((cell) => (
+							<CellView
+								key={cell.id}
+								cell={{
+									id: cell.id,
+									type: cell.type,
+									value: cell.value,
+									result: cell.result,
+								}}
+							/>
+						))}
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+
+	return (
+		<>
+			<div className="h-full">
+				{previewMode ? (
+					<HSComp.ResizablePanelGroup
+						direction="horizontal"
+						autoSaveId="notebook-edit-preview"
+					>
+						<HSComp.ResizablePanel minSize={20}>
+							{editorBody}
+						</HSComp.ResizablePanel>
+						<HSComp.ResizableHandle />
+						<HSComp.ResizablePanel minSize={20}>
+							{previewBody}
+						</HSComp.ResizablePanel>
+					</HSComp.ResizablePanelGroup>
+				) : (
+					editorBody
+				)}
 			</div>
 			<ConfirmDialog
 				open={deleteOpen}

--- a/src/routes/notebooks.$id.tsx
+++ b/src/routes/notebooks.$id.tsx
@@ -5,6 +5,8 @@ import * as yaml from "js-yaml";
 import {
 	Check,
 	ChevronDown,
+	Database,
+	FileCode,
 	FileDown,
 	Globe,
 	GlobeOff,
@@ -13,6 +15,8 @@ import {
 	Pencil,
 	Play,
 	Share2,
+	SquareTerminal,
+	Table,
 	Timer,
 	Trash2,
 	User,
@@ -218,63 +222,6 @@ function parseRawRequest(raw: string): {
 	return { method, path, headers, body };
 }
 
-function parsePathQuery(path: string): { name: string; value: string }[] {
-	const qIdx = path.indexOf("?");
-	if (qIdx < 0) return [];
-	const qs = path.slice(qIdx + 1);
-	return qs
-		.split("&")
-		.filter(Boolean)
-		.map((pair) => {
-			const eq = pair.indexOf("=");
-			const name = eq < 0 ? pair : pair.slice(0, eq);
-			const value = eq < 0 ? "" : pair.slice(eq + 1);
-			try {
-				return {
-					name: decodeURIComponent(name),
-					value: decodeURIComponent(value),
-				};
-			} catch {
-				return { name, value };
-			}
-		});
-}
-
-function KeyValueTable({
-	rows,
-	empty,
-}: {
-	rows: { name: string; value: string }[];
-	empty: string;
-}) {
-	if (rows.length === 0) {
-		return (
-			<div className="px-4 py-3 typo-body-xs text-text-tertiary italic">
-				{empty}
-			</div>
-		);
-	}
-	return (
-		<table className="w-full typo-body-xs">
-			<tbody>
-				{rows.map((r, i) => (
-					<tr
-						key={`${r.name}-${i}`}
-						className="border-b border-border-default last:border-b-0"
-					>
-						<td className="px-3 py-1.5 font-mono text-text-primary align-top w-[1%] whitespace-nowrap">
-							{r.name}
-						</td>
-						<td className="px-3 py-1.5 font-mono text-text-secondary break-all">
-							{r.value}
-						</td>
-					</tr>
-				))}
-			</tbody>
-		</table>
-	);
-}
-
 type CellResponse = {
 	status: number;
 	statusText: string;
@@ -362,7 +309,6 @@ export function RestCellView({
 	const [loading, setLoading] = useState(false);
 	const [hasFreshResponse, setHasFreshResponse] = useState(false);
 	const [tab, setTab] = useState<"body" | "headers">("body");
-	const [reqTab, setReqTab] = useState<"params" | "headers" | "raw">("raw");
 	const responseRef = useRef<HTMLDivElement | null>(null);
 	const client = useAidboxClient();
 
@@ -431,13 +377,6 @@ export function RestCellView({
 		}
 	};
 
-	const parsedRaw = parseRawRequest(raw);
-	const queryParams = parsePathQuery(parsedRaw.path);
-	const hasParams = queryParams.length > 0;
-	useEffect(() => {
-		if (reqTab === "params" && !hasParams) setReqTab("raw");
-	}, [reqTab, hasParams]);
-
 	const clearResponse = () => {
 		setResponse(null);
 		setHasFreshResponse(false);
@@ -454,66 +393,34 @@ export function RestCellView({
 
 	return (
 		<div className="group/cell -mx-3 mt-4 mb-4 rounded-lg border border-border-default bg-bg-primary overflow-hidden">
-			<HSComp.Tabs
-				value={reqTab}
-				onValueChange={(v) => setReqTab(v as "params" | "headers" | "raw")}
-				className="flex flex-col"
-			>
-				<div className="flex items-center justify-between bg-bg-secondary pl-3 pr-4 border-b border-border-default h-10">
-					<div className="flex items-center gap-3">
-						<span className="text-sm font-medium text-text-secondary w-[70px] shrink-0">
-							Request
-						</span>
-						<HSComp.TabsList>
-							<HSComp.TabsTrigger value="raw">Raw</HSComp.TabsTrigger>
-							{hasParams && (
-								<HSComp.TabsTrigger value="params">Params</HSComp.TabsTrigger>
-							)}
-							<HSComp.TabsTrigger value="headers">Headers</HSComp.TabsTrigger>
-						</HSComp.TabsList>
-					</div>
-					<button
-						type="button"
-						disabled={loading}
-						onClick={() => void send()}
-						className={`flex items-center gap-2 text-text-info-primary typo-body uppercase hover:text-text-info-secondary disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer transition-opacity ${
-							loading
-								? "opacity-100"
-								: "opacity-0 group-hover/cell:opacity-100 focus:opacity-100"
-						}`}
-					>
-						{loading ? (
-							<Loader2 className="size-4 animate-spin" />
-						) : (
-							<Play className="size-4 fill-current" />
-						)}
-						{loading ? "Sending…" : "Send"}
-					</button>
-				</div>
-				{reqTab === "raw" && (
-					<div className="max-h-[400px] overflow-auto [&_.cm-content]:!pl-1.5">
-						<HSComp.CodeEditor
-							mode="http"
-							defaultValue={raw}
-							onChange={updateRaw}
-							lineNumbers={false}
-							foldGutter={false}
-						/>
-					</div>
-				)}
-				{reqTab === "params" && hasParams && (
-					<KeyValueTable rows={queryParams} empty="No query params." />
-				)}
-				{reqTab === "headers" && (
-					<KeyValueTable
-						rows={Object.entries(parsedRaw.headers).map(([name, value]) => ({
-							name,
-							value,
-						}))}
-						empty="No headers."
-					/>
-				)}
-			</HSComp.Tabs>
+			<div className="flex items-center justify-between bg-bg-secondary pl-3 pr-4 border-b border-border-default h-10">
+				<span className="text-sm font-medium text-text-secondary w-[70px] shrink-0 flex items-center gap-1.5">
+					<SquareTerminal className="size-4" />
+					REST
+				</span>
+				<button
+					type="button"
+					disabled={loading}
+					onClick={() => void send()}
+					className="flex items-center gap-2 text-text-info-primary typo-body uppercase hover:text-text-info-secondary disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+				>
+					{loading ? (
+						<Loader2 className="size-4 animate-spin" />
+					) : (
+						<Play className="size-4 fill-current" />
+					)}
+					Send
+				</button>
+			</div>
+			<div className="max-h-[400px] overflow-auto [&_.cm-content]:!pl-1.5">
+				<HSComp.CodeEditor
+					mode="http"
+					defaultValue={raw}
+					onChange={updateRaw}
+					lineNumbers={false}
+					foldGutter={false}
+				/>
+			</div>
 			{response && (
 				<HSComp.Tabs
 					value={tab}
@@ -523,7 +430,7 @@ export function RestCellView({
 					<div className="flex items-center justify-between bg-bg-secondary pl-3 pr-4 h-10 border-t border-b border-border-default">
 						<div className="flex items-center gap-3">
 							<span className="text-sm font-medium text-text-secondary w-[70px] shrink-0">
-								Response
+								Response:
 							</span>
 							<HSComp.TabsList>
 								<HSComp.TabsTrigger value="body">Body</HSComp.TabsTrigger>
@@ -688,18 +595,15 @@ export function SqlCellView({
 	return (
 		<div className="group/cell -mx-3 mt-4 mb-4 rounded-lg border border-border-default bg-bg-primary overflow-hidden">
 			<div className="flex items-center justify-between bg-bg-secondary pl-3 pr-4 border-b border-border-default h-10">
-				<span className="text-sm font-medium text-text-secondary w-[70px] shrink-0">
+				<span className="text-sm font-medium text-text-secondary w-[70px] shrink-0 flex items-center gap-1.5">
+					<Database className="size-4" />
 					SQL
 				</span>
 				<button
 					type="button"
 					disabled={loading}
 					onClick={() => void send()}
-					className={`flex items-center gap-2 text-text-info-primary typo-body uppercase hover:text-text-info-secondary disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer transition-opacity ${
-						loading
-							? "opacity-100"
-							: "opacity-0 group-hover/cell:opacity-100 focus:opacity-100"
-					}`}
+					className="flex items-center gap-2 text-text-info-primary typo-body uppercase hover:text-text-info-secondary disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
 				>
 					{loading ? (
 						<Loader2 className="size-4 animate-spin" />
@@ -882,7 +786,8 @@ export function ViewDefinitionCellView({
 		<div className="group/cell -mx-3 mt-4 mb-4 rounded-lg border border-border-default bg-bg-primary overflow-hidden">
 			<div className="flex items-center justify-between bg-bg-secondary pl-3 pr-4 border-b border-border-default h-10 gap-3">
 				<div className="flex items-center gap-3 min-w-0">
-					<span className="text-sm font-medium text-text-secondary w-[140px] shrink-0">
+					<span className="text-sm font-medium text-text-secondary w-[140px] shrink-0 flex items-center gap-1.5">
+						<Table className="size-4" />
 						ViewDefinition
 					</span>
 					{editable && (
@@ -899,11 +804,7 @@ export function ViewDefinitionCellView({
 					type="button"
 					disabled={loading || !vd?.id}
 					onClick={() => void run()}
-					className={`flex items-center gap-2 text-text-info-primary typo-body uppercase hover:text-text-info-secondary disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer transition-opacity ${
-						loading
-							? "opacity-100"
-							: "opacity-0 group-hover/cell:opacity-100 focus:opacity-100"
-					}`}
+					className="flex items-center gap-2 text-text-info-primary typo-body uppercase hover:text-text-info-secondary disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
 				>
 					{loading ? (
 						<Loader2 className="size-4 animate-spin" />
@@ -1215,7 +1116,8 @@ export function SqlQueryCellView({
 		<div className="group/cell -mx-3 mt-4 mb-4 rounded-lg border border-border-default bg-bg-primary overflow-hidden">
 			<div className="flex items-center justify-between bg-bg-secondary pl-3 pr-4 border-b border-border-default h-10 gap-3">
 				<div className="flex items-center gap-3 min-w-0">
-					<span className="text-sm font-medium text-text-secondary w-[140px] shrink-0">
+					<span className="text-sm font-medium text-text-secondary w-[140px] shrink-0 flex items-center gap-1.5">
+						<FileCode className="size-4" />
 						SQLQuery
 					</span>
 					{editable && (
@@ -1235,11 +1137,7 @@ export function SqlQueryCellView({
 					type="button"
 					disabled={loading || !lib?.id}
 					onClick={() => void run()}
-					className={`flex items-center gap-2 text-text-info-primary typo-body uppercase hover:text-text-info-secondary disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer transition-opacity ${
-						loading
-							? "opacity-100"
-							: "opacity-0 group-hover/cell:opacity-100 focus:opacity-100"
-					}`}
+					className="flex items-center gap-2 text-text-info-primary typo-body uppercase hover:text-text-info-secondary disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
 				>
 					{loading ? (
 						<Loader2 className="size-4 animate-spin" />
@@ -1372,7 +1270,7 @@ export function SqlQueryCellView({
 	);
 }
 
-function CellView({ cell }: { cell: Cell }) {
+export function CellView({ cell }: { cell: Cell }) {
 	const type = cell.type ?? "rest";
 	if (type === "rest" || type === "rpc") {
 		return <RestCellView cell={cell} />;

--- a/src/routes/notebooks.index.tsx
+++ b/src/routes/notebooks.index.tsx
@@ -1,6 +1,7 @@
 import * as HSComp from "@health-samurai/react-components";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import Fuse from "fuse.js";
 import {
 	FileUp,
@@ -157,15 +158,13 @@ function SearchBar({
 	);
 }
 
-function NotebookRow({
+const NotebookRow = React.memo(function NotebookRow({
 	nb,
 	focused,
-	focusedRef,
 	onTagClick,
 }: {
 	nb: NotebookItem;
 	focused: boolean;
-	focusedRef: React.RefObject<HTMLLIElement | null> | undefined;
 	onTagClick: (t: string) => void;
 }) {
 	const KindIcon = nb.isCommunity ? Globe : User;
@@ -175,8 +174,7 @@ function NotebookRow({
 		: "text-text-warning-primary";
 	return (
 		<li
-			ref={focusedRef}
-			className={`relative transition-colors hover:bg-bg-secondary first:rounded-t-lg last:rounded-b-lg ${focused ? "bg-bg-secondary" : ""}`}
+			className={`relative transition-colors hover:bg-bg-secondary border-b border-border-default ${focused ? "bg-bg-secondary" : ""}`}
 		>
 			<Link
 				to="/notebooks/$id"
@@ -219,7 +217,7 @@ function NotebookRow({
 			</Link>
 		</li>
 	);
-}
+});
 
 function UploadButton() {
 	const client = useAidboxClient();
@@ -391,11 +389,17 @@ function NotebooksPage() {
 			search: (prev) => ({ ...prev, q: next || undefined }),
 			replace: true,
 		});
-	const setTags = (next: string[]) =>
-		navigate({
-			search: (prev) => ({ ...prev, tags: next.length > 0 ? next : undefined }),
-			replace: true,
-		});
+	const setTags = React.useCallback(
+		(next: string[]) =>
+			navigate({
+				search: (prev) => ({
+					...prev,
+					tags: next.length > 0 ? next : undefined,
+				}),
+				replace: true,
+			}),
+		[navigate],
+	);
 
 	const tagTokens = tags.map(tagSlug);
 
@@ -442,7 +446,7 @@ function NotebooksPage() {
 			);
 
 	const [focusedIndex, setFocusedIndex] = React.useState(-1);
-	const focusedRowRef = React.useRef<HTMLLIElement | null>(null);
+	const scrollRef = React.useRef<HTMLDivElement | null>(null);
 	const didFocus = React.useRef(false);
 	const setSearchInputRef = React.useCallback((el: HTMLInputElement | null) => {
 		if (el && !didFocus.current) {
@@ -451,10 +455,17 @@ function NotebooksPage() {
 		}
 	}, []);
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: focusedIndex triggers scroll
+	const rowVirtualizer = useVirtualizer({
+		count: items.length,
+		getScrollElement: () => scrollRef.current,
+		estimateSize: () => 100,
+		overscan: 8,
+	});
+
 	React.useEffect(() => {
-		focusedRowRef.current?.scrollIntoView({ block: "nearest" });
-	}, [focusedIndex]);
+		if (focusedIndex < 0) return;
+		rowVirtualizer.scrollToIndex(focusedIndex, { align: "auto" });
+	}, [focusedIndex, rowVirtualizer]);
 
 	React.useEffect(() => {
 		if (text && items.length > 0) setFocusedIndex(0);
@@ -469,11 +480,17 @@ function NotebooksPage() {
 		});
 	};
 
-	const addTag = (tagText: string) => {
-		const slug = tagSlug(tagText);
-		if (tags.some((t) => tagSlug(t) === slug)) return;
-		setTags([...tags, tagText]);
-	};
+	const tagsRef = React.useRef(tags);
+	tagsRef.current = tags;
+	const addTag = React.useCallback(
+		(tagText: string) => {
+			const slug = tagSlug(tagText);
+			const current = tagsRef.current;
+			if (current.some((t) => tagSlug(t) === slug)) return;
+			setTags([...current, tagText]);
+		},
+		[setTags],
+	);
 	const removeChip = (tag: string) => {
 		setTags(tags.filter((t) => t !== tag));
 	};
@@ -554,7 +571,10 @@ function NotebooksPage() {
 					</HSComp.Button>
 				</div>
 			</div>
-			<div className="flex-1 min-h-0 overflow-y-auto pb-[250px]">
+			<div
+				ref={scrollRef}
+				className="flex-1 min-h-0 overflow-y-auto pb-[250px]"
+			>
 				{isLoading ? null : isEmpty ? (
 					<EmptyState
 						title="Notebooks"
@@ -566,17 +586,39 @@ function NotebooksPage() {
 						{[...tags.map((t) => `#${t}`), text].filter(Boolean).join(" ")}”.
 					</div>
 				) : (
-					<ul className="mx-auto max-w-[990px] px-8 bg-bg-primary divide-y divide-border-default">
-						{items.map((nb, index) => (
-							<NotebookRow
-								key={nb.id}
-								nb={nb}
-								focused={index === focusedIndex}
-								focusedRef={index === focusedIndex ? focusedRowRef : undefined}
-								onTagClick={addTag}
-							/>
-						))}
-					</ul>
+					<div className="mx-auto max-w-[990px] px-8 bg-bg-primary">
+						<ul
+							style={{
+								position: "relative",
+								height: rowVirtualizer.getTotalSize(),
+							}}
+						>
+							{rowVirtualizer.getVirtualItems().map((vi) => {
+								const nb = items[vi.index];
+								if (!nb) return null;
+								return (
+									<div
+										key={nb.id}
+										ref={rowVirtualizer.measureElement}
+										data-index={vi.index}
+										style={{
+											position: "absolute",
+											top: 0,
+											left: 0,
+											right: 0,
+											transform: `translateY(${vi.start}px)`,
+										}}
+									>
+										<NotebookRow
+											nb={nb}
+											focused={vi.index === focusedIndex}
+											onTagClick={addTag}
+										/>
+									</div>
+								);
+							})}
+						</ul>
+					</div>
 				)}
 			</div>
 		</div>

--- a/src/routes/rest.tsx
+++ b/src/routes/rest.tsx
@@ -1518,7 +1518,6 @@ function RouteComponent() {
 		defaultValue: true,
 	});
 	const initialLeftMenuOpen = useRef(leftMenuOpen);
-	const [isPanelAnimating, setIsPanelAnimating] = useState(false);
 
 	const [menuTab, setMenuTab] = useLocalStorage<string>({
 		key: "rest-console-left-menu-default-tab",
@@ -1541,13 +1540,11 @@ function RouteComponent() {
 		getLeftMenuOpen: () => leftMenuOpen,
 		setLeftMenuOpen: (open) => {
 			if (open === leftMenuOpen) return;
-			setIsPanelAnimating(true);
 			if (open) {
 				leftPanelRef.current?.expand();
 			} else {
 				leftPanelRef.current?.collapse();
 			}
-			setTimeout(() => setIsPanelAnimating(false), 200);
 		},
 		getMenuTab: () => menuTab,
 		setMenuTab,
@@ -2204,9 +2201,6 @@ function RouteComponent() {
 						collapsedSize={0}
 						onCollapse={() => setLeftMenuOpen(false)}
 						onExpand={() => setLeftMenuOpen(true)}
-						className={
-							isPanelAnimating ? "transition-[flex-grow] duration-200" : ""
-						}
 					>
 						<LeftMenu
 							tabs={tabs}
@@ -2221,27 +2215,13 @@ function RouteComponent() {
 							onHistorySearchChange={setHistorySearch}
 						/>
 					</ResizablePanel>
-					{(leftMenuOpen || isPanelAnimating) && <ResizableHandle />}
-					<ResizablePanel
-						defaultSize={80}
-						minSize={40}
-						className={
-							isPanelAnimating ? "transition-[flex-grow] duration-200" : ""
-						}
-					>
+					{leftMenuOpen && <ResizableHandle />}
+					<ResizablePanel defaultSize={80} minSize={40}>
 						<div className="flex flex-col h-full min-w-0">
 							<div className="flex h-10 w-full">
 								<LeftMenuToggle
-									onClose={() => {
-										setIsPanelAnimating(true);
-										leftPanelRef.current?.collapse();
-										setTimeout(() => setIsPanelAnimating(false), 200);
-									}}
-									onOpen={() => {
-										setIsPanelAnimating(true);
-										leftPanelRef.current?.expand();
-										setTimeout(() => setIsPanelAnimating(false), 200);
-									}}
+									onClose={() => leftPanelRef.current?.collapse()}
+									onOpen={() => leftPanelRef.current?.expand()}
 								/>
 								<div className="grow min-w-0">
 									<ActiveTabs


### PR DESCRIPTION
## Summary

- **Notebook editor**: always-visible Send/Run buttons; cell headers get icons (REST/SQL/ViewDefinition/SQLQuery/Markdown); REST cell drops Raw/Params/Headers tabs (always raw) and ships with `Content-Type: application/json` + `Accept: application/json`; Markdown cell drops Edit/Preview tabs; delete button moves to the right with neutral gray; header gains a Preview toggle that opens a resizable read-only pane mirroring ResourceEditor split.
- **Multi-result panel** (notebooks SQL cell, db-console, ViewDefinition): replaces the vertical resizable stack with browser-style tabs (`Tabs variant="browser"` + `TabsBrowserList`) — per-tab row count, error indicator, dropdown picker with scroll-into-view.
- **Resource Browser** (`/u/resource`): virtualized list, `React.memo(ItemCard)` + stable callbacks, local-input + `useDeferredValue` + 200 ms debounced URL sync (search input no longer blocks on Fuse over hundreds of items), single blue chip style, `&abstract=false` added to the StructureDefinition search.
- **REST console**: instant left sidebar open/close (drops the 200 ms `transition-[flex-grow]` animation).
- **Notebooks index**: `React.memo(NotebookRow)`, `useCallback(addTag)`, virtualized list.
- **SDK bump**: `@health-samurai/react-components` carries the trackpad horizontal-wheel scroll fix used by the SQL cell result tabs.

## Test plan

- [ ] Open a notebook with REST/SQL/ViewDefinition/SQLQuery/Markdown cells — verify icons, no hover-gated buttons, Send/Run text stays constant, delete button on the right.
- [ ] Create a REST cell — default body has Content-Type/Accept JSON headers; no Raw/Params/Headers tabs.
- [ ] Markdown cell — no Edit/Preview tabs, always editable.
- [ ] Click Preview toggle in notebook header — split pane appears, Save/Delete on the left, "Preview" + X close on the right; close from X or toggle off.
- [ ] Run a SQL cell with 5+ queries — result tabs are browser-style; row count or error indicator shown; dropdown picker scrolls the chosen tab into view; mouse-wheel and trackpad horizontal swipes scroll the tab strip without bouncing back.
- [ ] `/u/resource`: type in search — input stays responsive; chips render in blue; result list is virtualized; URL updates ~200 ms after last keystroke.
- [ ] `/u/rest`: toggle left sidebar — opens/closes instantly without animation.
- [ ] `/u/notebooks`: scrolling and focus navigation works the same as before with virtualization.