### PR TITLE
AsyncOperations: list + detail UI for async-api operations

### DIFF
--- a/src/components/AsyncOperations/api.ts
+++ b/src/components/AsyncOperations/api.ts
@@ -1,0 +1,93 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useAidboxClient } from "../../AidboxClient";
+import type {
+	AsyncOperationStatusResponse,
+	AsyncOperationsListResponse,
+	ListQuery,
+} from "./types";
+
+const LIST_KEY = ["async-operations", "list"] as const;
+const STATUS_KEY = (id: string) => ["async-operations", "status", id] as const;
+
+function buildListUrl(q: ListQuery): string {
+	const params = new URLSearchParams();
+	if (q.statusFilter !== "all") params.set("status", q.statusFilter);
+	if (q.taskName.trim()) params.set("task-name", q.taskName.trim());
+	params.set("sort", q.sortField);
+	params.set("order", q.sortOrder);
+	const qs = params.toString();
+	return qs ? `/$async-operations?${qs}` : "/$async-operations";
+}
+
+export function useAsyncOperationsList(query: ListQuery) {
+	const client = useAidboxClient();
+
+	return useQuery({
+		queryKey: [
+			...LIST_KEY,
+			query.statusFilter,
+			query.taskName.trim(),
+			query.sortField,
+			query.sortOrder,
+		],
+		queryFn: async () => {
+			const result = await client.request<AsyncOperationsListResponse>({
+				method: "GET",
+				url: buildListUrl(query),
+			});
+			if (result.isOk()) {
+				return result.value.resource;
+			}
+			throw new Error("Failed to fetch async operations");
+		},
+		refetchInterval: 10_000,
+		refetchOnWindowFocus: false,
+	});
+}
+
+export function useAsyncOperationStatus(operationId: string | undefined) {
+	const client = useAidboxClient();
+
+	return useQuery({
+		queryKey: operationId
+			? STATUS_KEY(operationId)
+			: ["async-operations", "status", "none"],
+		enabled: !!operationId,
+		queryFn: async () => {
+			const result = await client.request<AsyncOperationStatusResponse>({
+				method: "GET",
+				url: `/$async-operations/${encodeURIComponent(operationId ?? "")}`,
+			});
+			if (result.isOk()) {
+				return result.value.resource;
+			}
+			throw new Error("Failed to fetch async operation status");
+		},
+		refetchInterval: (query) => {
+			const data = query.state.data as AsyncOperationStatusResponse | undefined;
+			return data?.status === "in-progress" ? 5_000 : false;
+		},
+		refetchOnWindowFocus: false,
+	});
+}
+
+export function useCancelAsyncOperation() {
+	const client = useAidboxClient();
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: async (operationId: string) => {
+			const result = await client.request<unknown>({
+				method: "POST",
+				url: `/$async-operations/${encodeURIComponent(operationId)}/$cancel`,
+				body: "{}",
+			});
+			if (result.isOk()) return result.value.resource;
+			throw new Error("Failed to cancel async operation");
+		},
+		onSuccess: (_data, operationId) => {
+			queryClient.invalidateQueries({ queryKey: LIST_KEY });
+			queryClient.invalidateQueries({ queryKey: STATUS_KEY(operationId) });
+		},
+	});
+}

