### PR TITLE
Notebooks: read-only view, Save a copy for community, id refs

### DIFF
--- a/src/components/notebook-resource-picker.tsx
+++ b/src/components/notebook-resource-picker.tsx
@@ -1,0 +1,309 @@
+import type { Bundle } from "@aidbox-ui/fhir-types/hl7-fhir-r5-core";
+import * as HSComp from "@health-samurai/react-components";
+import { useQuery } from "@tanstack/react-query";
+import { ChevronDown, FileCode2, Table } from "lucide-react";
+import * as React from "react";
+import { useAidboxClient } from "../AidboxClient";
+import {
+	SQL_QUERY_TYPE_CODE,
+	SQL_QUERY_TYPE_SYSTEM,
+} from "./SQLQueryBuilder/types";
+
+// Notebook-specific copy of the SQLQueryBuilder ResourcePicker. Unlike the
+// builder, notebooks don't persist a SQLQuery/ViewDefinition resource — they
+// just run an existing one — so a `url` is not required: candidates are listed
+// regardless of `url`, and the cell references the resource by `Type/id`.
+
+type CandidateKind = "ViewDefinition" | "SQLQuery";
+
+type RelatedArtifactRef = { url: string; label?: string };
+
+type CandidateOption = {
+	url?: string;
+	kind: CandidateKind;
+	id: string;
+	name?: string;
+	title?: string;
+	description?: string;
+	resource?: string;
+	relatedArtifacts?: RelatedArtifactRef[];
+	createdAt?: string;
+};
+
+type RawCandidate = {
+	id: string;
+	url?: string;
+	name?: string;
+	title?: string;
+	description?: string;
+	resource?: string;
+	relatedArtifact?: Array<{
+		type?: string;
+		label?: string;
+		resource?: string;
+	}>;
+	meta?: {
+		lastUpdated?: string;
+		extension?: Array<{ url?: string; valueInstant?: string }>;
+	};
+};
+
+function extractCreatedAt(r: RawCandidate): string | undefined {
+	const ext = r.meta?.extension;
+	if (!ext) return undefined;
+	for (const e of ext) {
+		if (e.valueInstant) return e.valueInstant;
+	}
+	return undefined;
+}
+
+function referenceFor(c: CandidateOption): string {
+	return `${c.kind === "SQLQuery" ? "Library" : "ViewDefinition"}/${c.id}`;
+}
+
+function Badge({ text, accentClass }: { text: string; accentClass: string }) {
+	return (
+		<span
+			className={`shrink-0 text-[11px] leading-4 normal-case whitespace-nowrap ${accentClass}`}
+		>
+			#{text}
+		</span>
+	);
+}
+
+const SQL_QUERY_TYPE_TOKEN = `${SQL_QUERY_TYPE_SYSTEM}|${SQL_QUERY_TYPE_CODE}`;
+
+function useDebouncedValue<T>(value: T, delay: number): T {
+	const [v, setV] = React.useState(value);
+	React.useEffect(() => {
+		const id = setTimeout(() => setV(value), delay);
+		return () => clearTimeout(id);
+	}, [value, delay]);
+	return v;
+}
+
+function useCandidates(
+	search: string,
+	enabled = true,
+	kinds: CandidateKind[] = ["ViewDefinition", "SQLQuery"],
+) {
+	const client = useAidboxClient();
+	const debouncedSearch = useDebouncedValue(search, 200);
+	const kindsKey = kinds.slice().sort().join(",");
+	return useQuery<CandidateOption[]>({
+		queryKey: ["notebook-resource-candidates", debouncedSearch, kindsKey],
+		enabled,
+		queryFn: async () => {
+			const baseParams: Array<[string, string]> = [
+				["_count", "1000"],
+				["_sort", "-_createdAt"],
+			];
+			if (debouncedSearch) baseParams.push(["_ilike", debouncedSearch]);
+			const want = (k: CandidateKind) => kinds.includes(k);
+			const [vd, lib] = await Promise.all([
+				want("ViewDefinition")
+					? client.request<Bundle>({
+							method: "GET",
+							url: "/fhir/ViewDefinition",
+							params: baseParams,
+						})
+					: null,
+				want("SQLQuery")
+					? client.request<Bundle>({
+							method: "GET",
+							url: "/fhir/Library",
+							params: [...baseParams, ["type", SQL_QUERY_TYPE_TOKEN]],
+						})
+					: null,
+			]);
+			const out: CandidateOption[] = [];
+			if (vd?.isOk()) {
+				for (const entry of vd.value.resource.entry ?? []) {
+					const r = entry.resource as unknown as RawCandidate;
+					out.push({
+						url: r.url,
+						kind: "ViewDefinition",
+						id: r.id,
+						name: r.name,
+						title: r.title,
+						description: r.description,
+						resource: r.resource,
+						createdAt: extractCreatedAt(r),
+					});
+				}
+			}
+			if (lib?.isOk()) {
+				for (const entry of lib.value.resource.entry ?? []) {
+					const r = entry.resource as unknown as RawCandidate;
+					const relatedArtifacts = (r.relatedArtifact ?? []).flatMap((ra) =>
+						ra.resource ? [{ url: ra.resource, label: ra.label }] : [],
+					);
+					out.push({
+						url: r.url,
+						kind: "SQLQuery",
+						id: r.id,
+						name: r.name,
+						title: r.title,
+						description: r.description,
+						relatedArtifacts:
+							relatedArtifacts.length > 0 ? relatedArtifacts : undefined,
+						createdAt: extractCreatedAt(r),
+					});
+				}
+			}
+			out.sort((a, b) => {
+				const da = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+				const db = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+				return db - da;
+			});
+			return out;
+		},
+	});
+}
+
+export function NotebookResourcePicker({
+	value,
+	onChange,
+	className,
+	kinds,
+	placeholder,
+}: {
+	value: string | undefined;
+	onChange: (reference: string) => void;
+	className?: string;
+	kinds?: CandidateKind[];
+	placeholder?: string;
+}) {
+	const [open, setOpen] = React.useState(false);
+	const [search, setSearch] = React.useState("");
+	const { data: candidates = [] } = useCandidates(search, open, kinds);
+	const { data: allCandidates = [] } = useCandidates("", open, kinds);
+	const commandRef = React.useRef<HTMLDivElement>(null);
+	const lookupByRef = React.useMemo(() => {
+		const map = new Map<string, CandidateOption>();
+		for (const c of allCandidates) if (c.url) map.set(c.url, c);
+		for (const c of candidates) if (c.url) map.set(c.url, c);
+		return (url: string) => map.get(url);
+	}, [allCandidates, candidates]);
+
+	React.useEffect(() => {
+		if (!open) return;
+		const id = requestAnimationFrame(() => {
+			const list = commandRef.current?.querySelector<HTMLElement>(
+				'[data-slot="command-list"]',
+			);
+			if (list) list.scrollLeft = 0;
+		});
+		return () => cancelAnimationFrame(id);
+	}, [open]);
+
+	return (
+		<HSComp.Popover open={open} onOpenChange={setOpen}>
+			<HSComp.PopoverTrigger asChild>
+				<HSComp.Button
+					variant="ghost"
+					size="small"
+					className={`h-7 px-2 justify-between font-mono text-xs bg-bg-primary hover:bg-bg-quaternary group-hover/tree-item-label:bg-bg-tertiary w-full ${value ? "text-text-primary! hover:text-text-primary!" : ""} ${className ?? ""}`}
+					onClick={(e) => e.stopPropagation()}
+				>
+					<span className={`truncate ${value ? "" : "text-text-tertiary"}`}>
+						{value || placeholder || "Select view or query…"}
+					</span>
+					<ChevronDown className="size-4 shrink-0 opacity-50" />
+				</HSComp.Button>
+			</HSComp.PopoverTrigger>
+			<HSComp.PopoverContent className="w-[640px] p-0" align="start">
+				<div ref={commandRef}>
+					<HSComp.Command shouldFilter={false}>
+						<HSComp.CommandInput
+							placeholder="Search view or query…"
+							value={search}
+							onValueChange={setSearch}
+						/>
+						<HSComp.CommandList>
+							<HSComp.CommandEmpty>
+								<div className="flex flex-col items-start gap-2 px-4 py-4 normal-case">
+									<span className="typo-body text-text-primary">
+										No matches
+									</span>
+								</div>
+							</HSComp.CommandEmpty>
+							{candidates.map((c) => {
+								const label = c.title || c.name || c.id;
+								const isView = c.kind === "ViewDefinition";
+								const Icon = isView ? Table : FileCode2;
+								const kindLabel = isView ? "View" : "Query";
+								const accentClass = isView
+									? "text-text-info-primary"
+									: "text-text-warning-primary";
+								const badges: React.ReactNode[] = [];
+								if (isView && c.resource) {
+									badges.push(
+										<Badge
+											key="resource"
+											text={c.resource}
+											accentClass="text-text-success-primary"
+										/>,
+									);
+								}
+								if (!isView && c.relatedArtifacts) {
+									for (const ra of c.relatedArtifacts) {
+										const linked = lookupByRef(ra.url);
+										const isLinkedView =
+											linked?.kind === "ViewDefinition" ||
+											ra.url.includes("/ViewDefinition/");
+										badges.push(
+											<Badge
+												key={ra.url}
+												text={
+													linked?.title ?? linked?.name ?? ra.label ?? ra.url
+												}
+												accentClass={
+													isLinkedView
+														? "text-text-info-primary"
+														: "text-text-warning-primary"
+												}
+											/>,
+										);
+									}
+								}
+								return (
+									<HSComp.CommandItem
+										key={c.id}
+										value={c.id}
+										onSelect={() => {
+											onChange(referenceFor(c));
+											setOpen(false);
+										}}
+									>
+										<div className="flex flex-col min-w-0">
+											<div
+												className={`flex items-center gap-1.5 typo-label-tiny uppercase tracking-wide ${accentClass}`}
+											>
+												<Icon className="size-3.5 shrink-0" />
+												<span>{kindLabel}</span>
+											</div>
+											<div className="typo-body text-text-primary truncate first-letter:uppercase mt-0.5">
+												{label}
+											</div>
+											{c.description && (
+												<div className="typo-body-xs text-text-secondary mt-0.5 line-clamp-1">
+													{c.description}
+												</div>
+											)}
+											{badges.length > 0 && (
+												<div className="flex flex-wrap gap-x-2 gap-y-0.5 mt-2">
+													{badges}
+												</div>
+											)}
+										</div>
+									</HSComp.CommandItem>
+								);
+							})}
+						</HSComp.CommandList>
+					</HSComp.Command>
+				</div>
+			</HSComp.PopoverContent>
+		</HSComp.Popover>
+	);
+}