--- a/src/components/AsyncOperations/detail.tsx
+++ b/src/components/AsyncOperations/detail.tsx
@@ -1,0 +1,313 @@
+import {
+	Button,
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+	Tabs,
+	TabsContent,
+	TabsList,
+	TabsTrigger,
+} from "@health-samurai/react-components";
+import { Link } from "@tanstack/react-router";
+import { AlertCircle, ArrowLeft, RefreshCw, XCircle } from "lucide-react";
+import { useState } from "react";
+import { useAsyncOperationStatus, useCancelAsyncOperation } from "./api";
+import { StatusBadge } from "./status-badge";
+import type { AsyncOperationStatus, AsyncOperationTask } from "./types";
+import { formatDateTime } from "./utils";
+
+function aggregate(tasks: AsyncOperationTask[]) {
+	const total = tasks.length;
+	const succeeded = tasks.filter((t) => t.success === true).length;
+	const failed = tasks.filter((t) => t.success === false).length;
+	const pending = total - succeeded - failed;
+	return { total, succeeded, failed, pending };
+}
+
+const PROGRESS_BAR_COLOR: Record<AsyncOperationStatus, string> = {
+	completed: "bg-utility-green",
+	failed: "bg-utility-red",
+	cancelled: "bg-utility-yellow",
+	"in-progress": "bg-utility-blue",
+};
+
+function ProgressBar({
+	status,
+	counts,
+}: {
+	status: AsyncOperationStatus | "not-found";
+	counts: { total: number; succeeded: number; failed: number };
+}) {
+	if (status === "not-found" || counts.total === 0) return null;
+	const done = counts.succeeded + counts.failed;
+	// Show 100% on terminal states regardless of recorded count — operations can
+	// finish via cancel-marker without all chunks landing.
+	const pct =
+		status === "in-progress" ? Math.min(100, (done / counts.total) * 100) : 100;
+	const color = PROGRESS_BAR_COLOR[status];
+	return (
+		<div className="h-2 rounded bg-bg-tertiary overflow-hidden">
+			<div
+				className={`h-full transition-[width] duration-300 ease-in-out ${color}`}
+				style={{ width: `${pct}%` }}
+			/>
+		</div>
+	);
+}
+
+function getString(
+	obj: Record<string, unknown> | null,
+	key: string,
+): string | null {
+	if (!obj) return null;
+	const v = obj[key];
+	return typeof v === "string" && v.length > 0 ? v : null;
+}
+
+function findFailureMessage(tasks: AsyncOperationTask[]): {
+	taskInstance: string;
+	message: string;
+} | null {
+	for (const t of tasks) {
+		if (t.success === false) {
+			const msg =
+				getString(t.task_outcome, "message") ??
+				getString(t.task_outcome, "error") ??
+				"Task failed (no error message recorded)";
+			return { taskInstance: t.task_instance, message: msg };
+		}
+	}
+	return null;
+}
+
+function JsonBlock({ value }: { value: unknown }) {
+	const text =
+		value === null || value === undefined
+			? "—"
+			: JSON.stringify(value, null, 2);
+	return (
+		<pre className="text-xs bg-bg-secondary border border-border-secondary rounded p-2 overflow-auto max-h-72 whitespace-pre-wrap break-words">
+			{text}
+		</pre>
+	);
+}
+
+export function AsyncOperationDetail({ operationId }: { operationId: string }) {
+	const [tab, setTab] = useState("tasks");
+	const { data, isLoading, refetch, isFetching, error } =
+		useAsyncOperationStatus(operationId);
+	const cancel = useCancelAsyncOperation();
+
+	if (isLoading) {
+		return (
+			<div className="flex items-center justify-center h-full text-text-secondary">
+				Loading...
+			</div>
+		);
+	}
+
+	if (error || !data) {
+		return (
+			<div className="flex flex-col items-center justify-center h-full gap-3 text-text-secondary">
+				<div>Failed to load operation</div>
+				<Button variant="secondary" size="small" onClick={() => refetch()}>
+					Retry
+				</Button>
+			</div>
+		);
+	}
+
+	const status = data.status;
+	const tasks = data.tasks ?? [];
+	const counts = aggregate(tasks);
+	const isActive = status === "in-progress";
+	const failure =
+		status === "failed" || counts.failed > 0 ? findFailureMessage(tasks) : null;
+
+	return (
+		<div className="flex flex-col h-full">
+			<div className="flex items-center gap-3 px-4 h-12 border-b border-border-secondary bg-bg-secondary">
+				<Link
+					to="/async-operations"
+					className="text-text-link hover:underline flex items-center gap-1"
+				>
+					<ArrowLeft className="size-4" />
+					Operations
+				</Link>
+				<span className="text-text-secondary">/</span>
+				<span className="font-mono text-sm truncate" title={operationId}>
+					{operationId}
+				</span>
+				<div className="ml-auto flex items-center gap-2">
+					<Button
+						variant="ghost"
+						size="small"
+						onClick={() => refetch()}
+						disabled={isFetching}
+					>
+						<RefreshCw
+							className={isFetching ? "animate-spin size-4" : "size-4"}
+						/>
+						Refresh
+					</Button>
+					{isActive ? (
+						<Button
+							variant="secondary"
+							danger
+							size="small"
+							disabled={cancel.isPending}
+							onClick={() => {
+								if (
+									window.confirm(
+										"Cancel this async operation? Active tasks will be removed.",
+									)
+								) {
+									cancel.mutate(operationId);
+								}
+							}}
+						>
+							<XCircle className="size-4" />
+							Cancel
+						</Button>
+					) : null}
+				</div>
+			</div>
+
+			<div className="flex flex-col gap-3 px-4 py-3 border-b border-border-secondary">
+				<div className="flex items-center gap-6">
+					<div className="flex items-center gap-2">
+						<span className="text-text-secondary text-sm">Status:</span>
+						<StatusBadge status={status} />
+					</div>
+					<div className="text-sm text-text-secondary tabular-nums">
+						{counts.succeeded}/{counts.total} succeeded
+						{counts.failed > 0 ? (
+							<span className="text-text-error-primary ml-2">
+								{counts.failed} failed
+							</span>
+						) : null}
+						{counts.pending > 0 ? (
+							<span className="ml-2">{counts.pending} pending</span>
+						) : null}
+					</div>
+				</div>
+				<ProgressBar status={status} counts={counts} />
+			</div>
+
+			{failure ? (
+				<div className="mx-4 mt-3 flex items-start gap-2 rounded border border-border-error bg-bg-error-secondary p-3 text-sm">
+					<AlertCircle className="size-4 mt-0.5 shrink-0 text-text-error-primary" />
+					<div className="min-w-0 flex-1">
+						<div className="text-text-error-primary font-medium">
+							{status === "failed" ? "Operation failed" : "A task failed"}
+						</div>
+						<div className="text-text-error-primary mt-0.5 break-words">
+							{failure.message}
+						</div>
+						<div className="text-text-secondary text-xs mt-1 font-mono break-all">
+							{failure.taskInstance}
+						</div>
+					</div>
+				</div>
+			) : null}
+
+			<div className="flex-1 overflow-auto p-4">
+				<Tabs value={tab} onValueChange={setTab}>
+					<TabsList>
+						<TabsTrigger value="tasks">Tasks ({tasks.length})</TabsTrigger>
+						<TabsTrigger value="raw">Raw JSON</TabsTrigger>
+					</TabsList>
+
+					<TabsContent value="tasks" className="mt-3">
+						{tasks.length === 0 ? (
+							<div className="text-text-secondary text-sm py-6 text-center">
+								No tasks recorded for this operation
+							</div>
+						) : (
+							<Table>
+								<TableHeader>
+									<TableRow>
+										<TableHead>Task instance</TableHead>
+										<TableHead>Task name</TableHead>
+										<TableHead>Success</TableHead>
+										<TableHead className="whitespace-nowrap">Started</TableHead>
+										<TableHead className="whitespace-nowrap">Done</TableHead>
+										<TableHead>Attempt</TableHead>
+									</TableRow>
+								</TableHeader>
+								<TableBody>
+									{tasks.map((t) => (
+										<TaskRow key={t.task_instance} task={t} />
+									))}
+								</TableBody>
+							</Table>
+						)}
+					</TabsContent>
+
+					<TabsContent value="raw" className="mt-3">
+						<JsonBlock value={data} />
+					</TabsContent>
+				</Tabs>
+			</div>
+		</div>
+	);
+}
+
+function TaskRow({ task }: { task: AsyncOperationTask }) {
+	const [expanded, setExpanded] = useState(false);
+	const successLabel =
+		task.success === true ? "yes" : task.success === false ? "no" : "—";
+	const successClass =
+		task.success === true
+			? "text-utility-green"
+			: task.success === false
+				? "text-utility-red"
+				: "text-text-secondary";
+
+	return (
+		<>
+			<TableRow
+				className="cursor-pointer"
+				onClick={() => setExpanded((v) => !v)}
+			>
+				<TableCell className="font-mono text-xs max-w-0 truncate">
+					{task.task_instance}
+				</TableCell>
+				<TableCell className="whitespace-nowrap text-xs">
+					{task.task_name}
+				</TableCell>
+				<TableCell className={successClass}>{successLabel}</TableCell>
+				<TableCell className="whitespace-nowrap text-text-secondary text-xs">
+					{formatDateTime(task.time_started ?? task.execution_time)}
+				</TableCell>
+				<TableCell className="whitespace-nowrap text-text-secondary text-xs">
+					{formatDateTime(task.time_done)}
+				</TableCell>
+				<TableCell className="text-text-secondary text-xs tabular-nums">
+					{task.attempt ?? "—"}
+				</TableCell>
+			</TableRow>
+			{expanded ? (
+				<tr className="bg-bg-secondary">
+					<td colSpan={6} className="p-3">
+						<div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+							<div>
+								<div className="text-xs text-text-secondary mb-1">
+									Input (task_data)
+								</div>
+								<JsonBlock value={task.task_data} />
+							</div>
+							<div>
+								<div className="text-xs text-text-secondary mb-1">Outcome</div>
+								<JsonBlock value={task.task_outcome} />
+							</div>
+						</div>
+					</td>
+				</tr>
+			) : null}
+		</>
+	);
+}

--- a/src/components/AsyncOperations/detail.tsx
+++ b/src/components/AsyncOperations/detail.tsx
@@ -1,4 +1,7 @@
 import {
+	Alert,
+	AlertDescription,
+	AlertTitle,
 	Button,
 	Table,
 	TableBody,
@@ -198,20 +201,18 @@ export function AsyncOperationDetail({ operationId }: { operationId: string }) {
 			</div>
 
 			{failure ? (
-				<div className="mx-4 mt-3 flex items-start gap-2 rounded border border-border-error bg-bg-error-secondary p-3 text-sm">
-					<AlertCircle className="size-4 mt-0.5 shrink-0 text-text-error-primary" />
-					<div className="min-w-0 flex-1">
-						<div className="text-text-error-primary font-medium">
-							{status === "failed" ? "Operation failed" : "A task failed"}
-						</div>
-						<div className="text-text-error-primary mt-0.5 break-words">
-							{failure.message}
-						</div>
-						<div className="text-text-secondary text-xs mt-1 font-mono break-all">
-							{failure.taskInstance}
-						</div>
-					</div>
-				</div>
+				<Alert variant="critical" className="mx-4 mt-3">
+					<AlertCircle />
+					<AlertTitle>
+						{status === "failed" ? "Operation failed" : "A task failed"}
+					</AlertTitle>
+					<AlertDescription className="break-words">
+						{failure.message}
+					</AlertDescription>
+					<AlertDescription className="text-text-secondary text-xs font-mono break-all">
+						{failure.taskInstance}
+					</AlertDescription>
+				</Alert>
 			) : null}
 
 			<div className="flex-1 overflow-auto p-4">

--- a/src/components/AsyncOperations/page.tsx
+++ b/src/components/AsyncOperations/page.tsx
@@ -1,0 +1,216 @@
+import {
+	Button,
+	Input,
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@health-samurai/react-components";
+import { Link } from "@tanstack/react-router";
+import { ArrowDown, ArrowUp, ArrowUpDown, RefreshCw } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useAsyncOperationsList } from "./api";
+import { StatusBadge } from "./status-badge";
+import {
+	type AsyncOperationStatus,
+	DEFAULT_LIST_QUERY,
+	type ListQuery,
+	type SortField,
+	STATUS_FILTER_OPTIONS,
+} from "./types";
+import { formatDateTime } from "./utils";
+
+function SortHeader({
+	label,
+	field,
+	query,
+	onSort,
+}: {
+	label: string;
+	field: SortField;
+	query: ListQuery;
+	onSort: (field: SortField) => void;
+}) {
+	const active = query.sortField === field;
+	const Icon = !active
+		? ArrowUpDown
+		: query.sortOrder === "asc"
+			? ArrowUp
+			: ArrowDown;
+	return (
+		<TableHead className="whitespace-nowrap">
+			<button
+				type="button"
+				className={`inline-flex items-center gap-1 cursor-pointer hover:text-text-primary ${active ? "text-text-primary font-medium" : "text-text-secondary"}`}
+				onClick={() => onSort(field)}
+			>
+				{label}
+				<Icon className="size-3" />
+			</button>
+		</TableHead>
+	);
+}
+
+export function AsyncOperationsPage() {
+	const [query, setQuery] = useState<ListQuery>(DEFAULT_LIST_QUERY);
+	// Local input value, debounced into query.taskName so we don't refetch on every keystroke.
+	const [taskNameInput, setTaskNameInput] = useState("");
+	useEffect(() => {
+		const t = setTimeout(() => {
+			setQuery((prev) =>
+				prev.taskName === taskNameInput
+					? prev
+					: { ...prev, taskName: taskNameInput },
+			);
+		}, 300);
+		return () => clearTimeout(t);
+	}, [taskNameInput]);
+
+	const { data, isLoading, refetch, isFetching } =
+		useAsyncOperationsList(query);
+
+	const operations = data?.operations ?? [];
+	const total = data?.total ?? 0;
+
+	const toggleSort = (field: SortField) => {
+		setQuery((prev) =>
+			prev.sortField === field
+				? { ...prev, sortOrder: prev.sortOrder === "asc" ? "desc" : "asc" }
+				: { ...prev, sortField: field, sortOrder: "desc" },
+		);
+	};
+
+	return (
+		<div className="flex flex-col h-full">
+			<div className="flex items-center justify-between gap-3 px-4 h-12 border-b border-border-secondary bg-bg-secondary">
+				<div className="flex items-center gap-3 flex-1 min-w-0">
+					<Select
+						value={query.statusFilter}
+						onValueChange={(v) =>
+							setQuery((prev) => ({
+								...prev,
+								statusFilter: v as AsyncOperationStatus | "all",
+							}))
+						}
+					>
+						<SelectTrigger className="w-44 h-8">
+							<SelectValue placeholder="Status" />
+						</SelectTrigger>
+						<SelectContent>
+							{STATUS_FILTER_OPTIONS.map((opt) => (
+								<SelectItem key={opt.value} value={opt.value}>
+									{opt.label}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+					<Input
+						className="h-8 max-w-72"
+						placeholder="Filter by task name..."
+						value={taskNameInput}
+						onChange={(e) => setTaskNameInput(e.target.value)}
+					/>
+					<Button
+						variant="ghost"
+						size="small"
+						onClick={() => refetch()}
+						disabled={isFetching}
+					>
+						<RefreshCw
+							className={isFetching ? "animate-spin size-4" : "size-4"}
+						/>
+						Refresh
+					</Button>
+				</div>
+				<span className="text-text-secondary text-sm whitespace-nowrap">
+					{total} operation{total === 1 ? "" : "s"}
+				</span>
+			</div>
+
+			<div className="flex-1 overflow-auto">
+				{isLoading ? (
+					<div className="flex items-center justify-center h-full text-text-secondary">
+						Loading...
+					</div>
+				) : operations.length === 0 ? (
+					<div className="flex items-center justify-center h-full text-text-secondary">
+						No async operations found
+					</div>
+				) : (
+					<Table stickyHeader>
+						<TableHeader>
+							<TableRow>
+								<TableHead>Operation</TableHead>
+								<TableHead>Task</TableHead>
+								<TableHead>Status</TableHead>
+								<TableHead className="text-right">Tasks</TableHead>
+								<SortHeader
+									label="Created"
+									field="created-at"
+									query={query}
+									onSort={toggleSort}
+								/>
+								<SortHeader
+									label="Last updated"
+									field="last-updated"
+									query={query}
+									onSort={toggleSort}
+								/>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{operations.map((op) => {
+								const id = op["operation-id"];
+								return (
+									<TableRow key={id}>
+										<TableCell className="max-w-0 truncate">
+											<Link
+												to="/async-operations/$operationId"
+												params={{ operationId: id }}
+												className="text-text-link hover:underline font-medium"
+												title={id}
+											>
+												{id}
+											</Link>
+										</TableCell>
+										<TableCell className="whitespace-nowrap">
+											{op["task-name"] ?? "—"}
+										</TableCell>
+										<TableCell>
+											<StatusBadge status={op.status} />
+										</TableCell>
+										<TableCell className="text-right text-text-secondary tabular-nums">
+											<span
+												title={`active=${op.active} succeeded=${op.succeeded} failed=${op.failed}`}
+											>
+												{op.succeeded}/{op.total}
+												{op.failed > 0 ? (
+													<span className="text-text-error-primary ml-1">
+														({op.failed} failed)
+													</span>
+												) : null}
+											</span>
+										</TableCell>
+										<TableCell className="whitespace-nowrap text-text-secondary">
+											{formatDateTime(op["created-at"])}
+										</TableCell>
+										<TableCell className="whitespace-nowrap text-text-secondary">
+											{formatDateTime(op["last-updated"])}
+										</TableCell>
+									</TableRow>
+								);
+							})}
+						</TableBody>
+					</Table>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/src/components/AsyncOperations/status-badge.tsx
+++ b/src/components/AsyncOperations/status-badge.tsx
@@ -1,0 +1,26 @@
+import { Badge } from "@health-samurai/react-components";
+import type { AsyncOperationStatus } from "./types";
+import { STATUS_LABEL } from "./types";
+
+const STATUS_CLASSES: Record<AsyncOperationStatus, string> = {
+	completed:
+		"border-transparent bg-utility-green/15 text-utility-green dark:text-utility-green",
+	failed: "border-transparent bg-utility-red/15 text-utility-red",
+	cancelled: "border-transparent bg-utility-yellow/15 text-utility-yellow",
+	"in-progress": "border-transparent bg-utility-blue/15 text-utility-blue",
+};
+
+export function StatusBadge({
+	status,
+}: {
+	status: AsyncOperationStatus | "not-found";
+}) {
+	if (status === "not-found") {
+		return <Badge variant="outline">Not found</Badge>;
+	}
+	return (
+		<Badge variant="outline" className={STATUS_CLASSES[status]}>
+			{STATUS_LABEL[status]}
+		</Badge>
+	);
+}

--- a/src/components/AsyncOperations/types.ts
+++ b/src/components/AsyncOperations/types.ts
@@ -1,0 +1,75 @@
+export type AsyncOperationStatus =
+	| "in-progress"
+	| "completed"
+	| "failed"
+	| "cancelled";
+
+export interface AsyncOperationSummary {
+	"operation-id": string;
+	status: AsyncOperationStatus;
+	"task-name": string | null;
+	total: number;
+	active: number;
+	succeeded: number;
+	failed: number;
+	"created-at": string | null;
+	"last-updated": string | null;
+}
+
+export interface AsyncOperationsListResponse {
+	operations: AsyncOperationSummary[];
+	total: number;
+}
+
+export interface AsyncOperationTask {
+	task_name: string;
+	task_instance: string;
+	task_data: Record<string, unknown> | null;
+	task_outcome: Record<string, unknown> | null;
+	success?: boolean | null;
+	time_started?: string | null;
+	time_done?: string | null;
+	attempt?: number | null;
+	execution_time?: string | null;
+}
+
+export interface AsyncOperationStatusResponse {
+	"operation-id": string;
+	status: AsyncOperationStatus | "not-found";
+	tasks: AsyncOperationTask[];
+}
+
+export const STATUS_FILTER_OPTIONS: {
+	value: AsyncOperationStatus | "all";
+	label: string;
+}[] = [
+	{ value: "all", label: "All" },
+	{ value: "in-progress", label: "In progress" },
+	{ value: "completed", label: "Completed" },
+	{ value: "failed", label: "Failed" },
+	{ value: "cancelled", label: "Cancelled" },
+];
+
+export const STATUS_LABEL: Record<AsyncOperationStatus, string> = {
+	"in-progress": "In progress",
+	completed: "Completed",
+	failed: "Failed",
+	cancelled: "Cancelled",
+};
+
+export type SortField = "created-at" | "last-updated";
+export type SortOrder = "asc" | "desc";
+
+export interface ListQuery {
+	statusFilter: AsyncOperationStatus | "all";
+	taskName: string;
+	sortField: SortField;
+	sortOrder: SortOrder;
+}
+
+export const DEFAULT_LIST_QUERY: ListQuery = {
+	statusFilter: "all",
+	taskName: "",
+	sortField: "last-updated",
+	sortOrder: "desc",
+};

--- a/src/components/AsyncOperations/utils.ts
+++ b/src/components/AsyncOperations/utils.ts
@@ -1,0 +1,6 @@
+export function formatDateTime(value: string | null | undefined): string {
+	if (!value) return "—";
+	const d = new Date(value);
+	if (Number.isNaN(d.getTime())) return value;
+	return d.toLocaleString();
+}

--- a/src/layout/sidebar.tsx
+++ b/src/layout/sidebar.tsx
@@ -15,6 +15,7 @@ import {
 	ClipboardList,
 	Columns3Cog,
 	Database,
+	ListChecks,
 	Notebook,
 	Package,
 	PanelLeftClose,
@@ -120,6 +121,16 @@ const mainMenuItems: {
 			<Link to="/audit-events">
 				<ShieldUser />
 				Audit events
+			</Link>
+		),
+	},
+	{
+		url: "/async-operations",
+		title: "Async operations",
+		link: (
+			<Link to="/async-operations">
+				<ListChecks />
+				Async operations
 			</Link>
 		),
 	},

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -16,17 +16,20 @@ import { Route as NotebooksRouteImport } from './routes/notebooks'
 import { Route as IgRouteImport } from './routes/ig'
 import { Route as DbConsoleRouteImport } from './routes/db-console'
 import { Route as AuditEventsRouteImport } from './routes/audit-events'
+import { Route as AsyncOperationsRouteImport } from './routes/async-operations'
 import { Route as AnalyticsRouteImport } from './routes/analytics'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ResourceIndexRouteImport } from './routes/resource.index'
 import { Route as NotebooksIndexRouteImport } from './routes/notebooks.index'
 import { Route as IgIndexRouteImport } from './routes/ig.index'
+import { Route as AsyncOperationsIndexRouteImport } from './routes/async-operations.index'
 import { Route as AnalyticsIndexRouteImport } from './routes/analytics.index'
 import { Route as ResourceResourceTypeRouteImport } from './routes/resource.$resourceType'
 import { Route as NotebooksNewRouteImport } from './routes/notebooks.new'
 import { Route as NotebooksIdRouteImport } from './routes/notebooks.$id'
 import { Route as IgAddRouteImport } from './routes/ig.add'
 import { Route as IgPackageIdRouteImport } from './routes/ig.$packageId'
+import { Route as AsyncOperationsOperationIdRouteImport } from './routes/async-operations.$operationId'
 import { Route as AnalyticsViewsRouteImport } from './routes/analytics.views'
 import { Route as AnalyticsQueriesRouteImport } from './routes/analytics.queries'
 import { Route as ResourceResourceTypeIndexRouteImport } from './routes/resource.$resourceType.index'
@@ -77,6 +80,11 @@ const AuditEventsRoute = AuditEventsRouteImport.update({
   path: '/audit-events',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AsyncOperationsRoute = AsyncOperationsRouteImport.update({
+  id: '/async-operations',
+  path: '/async-operations',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AnalyticsRoute = AnalyticsRouteImport.update({
   id: '/analytics',
   path: '/analytics',
@@ -101,6 +109,11 @@ const IgIndexRoute = IgIndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => IgRoute,
+} as any)
+const AsyncOperationsIndexRoute = AsyncOperationsIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => AsyncOperationsRoute,
 } as any)
 const AnalyticsIndexRoute = AnalyticsIndexRouteImport.update({
   id: '/',
@@ -132,6 +145,12 @@ const IgPackageIdRoute = IgPackageIdRouteImport.update({
   path: '/$packageId',
   getParentRoute: () => IgRoute,
 } as any)
+const AsyncOperationsOperationIdRoute =
+  AsyncOperationsOperationIdRouteImport.update({
+    id: '/$operationId',
+    path: '/$operationId',
+    getParentRoute: () => AsyncOperationsRoute,
+  } as any)
 const AnalyticsViewsRoute = AnalyticsViewsRouteImport.update({
   id: '/views',
   path: '/views',
@@ -210,6 +229,7 @@ const IgPackageIdResourceResourceTypeResourceIdRoute =
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/analytics': typeof AnalyticsRouteWithChildren
+  '/async-operations': typeof AsyncOperationsRouteWithChildren
   '/audit-events': typeof AuditEventsRoute
   '/db-console': typeof DbConsoleRoute
   '/ig': typeof IgRouteWithChildren
@@ -219,12 +239,14 @@ export interface FileRoutesByFullPath {
   '/settings': typeof SettingsRoute
   '/analytics/queries': typeof AnalyticsQueriesRouteWithChildren
   '/analytics/views': typeof AnalyticsViewsRouteWithChildren
+  '/async-operations/$operationId': typeof AsyncOperationsOperationIdRoute
   '/ig/$packageId': typeof IgPackageIdRouteWithChildren
   '/ig/add': typeof IgAddRoute
   '/notebooks/$id': typeof NotebooksIdRoute
   '/notebooks/new': typeof NotebooksNewRoute
   '/resource/$resourceType': typeof ResourceResourceTypeRouteWithChildren
   '/analytics/': typeof AnalyticsIndexRoute
+  '/async-operations/': typeof AsyncOperationsIndexRoute
   '/ig/': typeof IgIndexRoute
   '/notebooks/': typeof NotebooksIndexRoute
   '/resource/': typeof ResourceIndexRoute
@@ -247,10 +269,12 @@ export interface FileRoutesByTo {
   '/db-console': typeof DbConsoleRoute
   '/rest': typeof RestRoute
   '/settings': typeof SettingsRoute
+  '/async-operations/$operationId': typeof AsyncOperationsOperationIdRoute
   '/ig/add': typeof IgAddRoute
   '/notebooks/$id': typeof NotebooksIdRoute
   '/notebooks/new': typeof NotebooksNewRoute
   '/analytics': typeof AnalyticsIndexRoute
+  '/async-operations': typeof AsyncOperationsIndexRoute
   '/ig': typeof IgIndexRoute
   '/notebooks': typeof NotebooksIndexRoute
   '/resource': typeof ResourceIndexRoute
@@ -271,6 +295,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/analytics': typeof AnalyticsRouteWithChildren
+  '/async-operations': typeof AsyncOperationsRouteWithChildren
   '/audit-events': typeof AuditEventsRoute
   '/db-console': typeof DbConsoleRoute
   '/ig': typeof IgRouteWithChildren
@@ -280,12 +305,14 @@ export interface FileRoutesById {
   '/settings': typeof SettingsRoute
   '/analytics/queries': typeof AnalyticsQueriesRouteWithChildren
   '/analytics/views': typeof AnalyticsViewsRouteWithChildren
+  '/async-operations/$operationId': typeof AsyncOperationsOperationIdRoute
   '/ig/$packageId': typeof IgPackageIdRouteWithChildren
   '/ig/add': typeof IgAddRoute
   '/notebooks/$id': typeof NotebooksIdRoute
   '/notebooks/new': typeof NotebooksNewRoute
   '/resource/$resourceType': typeof ResourceResourceTypeRouteWithChildren
   '/analytics/': typeof AnalyticsIndexRoute
+  '/async-operations/': typeof AsyncOperationsIndexRoute
   '/ig/': typeof IgIndexRoute
   '/notebooks/': typeof NotebooksIndexRoute
   '/resource/': typeof ResourceIndexRoute
@@ -307,6 +334,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/analytics'
+    | '/async-operations'
     | '/audit-events'
     | '/db-console'
     | '/ig'
@@ -316,12 +344,14 @@ export interface FileRouteTypes {
     | '/settings'
     | '/analytics/queries'
     | '/analytics/views'
+    | '/async-operations/$operationId'
     | '/ig/$packageId'
     | '/ig/add'
     | '/notebooks/$id'
     | '/notebooks/new'
     | '/resource/$resourceType'
     | '/analytics/'
+    | '/async-operations/'
     | '/ig/'
     | '/notebooks/'
     | '/resource/'
@@ -344,10 +374,12 @@ export interface FileRouteTypes {
     | '/db-console'
     | '/rest'
     | '/settings'
+    | '/async-operations/$operationId'
     | '/ig/add'
     | '/notebooks/$id'
     | '/notebooks/new'
     | '/analytics'
+    | '/async-operations'
     | '/ig'
     | '/notebooks'
     | '/resource'
@@ -367,6 +399,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/analytics'
+    | '/async-operations'
     | '/audit-events'
     | '/db-console'
     | '/ig'
@@ -376,12 +409,14 @@ export interface FileRouteTypes {
     | '/settings'
     | '/analytics/queries'
     | '/analytics/views'
+    | '/async-operations/$operationId'
     | '/ig/$packageId'
     | '/ig/add'
     | '/notebooks/$id'
     | '/notebooks/new'
     | '/resource/$resourceType'
     | '/analytics/'
+    | '/async-operations/'
     | '/ig/'
     | '/notebooks/'
     | '/resource/'
@@ -402,6 +437,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AnalyticsRoute: typeof AnalyticsRouteWithChildren
+  AsyncOperationsRoute: typeof AsyncOperationsRouteWithChildren
   AuditEventsRoute: typeof AuditEventsRoute
   DbConsoleRoute: typeof DbConsoleRoute
   IgRoute: typeof IgRouteWithChildren
@@ -462,6 +498,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuditEventsRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/async-operations': {
+      id: '/async-operations'
+      path: '/async-operations'
+      fullPath: '/async-operations'
+      preLoaderRoute: typeof AsyncOperationsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/analytics': {
       id: '/analytics'
       path: '/analytics'
@@ -496,6 +539,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/ig/'
       preLoaderRoute: typeof IgIndexRouteImport
       parentRoute: typeof IgRoute
+    }
+    '/async-operations/': {
+      id: '/async-operations/'
+      path: '/'
+      fullPath: '/async-operations/'
+      preLoaderRoute: typeof AsyncOperationsIndexRouteImport
+      parentRoute: typeof AsyncOperationsRoute
     }
     '/analytics/': {
       id: '/analytics/'
@@ -538,6 +588,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/ig/$packageId'
       preLoaderRoute: typeof IgPackageIdRouteImport
       parentRoute: typeof IgRoute
+    }
+    '/async-operations/$operationId': {
+      id: '/async-operations/$operationId'
+      path: '/$operationId'
+      fullPath: '/async-operations/$operationId'
+      preLoaderRoute: typeof AsyncOperationsOperationIdRouteImport
+      parentRoute: typeof AsyncOperationsRoute
     }
     '/analytics/views': {
       id: '/analytics/views'
@@ -687,6 +744,20 @@ const AnalyticsRouteWithChildren = AnalyticsRoute._addFileChildren(
   AnalyticsRouteChildren,
 )
 
+interface AsyncOperationsRouteChildren {
+  AsyncOperationsOperationIdRoute: typeof AsyncOperationsOperationIdRoute
+  AsyncOperationsIndexRoute: typeof AsyncOperationsIndexRoute
+}
+
+const AsyncOperationsRouteChildren: AsyncOperationsRouteChildren = {
+  AsyncOperationsOperationIdRoute: AsyncOperationsOperationIdRoute,
+  AsyncOperationsIndexRoute: AsyncOperationsIndexRoute,
+}
+
+const AsyncOperationsRouteWithChildren = AsyncOperationsRoute._addFileChildren(
+  AsyncOperationsRouteChildren,
+)
+
 interface IgPackageIdRouteChildren {
   IgPackageIdIndexRoute: typeof IgPackageIdIndexRoute
   IgPackageIdResourceResourceTypeResourceIdRoute: typeof IgPackageIdResourceResourceTypeResourceIdRoute
@@ -766,6 +837,7 @@ const ResourceRouteWithChildren = ResourceRoute._addFileChildren(
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AnalyticsRoute: AnalyticsRouteWithChildren,
+  AsyncOperationsRoute: AsyncOperationsRouteWithChildren,
   AuditEventsRoute: AuditEventsRoute,
   DbConsoleRoute: DbConsoleRoute,
   IgRoute: IgRouteWithChildren,

--- a/src/routes/async-operations.$operationId.tsx
+++ b/src/routes/async-operations.$operationId.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { AsyncOperationDetail } from "../components/AsyncOperations/detail";
+
+export const Route = createFileRoute("/async-operations/$operationId")({
+	component: RouteComponent,
+});
+
+function RouteComponent() {
+	const { operationId } = Route.useParams();
+	return <AsyncOperationDetail operationId={operationId} />;
+}

--- a/src/routes/async-operations.index.tsx
+++ b/src/routes/async-operations.index.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { AsyncOperationsPage } from "../components/AsyncOperations/page";
+
+export const Route = createFileRoute("/async-operations/")({
+	component: AsyncOperationsPage,
+});

--- a/src/routes/async-operations.tsx
+++ b/src/routes/async-operations.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute, Outlet } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/async-operations")({
+	staticData: { title: "Async operations" },
+	loader: () => ({ breadCrumb: "Async operations" }),
+	component: () => <Outlet />,
+});


### PR DESCRIPTION
## Summary

Adds a new top-level page **Async operations** to the Aidbox UI sidebar that surfaces async-api operations from `db_scheduler.scheduled_tasks(+_history)`.

### List view (`/async-operations`)
- Table grouped by `operation-id` with status / task / counts / created / last-updated columns
- Status filter (all / in-progress / completed / failed / cancelled)
- Task-name ilike filter (debounced 300ms)
- Sortable Created / Last updated columns
- 10s polling

### Detail view (`/async-operations/$operationId`)
- Status badge + progress bar (color by status)
- Red banner with first failed task's ex-message
- Expandable task table (per-task `task_data` input + `task_outcome` output as JSON)
- Cancel button while `in-progress`
- 5s polling while active, off when terminal

## Backend dependency

This UI calls three new endpoints on the aidbox side:
- `GET /$async-operations[?status=...&task-name=...&sort=...&order=...]`
- `GET /$async-operations/<id>`
- `POST /$async-operations/<id>/$cancel`

These ship in a parallel sansara PR. Until that lands the page will show "Failed to fetch async operations" — consider not merging this one ahead of the backend, or hiding the sidebar entry behind a feature probe (mirrors the audit-events approach).

## Test plan
- [ ] Backend PR merged + deployed
- [ ] `/u/async-operations` lists operations with correct counts
- [ ] Status filter narrows the table
- [ ] Task-name filter narrows the table after ~300ms
- [ ] Created / Last updated column headers toggle sort direction
- [ ] Detail page shows progress bar and task table
- [ ] Failed operation surfaces ex-message banner
- [ ] Cancel button appears for in-progress, hidden for terminal states
- [ ] Cancel mutation flips status to `cancelled`

🤖 Generated with [Claude Code](https://claude.com/claude-code)