--- a/src/routes/notebooks.$id.tsx
+++ b/src/routes/notebooks.$id.tsx
@@ -5,6 +5,7 @@ import * as yaml from "js-yaml";
 import {
 	Check,
 	ChevronDown,
+	Copy,
 	Database,
 	FileCode,
 	FileDown,
@@ -29,7 +30,7 @@ import { useAidboxClient } from "../AidboxClient";
 import { ConfirmDialog } from "../components/confirm-dialog";
 import { ResultContent } from "../components/db-console/result-content";
 import { transformToQueryResultItems } from "../components/db-console/tables-view";
-import { ResourcePicker } from "../components/SQLQueryBuilder/resource-picker";
+import { NotebookResourcePicker } from "../components/notebook-resource-picker";
 import { HTTP_STATUS_CODES } from "../shared/const";
 import { prettyEdn } from "../utils/edn";
 import type { QueryResultItem } from "../webmcp/db-console-context";
@@ -297,11 +298,14 @@ export function RestCellView({
 	cell,
 	onValueChange,
 	onResultChange,
+	readOnly,
 }: {
 	cell: Cell;
 	onValueChange?: (value: string) => void;
 	onResultChange?: (result: unknown) => void;
+	readOnly?: boolean;
 }) {
+	const isReadOnly = readOnly ?? !onValueChange;
 	const [raw, setRaw] = useState(cell.value ?? "");
 	const [response, setResponse] = useState<CellResponse | null>(
 		savedRestToResponse(cell.result),
@@ -417,6 +421,7 @@ export function RestCellView({
 					mode="http"
 					defaultValue={raw}
 					onChange={updateRaw}
+					readOnly={isReadOnly}
 					lineNumbers={false}
 					foldGutter={false}
 				/>
@@ -537,11 +542,14 @@ export function SqlCellView({
 	cell,
 	onValueChange,
 	onResultChange,
+	readOnly,
 }: {
 	cell: Cell;
 	onValueChange?: (value: string) => void;
 	onResultChange?: (result: unknown) => void;
+	readOnly?: boolean;
 }) {
+	const isReadOnly = readOnly ?? !onValueChange;
 	const [query, setQuery] = useState(cell.value ?? "");
 	const [results, setResults] = useState<QueryResultItem[] | null>(() =>
 		savedSqlToResults(cell.result),
@@ -618,6 +626,7 @@ export function SqlCellView({
 					mode="sql"
 					defaultValue={query}
 					onChange={updateQuery}
+					readOnly={isReadOnly}
 					lineNumbers={false}
 					foldGutter={false}
 				/>
@@ -684,16 +693,39 @@ type ViewRunResult =
 	| { ok: true; rows: Record<string, unknown>[] }
 	| { ok: false; error: string };
 
-function useViewDefinitionByUrl(url: string | null) {
+// A notebook cell references a resource either by canonical url or, when the
+// resource has no url, by a relative "ResourceType/id" reference.
+function refToId(
+	type: "ViewDefinition" | "Library",
+	ref: string,
+): string | null {
+	if (!ref || ref.includes("://")) return null;
+	const m = ref.match(/^(\w+)\/(.+)$/);
+	return m && m[1] === type && m[2] ? m[2] : null;
+}
+
+function useViewDefinitionByUrl(ref: string | null) {
 	const client = useAidboxClient();
 	return useQuery<ViewDefinitionResource | null>({
-		queryKey: ["view-definition-by-url", url],
-		enabled: !!url,
+		queryKey: ["view-definition-by-url", ref],
+		enabled: !!ref,
 		staleTime: 60_000,
 		queryFn: async () => {
+			const id = refToId("ViewDefinition", ref ?? "");
+			if (id) {
+				try {
+					const resp = await client.rawRequest({
+						method: "GET",
+						url: `/fhir/ViewDefinition/${encodeURIComponent(id)}`,
+					});
+					return (await resp.response.json()) as ViewDefinitionResource;
+				} catch {
+					return null;
+				}
+			}
 			const resp = await client.rawRequest({
 				method: "GET",
-				url: `/fhir/ViewDefinition?url=${encodeURIComponent(url ?? "")}&_count=1`,
+				url: `/fhir/ViewDefinition?url=${encodeURIComponent(ref ?? "")}&_count=1`,
 			});
 			const json = (await resp.response.json()) as {
 				entry?: { resource: ViewDefinitionResource }[];
@@ -707,13 +739,16 @@ export function ViewDefinitionCellView({
 	cell,
 	onValueChange,
 	onResultChange,
+	readOnly,
 }: {
 	cell: Cell;
 	onValueChange?: (value: string) => void;
 	onResultChange?: (result: unknown) => void;
+	readOnly?: boolean;
 }) {
 	const client = useAidboxClient();
-	const editable = !!onValueChange;
+	const isReadOnly = readOnly ?? !onValueChange;
+	const editable = !isReadOnly;
 	const url = cell.value ?? "";
 	const { data: vd, isLoading: vdLoading } = useViewDefinitionByUrl(
 		url ? url : null,
@@ -791,7 +826,7 @@ export function ViewDefinitionCellView({
 						ViewDefinition
 					</span>
 					{editable && (
-						<ResourcePicker
+						<NotebookResourcePicker
 							value=""
 							onChange={(v) => onValueChange?.(v)}
 							kinds={["ViewDefinition"]}
@@ -927,16 +962,28 @@ type SqlQueryRunResult =
 	| { ok: true; columns: string[]; rows: unknown[][] }
 	| { ok: false; error: string };
 
-function useLibraryByUrl(url: string | null) {
+function useLibraryByUrl(ref: string | null) {
 	const client = useAidboxClient();
 	return useQuery<LibraryResource | null>({
-		queryKey: ["sqlquery-library-by-url", url],
-		enabled: !!url,
+		queryKey: ["sqlquery-library-by-url", ref],
+		enabled: !!ref,
 		staleTime: 60_000,
 		queryFn: async () => {
+			const id = refToId("Library", ref ?? "");
+			if (id) {
+				try {
+					const resp = await client.rawRequest({
+						method: "GET",
+						url: `/fhir/Library/${encodeURIComponent(id)}`,
+					});
+					return (await resp.response.json()) as LibraryResource;
+				} catch {
+					return null;
+				}
+			}
 			const resp = await client.rawRequest({
 				method: "GET",
-				url: `/fhir/Library?url=${encodeURIComponent(url ?? "")}&_count=1`,
+				url: `/fhir/Library?url=${encodeURIComponent(ref ?? "")}&_count=1`,
 			});
 			const json = (await resp.response.json()) as {
 				entry?: { resource: LibraryResource }[];
@@ -1040,13 +1087,16 @@ export function SqlQueryCellView({
 	cell,
 	onValueChange,
 	onResultChange,
+	readOnly,
 }: {
 	cell: Cell;
 	onValueChange?: (value: string) => void;
 	onResultChange?: (result: unknown) => void;
+	readOnly?: boolean;
 }) {
 	const client = useAidboxClient();
-	const editable = !!onValueChange;
+	const isReadOnly = readOnly ?? !onValueChange;
+	const editable = !isReadOnly;
 	const parsed = parseSqlQueryCellValue(cell.value ?? "");
 	const url = parsed.url;
 	const { data: lib, isLoading: libLoading } = useLibraryByUrl(
@@ -1121,7 +1171,7 @@ export function SqlQueryCellView({
 						SQLQuery
 					</span>
 					{editable && (
-						<ResourcePicker
+						<NotebookResourcePicker
 							value=""
 							onChange={(v) => {
 								setParamValues({});
@@ -1190,6 +1240,7 @@ export function SqlQueryCellView({
 								<input
 									id={`sqlq-${key}`}
 									value={paramValues[key] ?? ""}
+									disabled={isReadOnly}
 									onChange={(e) => {
 										const next = {
 											...paramValues,
@@ -1273,16 +1324,16 @@ export function SqlQueryCellView({
 export function CellView({ cell }: { cell: Cell }) {
 	const type = cell.type ?? "rest";
 	if (type === "rest" || type === "rpc") {
-		return <RestCellView cell={cell} />;
+		return <RestCellView cell={cell} readOnly />;
 	}
 	if (type === "sql") {
-		return <SqlCellView cell={cell} />;
+		return <SqlCellView cell={cell} readOnly />;
 	}
 	if (type === "view-definition") {
-		return <ViewDefinitionCellView cell={cell} />;
+		return <ViewDefinitionCellView cell={cell} readOnly />;
 	}
 	if (type === "sql-query") {
-		return <SqlQueryCellView cell={cell} />;
+		return <SqlQueryCellView cell={cell} readOnly />;
 	}
 	if (type === "markdown") {
 		return (
@@ -1324,6 +1375,26 @@ function notebookForExport(notebook: Notebook): Record<string, unknown> {
 			),
 		};
 	}
+	return cleaned;
+}
+
+function notebookForCopy(notebook: Notebook): Record<string, unknown> {
+	const cleaned = notebookForExport(notebook);
+	delete cleaned.id;
+	delete cleaned.meta;
+	// The community view delivers tags as a plain array (["Community"]);
+	// notebookForExport only strips the {value:[]} shape, so handle the array here.
+	const tags = cleaned.tags;
+	if (Array.isArray(tags)) {
+		const filtered = tags.filter(
+			(v) => typeof v !== "string" || v.toLowerCase() !== "community",
+		);
+		if (filtered.length > 0) cleaned.tags = filtered;
+		else delete cleaned.tags;
+	}
+	const trimmed = notebook.name?.trim();
+	const base = trimmed && trimmed.length > 0 ? trimmed : "Untitled notebook";
+	cleaned.name = base.startsWith("Copy of ") ? base : `Copy of ${base}`;
 	return cleaned;
 }
 
@@ -1445,6 +1516,55 @@ function ShareButton({ notebook }: { notebook: Notebook }) {
 				</HSComp.DropdownMenuItem>
 			</HSComp.DropdownMenuContent>
 		</HSComp.DropdownMenu>
+	);
+}
+
+function CopyNotebookButton({ notebook }: { notebook: Notebook }) {
+	const client = useAidboxClient();
+	const navigate = useNavigate();
+	const queryClient = useQueryClient();
+	const mut = useMutation<{ id: string }, Error>({
+		mutationFn: async () => {
+			const body = {
+				method: "aidbox.notebooks/save-notebook",
+				params: { notebook: notebookForCopy(notebook) },
+			};
+			const resp = await client.rawRequest({
+				method: "POST",
+				url: `/rpc?_m=${body.method}`,
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify(body),
+			});
+			const json = (await resp.response.json()) as {
+				result?: { notebook?: { id?: string } };
+				error?: { message?: string };
+			};
+			const id = json.result?.notebook?.id;
+			if (!id) throw new Error(json.error?.message ?? "Copy failed");
+			return { id };
+		},
+		onSuccess: ({ id }) => {
+			void queryClient.invalidateQueries({ queryKey: ["notebooks-list"] });
+			HSComp.toast.success("Copied to your notebooks");
+			void navigate({ to: "/notebooks/$id/edit", params: { id } });
+		},
+		onError: (e) => HSComp.toast.error(e.message),
+	});
+	return (
+		<HSComp.Button
+			variant="ghost"
+			size="small"
+			className="px-0! text-text-link"
+			disabled={mut.isPending}
+			onClick={() => mut.mutate()}
+		>
+			{mut.isPending ? (
+				<Loader2 className="size-4 animate-spin" />
+			) : (
+				<Copy className="size-4" />
+			)}
+			Save a copy
+		</HSComp.Button>
 	);
 }
 
@@ -1654,28 +1774,37 @@ function NotebookViewPage() {
 
 	return (
 		<div className="h-full flex flex-col">
-			{notebook && canEdit && (
+			{notebook && (
 				<div
 					className="flex items-center bg-bg-secondary flex-none h-10 border-b border-border-default"
 					data-export-skip
 				>
 					<div className="mx-auto max-w-[990px] w-full flex items-center gap-4 px-8">
-						<Link to="/notebooks/$id/edit" params={{ id: notebook.id }}>
-							<HSComp.Button
-								variant="ghost"
-								size="small"
-								className="px-0! text-text-link"
-							>
-								<Pencil className="size-4" />
-								Edit
-							</HSComp.Button>
-						</Link>
-						<PublishButtons
-							notebook={notebook}
-							queryKey={["notebook", id, path ?? null]}
-						/>
-						<DeleteNotebookButton notebook={notebook} />
-						<ShareButton notebook={notebook} />
+						{canEdit ? (
+							<>
+								<Link to="/notebooks/$id/edit" params={{ id: notebook.id }}>
+									<HSComp.Button
+										variant="ghost"
+										size="small"
+										className="px-0! text-text-link"
+									>
+										<Pencil className="size-4" />
+										Edit
+									</HSComp.Button>
+								</Link>
+								<PublishButtons
+									notebook={notebook}
+									queryKey={["notebook", id, path ?? null]}
+								/>
+								<DeleteNotebookButton notebook={notebook} />
+								<ShareButton notebook={notebook} />
+							</>
+						) : (
+							<>
+								<CopyNotebookButton notebook={notebook} />
+								<ShareButton notebook={notebook} />
+							</>
+						)}
 					</div>
 				</div>
 			)}

--- a/src/routes/notebooks.$id.tsx
+++ b/src/routes/notebooks.$id.tsx
@@ -315,6 +315,7 @@ export function RestCellView({
 	const [tab, setTab] = useState<"body" | "headers">("body");
 	const responseRef = useRef<HTMLDivElement | null>(null);
 	const client = useAidboxClient();
+	const queryClient = useQueryClient();
 
 	const updateRaw = (v: string) => {
 		setRaw(v);
@@ -378,6 +379,14 @@ export function RestCellView({
 			onResultChange?.(next);
 		} finally {
 			setLoading(false);
+			// A REST call may create/update a ViewDefinition or SQLQuery that
+			// other cells reference, so refresh those lookups.
+			void queryClient.invalidateQueries({
+				queryKey: ["view-definition-by-url"],
+			});
+			void queryClient.invalidateQueries({
+				queryKey: ["sqlquery-library-by-url"],
+			});
 		}
 	};
 

--- a/src/routes/notebooks.$id_.edit.tsx
+++ b/src/routes/notebooks.$id_.edit.tsx
@@ -45,6 +45,7 @@ function useNotebookForEdit(id: string) {
 					id: c.id,
 					type: c.type,
 					value: c.value,
+					result: c.result,
 				})),
 				"publication-id": nb["publication-id"],
 				"edit-secret": nb["edit-secret"],


### PR DESCRIPTION
## Summary
- **View mode is read-only.** REST/SQL editors and SQLQuery param inputs no longer accept edits in the read-only view — previously they looked editable but changes were silently dropped (and lost when switching to edit).
- **Community notebooks get "Save a copy" + Share.** Community notebooks had no Edit path. `Save a copy` forks a personal copy via `save-notebook` — stripping `id`/`meta`/`origin`/`source`/`publication-id`/`edit-secret`/community tag and renaming to `Copy of …` — invalidates the list, and opens the copy in edit. Share is now also exposed for community.
- **Cell results preserved.** Copies keep `cells[].result`, and the edit route now loads `cells[].result` (previously dropped when entering edit).
- **Reference VD/SQLQuery by id.** Notebook cells can reference a ViewDefinition/Library by `Type/id`, so resources without a canonical `url` can be picked and run. Adds a notebook-specific `NotebookResourcePicker` (no `url:missing` filter); the shared `SQLQueryBuilder` picker is left unchanged (url stays required there).

## Test plan
- [ ] Community notebook: editors are read-only; `Save a copy` creates a personal copy, opens it in edit, copy has no Community marker / publication fields.
- [ ] Saved cell results show in the copy and when entering edit on any notebook.
- [ ] VD/SQLQuery cell: pick a resource without a \`url\` → it loads and runs (reference stored as \`Type/id\`).
- [ ] Existing notebooks referencing resources by canonical \`url\` still load/run (legacy fallback).
- [ ] SQLQueryBuilder resource picker still filters to url-bearing resources (unchanged).