### PR TITLE
FAR UI: tab-per-resource-type redesign

### DIFF
--- a/src/components/IGBrowser/browser.tsx
+++ b/src/components/IGBrowser/browser.tsx
@@ -166,7 +166,6 @@ const ItemCard = React.memo(function ItemCard({
 					tab: undefined,
 					view: undefined,
 					q: undefined,
-					page: undefined,
 				}}
 				className="block"
 			>
@@ -476,7 +475,6 @@ export function Browser() {
 					tab: undefined,
 					view: undefined,
 					q: undefined,
-					page: undefined,
 				},
 			});
 		}
@@ -528,7 +526,6 @@ export function Browser() {
 					tab: undefined,
 					view: undefined,
 					q: undefined,
-					page: undefined,
 				},
 			});
 		},

--- a/src/components/IGBrowser/browser.tsx
+++ b/src/components/IGBrowser/browser.tsx
@@ -1,29 +1,38 @@
+import { useLocalStorage } from "@aidbox-ui/hooks/useLocalStorage";
 import * as HSComp from "@health-samurai/react-components";
 import { useQuery } from "@tanstack/react-query";
 import { Link, useNavigate, useSearch } from "@tanstack/react-router";
-import { PlusIcon, X } from "lucide-react";
-import React, { useMemo, useRef, useState } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import Fuse from "fuse.js";
+import { Pin, PlusIcon, Search, X } from "lucide-react";
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import { useAidboxClient } from "../../AidboxClient";
 import { createFuzzySearch } from "../../utils/fuzzy-search";
+import {
+	filterHighlightRanges,
+	highlight,
+	type MatchRange,
+} from "../../utils/highlight";
+import { parseQuery, tagSlug } from "../../utils/tag-search";
 import { useWebMCPIGBrowser } from "../../webmcp/ig-browser";
 import type { IGBrowserActions } from "../../webmcp/ig-browser-context";
 import { EmptyState } from "../empty-state";
 
 type Installation = {
-	intention: string;
+	intention?: string;
 };
 
-type PackageRow = {
+type PackageTag = "system" | "direct" | "transitive";
+
+type PackageItem = {
 	id: string;
 	name: string;
 	version: string;
-	type: string;
-	installation: Installation[];
+	description?: string;
+	tags: string[];
+	nameMatches?: readonly MatchRange[];
+	descriptionMatches?: readonly MatchRange[];
 };
-
-function capitalize(s: string): string {
-	return s.charAt(0).toUpperCase() + s.slice(1);
-}
 
 const SYSTEM_PREFIXES = [
 	"io.health-samurai.core",
@@ -31,18 +40,19 @@ const SYSTEM_PREFIXES = [
 	"io.health-samurai.mdm",
 ];
 
-function getPackageType(name: string, installation: Installation[]): string {
+function getPackageTag(name: string, installation: Installation[]): PackageTag {
 	if (SYSTEM_PREFIXES.some((prefix) => name.startsWith(prefix))) {
-		return "System";
+		return "system";
 	}
-	const first = installation?.[0]?.intention;
-	return first ? capitalize(first) : "";
+	return installation?.[0]?.intention === "transitive"
+		? "transitive"
+		: "direct";
 }
 
 function usePackagesData() {
 	const client = useAidboxClient();
 
-	return useQuery<PackageRow[]>({
+	return useQuery<PackageItem[]>({
 		queryKey: ["ig-browser-packages"],
 		staleTime: 5 * 60 * 1000,
 		queryFn: async () => {
@@ -61,232 +71,454 @@ function usePackagesData() {
 				const name = (pkg.name as string) ?? "";
 				const version = (pkg.version as string) ?? "";
 				const installation = (pkg.installation as Installation[]) ?? [];
+				const typeTag = (pkg.type as string | undefined)?.toLowerCase();
 				return {
 					id: `${name}#${version}`,
 					name,
 					version,
-					type: getPackageType(name, installation),
-					installation,
-				};
+					description: (pkg.description ?? pkg.author ?? pkg.title) as
+						| string
+						| undefined,
+					tags: typeTag
+						? [getPackageTag(name, installation), typeTag]
+						: [getPackageTag(name, installation)],
+				} satisfies PackageItem;
 			});
 		},
 	});
 }
 
-type SortColumn = "name" | "type";
-type SortState = { column: SortColumn; direction: "asc" | "desc" };
+const CHIP_STYLE = "bg-blue-50 text-text-info-primary";
 
-const skeletonRows = Array.from({ length: 20 }, (_, i) => (
-	// biome-ignore lint/suspicious/noArrayIndexKey: static skeleton rows
-	<HSComp.TableRow key={`skeleton-${i}`} zebra index={i}>
-		<HSComp.TableCell>
-			<div className="flex items-center gap-2">
-				<HSComp.Skeleton
-					className="h-5"
-					style={{ width: `${140 + ((i * 47) % 160)}px` }}
-				/>
-				<HSComp.Skeleton
-					className="h-5"
-					style={{ width: `${50 + ((i * 31) % 40)}px` }}
-				/>
-			</div>
-		</HSComp.TableCell>
-		<HSComp.TableCell>
-			<HSComp.Skeleton
-				className="h-5"
-				style={{ width: `${60 + ((i * 23) % 40)}px` }}
-			/>
-		</HSComp.TableCell>
-	</HSComp.TableRow>
-));
+function itemTagSlugs(item: PackageItem): string[] {
+	return item.tags.map(tagSlug);
+}
 
-function PackageList({
-	data,
-	isLoading,
-	sort,
-	onSort,
-	focusedIndex,
-}: {
-	data: PackageRow[];
-	isLoading: boolean;
-	sort: SortState;
-	onSort: (column: SortColumn) => void;
-	focusedIndex: number;
-}) {
-	const navigate = useNavigate();
-	const focusedRowRef = React.useRef<HTMLTableRowElement | null>(null);
+function filterByTags(
+	items: PackageItem[],
+	tagTokens: string[],
+): PackageItem[] {
+	if (tagTokens.length === 0) return items;
+	return items.filter((item) => {
+		const slugs = itemTagSlugs(item);
+		return tagTokens.every((tag) => slugs.some((slug) => slug === tag));
+	});
+}
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: focusedIndex triggers scroll
-	React.useEffect(() => {
-		focusedRowRef.current?.scrollIntoView({ block: "nearest" });
-	}, [focusedIndex]);
+function sortByName(items: PackageItem[]): PackageItem[] {
+	return [...items].sort(
+		(a, b) =>
+			a.name.localeCompare(b.name) || a.version.localeCompare(b.version),
+	);
+}
 
-	const goToPackage = (packageId: string) =>
-		navigate({
-			to: "/ig/$packageId",
-			params: { packageId },
-			search: {
-				tab: undefined,
-				view: undefined,
-				q: undefined,
-				page: undefined,
-			},
-		});
+function applyFavorites(
+	items: PackageItem[],
+	favorites: Set<string>,
+	hasQuery: boolean,
+): PackageItem[] {
+	if (hasQuery) return items;
+	return [...items].sort((a, b) => {
+		const af = favorites.has(a.id);
+		const bf = favorites.has(b.id);
+		if (af === bf) return 0;
+		return af ? -1 : 1;
+	});
+}
 
+function Badge({ text, onClick }: { text: string; onClick: () => void }) {
 	return (
-		<div className="h-full overflow-auto [&_table]:mb-25">
-			<HSComp.Table stickyHeader zebra>
-				<HSComp.TableHeader>
-					<HSComp.TableRow>
-						<HSComp.TableHead
-							sortable
-							sorted={sort.column === "name" && sort.direction}
-							onClick={() => onSort("name")}
-							className="pl-7!"
-						>
-							Package
-						</HSComp.TableHead>
-						<HSComp.TableHead
-							className="w-36"
-							sortable
-							sorted={sort.column === "type" && sort.direction}
-							onClick={() => onSort("type")}
-						>
-							Type
-						</HSComp.TableHead>
-					</HSComp.TableRow>
-				</HSComp.TableHeader>
-				<HSComp.TableBody>
-					{isLoading
-						? skeletonRows
-						: data.map((row, index) => (
-								<HSComp.TableRow
-									ref={index === focusedIndex ? focusedRowRef : undefined}
-									key={row.id}
-									zebra
-									index={index}
-									className={HSComp.cn(
-										"cursor-pointer",
-										index === focusedIndex && "bg-bg-hover",
-									)}
-									onClick={() => goToPackage(row.id)}
-								>
-									<HSComp.TableCell className="pl-7!">
-										<span className="text-text-link hover:underline">
-											{row.name}
-										</span>{" "}
-										<span className="text-text-secondary">{row.version}</span>
-									</HSComp.TableCell>
-									<HSComp.TableCell className="w-36 text-text-secondary">
-										{row.type}
-									</HSComp.TableCell>
-								</HSComp.TableRow>
-							))}
-				</HSComp.TableBody>
-			</HSComp.Table>
+		<button
+			type="button"
+			onClick={(e) => {
+				e.preventDefault();
+				e.stopPropagation();
+				onClick();
+			}}
+			className="shrink-0 text-[11px] leading-4 normal-case whitespace-nowrap cursor-pointer hover:underline text-text-info-primary"
+		>
+			#{text}
+		</button>
+	);
+}
+
+const ItemCard = React.memo(function ItemCard({
+	item,
+	isFavorite,
+	onTagClick,
+	onToggleFavorite,
+	focused,
+}: {
+	item: PackageItem;
+	isFavorite: boolean;
+	onTagClick: (text: string) => void;
+	onToggleFavorite: (id: string) => void;
+	focused: boolean;
+}) {
+	return (
+		<li
+			className={`relative group/row transition-colors hover:bg-bg-secondary border-b border-border-default ${focused ? "bg-bg-secondary" : ""}`}
+		>
+			<Link
+				to="/ig/$packageId"
+				params={{ packageId: item.id }}
+				search={{
+					tab: undefined,
+					view: undefined,
+					q: undefined,
+					page: undefined,
+				}}
+				className="block"
+			>
+				<div className="flex flex-col pl-4 pr-10 py-3 min-w-0">
+					<div className="typo-body text-text-primary truncate">
+						{highlight(item.name, item.nameMatches)}{" "}
+						<span className="text-text-secondary">{item.version}</span>
+					</div>
+					{item.description && (
+						<div className="typo-body-xs text-text-secondary mt-0.5 line-clamp-1">
+							{highlight(item.description, item.descriptionMatches)}
+						</div>
+					)}
+					<div className="flex flex-wrap gap-x-2 gap-y-0.5 mt-2">
+						{item.tags.map((t) => (
+							<Badge key={t} text={t} onClick={() => onTagClick(t)} />
+						))}
+					</div>
+				</div>
+			</Link>
+			<button
+				type="button"
+				aria-label={isFavorite ? "Unpin" : "Pin"}
+				onClick={(e) => {
+					e.preventDefault();
+					e.stopPropagation();
+					onToggleFavorite(item.id);
+				}}
+				className={`absolute top-2 right-2 size-7 flex items-center justify-center rounded hover:bg-bg-tertiary transition-opacity ${isFavorite ? "opacity-100 text-text-info-primary" : "opacity-0 group-hover/row:opacity-100 text-text-secondary"}`}
+			>
+				<Pin className="size-4" />
+			</button>
+		</li>
+	);
+});
+
+function SearchBar({
+	chips,
+	textPart,
+	inputRef,
+	onTextChange,
+	onRemoveChip,
+	onClear,
+	onInputKeyDown,
+}: {
+	chips: string[];
+	textPart: string;
+	inputRef: (el: HTMLInputElement | null) => void;
+	onTextChange: (next: string) => void;
+	onRemoveChip: (slug: string) => void;
+	onClear: () => void;
+	onInputKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+}) {
+	return (
+		<div className="flex flex-1 items-center gap-2 min-h-9 px-3 py-1 rounded-lg border border-border-primary bg-bg-primary flex-wrap">
+			<Search className="size-4 text-text-tertiary shrink-0" />
+			{chips.map((chip) => (
+				<button
+					key={chip}
+					type="button"
+					aria-label={`Remove tag ${chip}`}
+					onClick={() => onRemoveChip(chip)}
+					className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[11px] leading-4 whitespace-nowrap cursor-pointer ${CHIP_STYLE}`}
+				>
+					#{chip}
+					<X className="size-3 opacity-70" />
+				</button>
+			))}
+			<input
+				ref={inputRef}
+				value={textPart}
+				onChange={(e) => onTextChange(e.target.value)}
+				onKeyDown={(e) => {
+					const last = chips[chips.length - 1];
+					if (e.key === "Backspace" && textPart === "" && last) {
+						e.preventDefault();
+						onRemoveChip(last);
+						return;
+					}
+					onInputKeyDown?.(e);
+				}}
+				placeholder={
+					chips.length === 0 ? "Search packages by name or description…" : ""
+				}
+				className="flex-1 min-w-[80px] bg-transparent outline-none typo-body text-text-primary placeholder:text-text-tertiary"
+			/>
+			{(chips.length > 0 || textPart.length > 0) && (
+				<HSComp.IconButton
+					variant="link"
+					aria-label="Clear"
+					onClick={onClear}
+					icon={<X />}
+				/>
+			)}
 		</div>
 	);
 }
 
 export function Browser() {
-	const { data, isLoading } = usePackagesData();
-
-	const { q, sort: sortParam } = useSearch({ from: "/ig/" });
-	const filterQuery = q ?? "";
-	const [focusedIndex, setFocusedIndex] = useState(-1);
+	const search = useSearch({ from: "/ig/" });
 	const navigate = useNavigate();
 
-	const DEFAULT_SORT: SortState = { column: "type", direction: "asc" };
+	const urlText = search.q ?? "";
+	const chips = search.tags ?? [];
+	const tagTokens = chips.map(tagSlug);
 
-	const sort: SortState = useMemo(() => {
-		if (!sortParam) return DEFAULT_SORT;
-		const desc = sortParam.startsWith("-");
-		const col = (desc ? sortParam.slice(1) : sortParam) as SortColumn;
-		if (col !== "name" && col !== "type") return DEFAULT_SORT;
-		return { column: col, direction: desc ? "desc" : "asc" };
-	}, [sortParam]);
+	// Local input state for instant typing; URL sync is debounced + non-blocking.
+	const [inputText, setInputText] = React.useState(urlText);
+	const text = React.useDeferredValue(inputText);
+	const hasQuery = chips.length > 0 || Boolean(text);
 
-	const serializeSort = (s: SortState): string | undefined => {
-		if (
-			s.column === DEFAULT_SORT.column &&
-			s.direction === DEFAULT_SORT.direction
-		)
-			return undefined;
-		return s.direction === "desc" ? `-${s.column}` : s.column;
-	};
+	// Pull external URL changes (back/forward, navigate from outside) back into local state.
+	const lastUrlTextRef = useRef(urlText);
+	useEffect(() => {
+		if (urlText !== lastUrlTextRef.current) {
+			lastUrlTextRef.current = urlText;
+			setInputText(urlText);
+		}
+	}, [urlText]);
 
-	const setFilterQuery = (q: string) => {
-		navigate({
-			from: "/ig/",
-			search: (prev) => ({ ...prev, q: q || undefined }),
-		});
-	};
-
-	const handleSort = (column: SortColumn) => {
-		const next =
-			sort.column === column
-				? {
-						column,
-						direction:
-							sort.direction === "asc" ? ("desc" as const) : ("asc" as const),
-					}
-				: { column, direction: "asc" as const };
-		navigate({
-			from: "/ig/",
-			search: (prev) => ({ ...prev, sort: serializeSort(next) }),
-		});
-	};
-
-	const fuzzySearch = useMemo(
-		() =>
-			data
-				? createFuzzySearch(data, {
-						keys: [
-							{ name: "id", weight: 2 },
-							{ name: "type", weight: 1 },
-						],
-						minMatchCharLength: 1,
-						threshold: 0.3,
-					})
-				: () => [],
-		[data],
+	const urlSyncTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const setText = useCallback(
+		(next: string) => {
+			setInputText(next);
+			if (urlSyncTimerRef.current) clearTimeout(urlSyncTimerRef.current);
+			urlSyncTimerRef.current = setTimeout(() => {
+				lastUrlTextRef.current = next;
+				navigate({
+					from: "/ig/",
+					search: (prev) => ({ ...prev, q: next || undefined }),
+					replace: true,
+				});
+			}, 200);
+		},
+		[navigate],
+	);
+	useEffect(
+		() => () => {
+			if (urlSyncTimerRef.current) clearTimeout(urlSyncTimerRef.current);
+		},
+		[],
+	);
+	const setTags = useCallback(
+		(next: string[]) => {
+			navigate({
+				from: "/ig/",
+				search: (prev) => ({
+					...prev,
+					tags: next.length > 0 ? next : undefined,
+				}),
+				replace: true,
+			});
+		},
+		[navigate],
 	);
 
-	const filteredData = useMemo(() => {
-		const results = fuzzySearch(filterQuery);
-		return [...results].sort((a, b) => {
-			const aVal = a[sort.column];
-			const bVal = b[sort.column];
-			const cmp = aVal.localeCompare(bVal);
-			return sort.direction === "asc" ? cmp : -cmp;
-		});
-	}, [fuzzySearch, filterQuery, sort]);
+	const [favoritesArray, setFavoritesArray] = useLocalStorage<string[]>({
+		key: "ig-browser-favorites",
+		defaultValue: [],
+	});
+	const favorites = useMemo(() => new Set(favoritesArray), [favoritesArray]);
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: reset focus on filter change
+	const { data, isLoading } = usePackagesData();
+	const allItems = data ?? [];
+
+	const tagFiltered = filterByTags(allItems, tagTokens);
+
+	const fuse = useMemo(
+		() =>
+			new Fuse(tagFiltered, {
+				keys: [
+					{ name: "name", weight: 10 },
+					{ name: "version", weight: 3 },
+					{ name: "description", weight: 1 },
+				],
+				includeMatches: true,
+				ignoreLocation: true,
+				useExtendedSearch: true,
+				minMatchCharLength: 1,
+				threshold: 0.3,
+			}),
+		[tagFiltered],
+	);
+
+	const textFiltered: PackageItem[] = text
+		? fuse.search(text).map((r) => {
+				const nameMatch = r.matches?.find((m) => m.key === "name");
+				const descMatch = r.matches?.find((m) => m.key === "description");
+				return {
+					...r.item,
+					nameMatches: filterHighlightRanges(
+						text,
+						nameMatch?.indices as readonly MatchRange[] | undefined,
+					),
+					descriptionMatches: filterHighlightRanges(
+						text,
+						descMatch?.indices as readonly MatchRange[] | undefined,
+					),
+				};
+			})
+		: sortByName(tagFiltered);
+	const items = applyFavorites(textFiltered, favorites, hasQuery);
+
+	const chipsRef = useRef(chips);
+	chipsRef.current = chips;
+	const handleTagClick = useCallback(
+		(tagText: string) => {
+			const slug = tagSlug(tagText);
+			const current = chipsRef.current;
+			if (current.some((c) => tagSlug(c) === slug)) return;
+			setTags([...current, tagText]);
+		},
+		[setTags],
+	);
+	const removeChip = (tag: string) => {
+		setTags(chips.filter((c) => c !== tag));
+	};
+	const updateTextPart = (next: string) => {
+		// last token without trailing whitespace is "in progress" — don't parse yet
+		let toParse = next;
+		let tail = "";
+		if (!/\s$/.test(next)) {
+			const m = next.match(/^(.*\s)(\S*)$/);
+			if (m) {
+				toParse = m[1] ?? "";
+				tail = m[2] ?? "";
+			} else {
+				toParse = "";
+				tail = next;
+			}
+		}
+		const parsed = parseQuery(toParse);
+		if (parsed.chips.length > 0) {
+			const seen = new Set(chips.map(tagSlug));
+			const extra: string[] = [];
+			for (const c of parsed.chips) {
+				const s = tagSlug(c);
+				if (!seen.has(s)) {
+					extra.push(c);
+					seen.add(s);
+				}
+			}
+			if (extra.length > 0) setTags([...chips, ...extra]);
+			setText([parsed.text, tail].filter(Boolean).join(" "));
+		} else {
+			setText(next);
+		}
+	};
+	const onClear = () => {
+		setTags([]);
+		setText("");
+	};
+
+	const toggleFavorite = useCallback(
+		(id: string) => {
+			setFavoritesArray((prev) =>
+				prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
+			);
+		},
+		[setFavoritesArray],
+	);
+
+	const [focusedIndex, setFocusedIndex] = React.useState(-1);
+	const scrollRef = useRef<HTMLDivElement | null>(null);
+	const didFocus = useRef(false);
+	const setSearchInputRef = React.useCallback((el: HTMLInputElement | null) => {
+		if (el && !didFocus.current) {
+			el.focus();
+			didFocus.current = true;
+		}
+	}, []);
+
+	const rowVirtualizer = useVirtualizer({
+		count: items.length,
+		getScrollElement: () => scrollRef.current,
+		estimateSize: () => 90,
+		overscan: 8,
+		getItemKey: (index) => items[index]?.id ?? index,
+	});
+
+	useEffect(() => {
+		if (focusedIndex < 0) return;
+		rowVirtualizer.scrollToIndex(focusedIndex, { align: "auto" });
+	}, [focusedIndex, rowVirtualizer]);
+
 	React.useEffect(() => {
-		setFocusedIndex(filteredData.length === 1 ? 0 : -1);
-	}, [filterQuery]);
+		if (text && items.length > 0) setFocusedIndex(0);
+		else setFocusedIndex(-1);
+	}, [text, items.length]);
+
+	const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+		if (e.key === "ArrowDown" || (e.key === "Tab" && !e.shiftKey)) {
+			e.preventDefault();
+			setFocusedIndex((p) => Math.min(p + 1, items.length - 1));
+		} else if (e.key === "ArrowUp" || (e.key === "Tab" && e.shiftKey)) {
+			e.preventDefault();
+			setFocusedIndex((p) => Math.max(p - 1, -1));
+		} else if (e.key === "Enter") {
+			if (focusedIndex < 0) return;
+			const it = items[focusedIndex];
+			if (!it) return;
+			e.preventDefault();
+			navigate({
+				to: "/ig/$packageId",
+				params: { packageId: it.id },
+				search: {
+					tab: undefined,
+					view: undefined,
+					q: undefined,
+					page: undefined,
+				},
+			});
+		}
+	};
 
 	const actionsRef = useRef<IGBrowserActions>({} as IGBrowserActions);
 	actionsRef.current = {
-		listPackages: (query?: string) => {
-			if (query !== undefined) {
-				setFilterQuery(query);
+		listPackages: (filter) => {
+			let resolvedTags: string[];
+			let resolvedText: string;
+			if (filter !== undefined) {
+				const parsed = parseQuery(filter);
+				setTags(parsed.chips);
+				setText(parsed.text);
+				resolvedTags = parsed.chips.map(tagSlug);
+				resolvedText = parsed.text;
+			} else {
+				resolvedTags = tagTokens;
+				resolvedText = text;
 			}
-			const results = fuzzySearch(query ?? filterQuery);
-			const sorted = [...results].sort((a, b) => {
-				const cmp = a[sort.column].localeCompare(b[sort.column]);
-				return sort.direction === "asc" ? cmp : -cmp;
-			});
-			return sorted.map((p) => ({
-				name: p.name,
-				version: p.version,
-				type: p.type,
+			const filtered = filterByTags(allItems, resolvedTags);
+			const t = resolvedText
+				? createFuzzySearch(filtered, {
+						keys: [
+							{ name: "name", weight: 2 },
+							{ name: "version", weight: 1 },
+							{ name: "description", weight: 1 },
+						],
+						minMatchCharLength: 1,
+						threshold: 0.3,
+					})(resolvedText)
+				: sortByName(filtered);
+			const finalList = applyFavorites(
+				t,
+				favorites,
+				Boolean(resolvedText) || resolvedTags.length > 0,
+			);
+			return finalList.map((row) => ({
+				name: row.name,
+				version: row.version,
+				tags: row.tags,
 			}));
-		},
-		getSort: () => ({ column: sort.column, direction: sort.direction }),
-		sortPackages: (column) => {
-			handleSort(column);
 		},
 		selectPackage: (id) => {
 			navigate({
@@ -301,91 +533,79 @@ export function Browser() {
 			});
 		},
 		openInstallationPage: () => {
-			navigate({ to: "/ig/add", search: {} });
+			navigate({ to: "/ig/add" });
 		},
 	};
 	useWebMCPIGBrowser(actionsRef);
 
-	const handleSearchKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-		if (e.key === "ArrowDown" || (e.key === "Tab" && !e.shiftKey)) {
-			e.preventDefault();
-			setFocusedIndex((prev) => Math.min(prev + 1, filteredData.length - 1));
-		} else if (e.key === "ArrowUp" || (e.key === "Tab" && e.shiftKey)) {
-			e.preventDefault();
-			setFocusedIndex((prev) => Math.max(prev - 1, -1));
-		} else if (
-			e.key === "Enter" &&
-			focusedIndex >= 0 &&
-			focusedIndex < filteredData.length
-		) {
-			const item = filteredData[focusedIndex];
-			if (!item) return;
-			e.preventDefault();
-			navigate({
-				to: "/ig/$packageId",
-				params: { packageId: item.id },
-				search: {
-					tab: undefined,
-					view: undefined,
-					q: undefined,
-					page: undefined,
-				},
-			});
-		}
-	};
-
 	return (
-		<div className="overflow-hidden h-full flex flex-col">
-			<div className="flex gap-4 items-center px-4 py-3 border-b border-border-secondary">
-				<HSComp.Input
-					autoFocus
-					type="text"
-					className="flex-1 bg-bg-primary"
-					placeholder="Search packages"
-					value={filterQuery}
-					onChange={(e) => setFilterQuery(e.target.value)}
-					onKeyDown={handleSearchKeyDown}
-					rightSlot={
-						filterQuery && (
-							<HSComp.IconButton
-								icon={<X />}
-								aria-label="Clear"
-								variant="link"
-								onClick={() => setFilterQuery("")}
+		<div ref={scrollRef} className="h-full overflow-y-auto pb-[250px]">
+			<div className="sticky top-0 z-10 bg-bg-primary py-4 shadow-[0_10px_10px_0_var(--color-bg-primary)]">
+				<div className="mx-auto max-w-[990px] px-8 flex items-start gap-3">
+					<SearchBar
+						chips={chips}
+						textPart={inputText}
+						inputRef={setSearchInputRef}
+						onTextChange={updateTextPart}
+						onRemoveChip={removeChip}
+						onClear={onClear}
+						onInputKeyDown={handleKeyDown}
+					/>
+					<HSComp.Button variant="secondary" className="shrink-0" asChild>
+						<Link to="/ig/add">
+							<PlusIcon
+								className="size-4 text-text-error-primary"
+								strokeWidth={1.25}
 							/>
-						)
-					}
-				/>
-				<HSComp.Button variant="primary" className="min-w-24">
-					Search
-				</HSComp.Button>
-				<div className="w-px h-6 bg-border-secondary" />
-				<HSComp.Button variant="secondary" asChild>
-					<Link to="/ig/add">
-						<PlusIcon
-							className="size-4 text-text-error-primary"
-							strokeWidth={1.25}
-						/>
-						Package
-					</Link>
-				</HSComp.Button>
+							Package
+						</Link>
+					</HSComp.Button>
+				</div>
 			</div>
-			<div className="grow min-h-0">
-				{!isLoading && filteredData.length === 0 ? (
+			{!isLoading && items.length === 0 ? (
+				<div className="mx-auto max-w-[990px] px-8">
 					<EmptyState
 						title="No packages found"
 						description="Try a different search query"
 					/>
-				) : (
-					<PackageList
-						data={filteredData}
-						isLoading={isLoading}
-						sort={sort}
-						onSort={handleSort}
-						focusedIndex={focusedIndex}
-					/>
-				)}
-			</div>
+				</div>
+			) : (
+				<div className="mx-auto max-w-[990px] px-8 bg-bg-primary">
+					<ul
+						style={{
+							position: "relative",
+							height: rowVirtualizer.getTotalSize(),
+						}}
+					>
+						{rowVirtualizer.getVirtualItems().map((vi) => {
+							const it = items[vi.index];
+							if (!it) return null;
+							return (
+								<div
+									key={it.id}
+									ref={rowVirtualizer.measureElement}
+									data-index={vi.index}
+									style={{
+										position: "absolute",
+										top: 0,
+										left: 0,
+										right: 0,
+										transform: `translateY(${vi.start}px)`,
+									}}
+								>
+									<ItemCard
+										item={it}
+										isFavorite={favorites.has(it.id)}
+										onTagClick={handleTagClick}
+										onToggleFavorite={toggleFavorite}
+										focused={vi.index === focusedIndex}
+									/>
+								</div>
+							);
+						})}
+					</ul>
+				</div>
+			)}
 		</div>
 	);
 }

--- a/src/components/IGBrowser/import-package.tsx
+++ b/src/components/IGBrowser/import-package.tsx
@@ -774,7 +774,7 @@ export function ImportPackage() {
 	useWebMCPImportPackage(actionsRef);
 
 	return (
-		<div className="w-full max-w-4xl px-4 py-4">
+		<div className="mx-auto max-w-[990px] px-8 py-4">
 			<MethodPicker selected={method} onSelect={setMethod} />
 
 			<div className="mt-6">

--- a/src/components/IGBrowser/import-package.tsx
+++ b/src/components/IGBrowser/import-package.tsx
@@ -326,7 +326,7 @@ function RegistryForm({
 			await queryClient.invalidateQueries({
 				queryKey: ["ig-browser-packages"],
 			});
-			navigate({ to: "/ig", search: { q: undefined, sort: undefined } });
+			navigate({ to: "/ig", search: { q: undefined, tags: undefined } });
 		} catch (error) {
 			hadError = true;
 			await Utils.onError(error);
@@ -513,7 +513,7 @@ function UrlForm({
 			await queryClient.invalidateQueries({
 				queryKey: ["ig-browser-packages"],
 			});
-			navigate({ to: "/ig", search: { q: undefined, sort: undefined } });
+			navigate({ to: "/ig", search: { q: undefined, tags: undefined } });
 		} catch (error) {
 			hadError = true;
 			await Utils.onError(error);
@@ -642,7 +642,7 @@ function FileForm({
 			await queryClient.invalidateQueries({
 				queryKey: ["ig-browser-packages"],
 			});
-			navigate({ to: "/ig", search: { q: undefined, sort: undefined } });
+			navigate({ to: "/ig", search: { q: undefined, tags: undefined } });
 		} catch (error) {
 			hadError = true;
 			await Utils.onError(error);

--- a/src/components/IGBrowser/package-detail.tsx
+++ b/src/components/IGBrowser/package-detail.tsx
@@ -1,30 +1,36 @@
 import * as HSComp from "@health-samurai/react-components";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+	useInfiniteQuery,
+	useMutation,
+	useQuery,
+	useQueryClient,
+} from "@tanstack/react-query";
 import {
 	Link,
 	useNavigate,
 	useParams,
 	useSearch,
 } from "@tanstack/react-router";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import {
-	ChevronLeftIcon,
-	ChevronRightIcon,
 	Loader2Icon,
 	RefreshCwIcon,
+	Search,
 	Trash2Icon,
 	X,
 } from "lucide-react";
 import {
 	type RefObject,
 	useCallback,
+	useDeferredValue,
 	useEffect,
+	useMemo,
 	useRef,
 	useState,
 } from "react";
 import type { AidboxClientR5 } from "../../AidboxClient";
 import { useAidboxClient } from "../../AidboxClient";
 import * as Utils from "../../api/utils";
-import { useDebounce } from "../../hooks/useDebounce";
 import { useLocalStorage } from "../../hooks/useLocalStorage";
 import { useWebMCPPackageDetail } from "../../webmcp/package-detail";
 import type { PackageDetailActions } from "../../webmcp/package-detail-context";
@@ -441,7 +447,6 @@ function VisualView({ meta }: { meta: PackageMeta }) {
 										tab: undefined,
 										view: undefined,
 										q: undefined,
-										page: undefined,
 									}}
 									className="text-text-link hover:underline text-sm"
 								>
@@ -554,102 +559,55 @@ function PackageInfoContent({
 	);
 }
 
-type CanonicalEntry = {
-	resource: {
-		resourceType: string;
-		id: string;
-		url?: string;
-		title?: string;
-		name?: string;
-		version?: string;
-		status?: string;
-	};
+type PackageEntity = {
+	resourceType: string;
+	id: string;
+	url?: string;
+	title?: string;
+	name?: string;
+	version?: string;
+	status?: string;
+	description?: string;
+	purpose?: string;
+	type?: string;
+	derivation?: string;
+	base?: string[];
 };
 
-type CanonicalResult = {
+type PackageEntityEntry = {
+	resource: PackageEntity;
+};
+
+type PackageEntitiesResult = {
 	total: number;
-	entry: CanonicalEntry[];
+	entry: PackageEntityEntry[];
 };
 
 const PAGE_SIZE = 50;
 
-function PaginationPages({
-	currentPage,
-	totalPages,
-	onPageChange,
-}: {
-	currentPage: number;
-	totalPages: number;
-	onPageChange: (page: number) => void;
-}) {
-	const pages: (number | string)[] = [];
-	if (totalPages <= 7) {
-		for (let i = 1; i <= totalPages; i++) pages.push(i);
-	} else {
-		pages.push(1);
-		if (currentPage > 3) pages.push("ellipsis-start");
-		const start = Math.max(2, currentPage - 1);
-		const end = Math.min(totalPages - 1, currentPage + 1);
-		for (let i = start; i <= end; i++) pages.push(i);
-		if (currentPage < totalPages - 2) pages.push("ellipsis-end");
-		pages.push(totalPages);
-	}
+const ENTITY_ELEMENTS =
+	"id,url,name,title,version,status,description,purpose,type,derivation,base";
 
-	return (
-		<div className="flex items-center gap-1">
-			<HSComp.Button
-				variant="ghost"
-				size="small"
-				disabled={currentPage <= 1}
-				onClick={() => onPageChange(currentPage - 1)}
-			>
-				<ChevronLeftIcon size={16} />
-			</HSComp.Button>
-			{pages.map((p) =>
-				typeof p === "string" ? (
-					<span key={p} className="px-1 text-text-secondary">
-						...
-					</span>
-				) : (
-					<HSComp.Button
-						key={p}
-						variant={p === currentPage ? "secondary" : "ghost"}
-						size="small"
-						onClick={() => onPageChange(p)}
-					>
-						{p}
-					</HSComp.Button>
-				),
-			)}
-			<HSComp.Button
-				variant="ghost"
-				size="small"
-				disabled={currentPage >= totalPages}
-				onClick={() => onPageChange(currentPage + 1)}
-			>
-				<ChevronRightIcon size={16} />
-			</HSComp.Button>
-		</div>
-	);
-}
-
-async function fetchCanonicals(
+async function fetchPackageEntities(
 	client: AidboxClientR5,
 	packageId: string,
+	resourceType: string,
 	substring: string,
 	page: number,
-): Promise<CanonicalResult> {
+): Promise<PackageEntitiesResult> {
 	const response = await client.rawRequest({
 		method: "POST",
-		url: "/rpc?_m=aidbox.introspector/search-package-canonicals",
+		url: "/rpc?_m=aidbox.introspector/get-package-entities",
 		headers: { "Content-Type": "application/json" },
 		body: JSON.stringify({
-			method: "aidbox.introspector/search-package-canonicals",
+			method: "aidbox.introspector/get-package-entities",
 			params: {
 				"package-coordinate": packageId,
+				"resource-type": resourceType,
 				...(substring ? { substring } : {}),
 				count: PAGE_SIZE,
 				page,
+				elements: ENTITY_ELEMENTS,
 			},
 		}),
 	});
@@ -657,98 +615,298 @@ async function fetchCanonicals(
 	return json.result ?? { total: 0, entry: [] };
 }
 
-function useCanonicals(packageId: string, substring: string, page: number) {
+function usePackageEntitiesInfinite(
+	packageId: string,
+	resourceType: string,
+	substring: string,
+) {
 	const client = useAidboxClient();
 
-	return useQuery<CanonicalResult>({
-		queryKey: ["ig-canonicals", packageId, substring, page],
+	return useInfiniteQuery<PackageEntitiesResult>({
+		queryKey: [
+			"ig-package-entities-infinite",
+			packageId,
+			resourceType,
+			substring,
+		],
 		staleTime: 5 * 60 * 1000,
-		queryFn: () => fetchCanonicals(client, packageId, substring, page),
+		initialPageParam: 1,
+		queryFn: ({ pageParam }) =>
+			fetchPackageEntities(
+				client,
+				packageId,
+				resourceType,
+				substring,
+				pageParam as number,
+			),
+		getNextPageParam: (lastPage, allPages) => {
+			const loaded = allPages.reduce((sum, p) => sum + p.entry.length, 0);
+			return loaded < lastPage.total ? allPages.length + 1 : undefined;
+		},
 	});
 }
 
-function ResizeHandle({
-	width,
-	onWidthChange,
-}: {
-	width: number;
-	onWidthChange: (width: number) => void;
-}) {
-	const handleMouseDown = useCallback(
-		(e: React.MouseEvent) => {
-			e.preventDefault();
-			const startX = e.clientX;
-			const startWidth = width;
-			const onMouseMove = (ev: MouseEvent) => {
-				onWidthChange(Math.max(80, startWidth + ev.clientX - startX));
-			};
-			const onMouseUp = () => {
-				document.removeEventListener("mousemove", onMouseMove);
-				document.removeEventListener("mouseup", onMouseUp);
-			};
-			document.addEventListener("mousemove", onMouseMove);
-			document.addEventListener("mouseup", onMouseUp);
+function usePackageResourceTypes(packageId: string) {
+	const client = useAidboxClient();
+
+	return useQuery<string[]>({
+		queryKey: ["ig-package-resource-types", packageId],
+		staleTime: 5 * 60 * 1000,
+		queryFn: async () => {
+			const response = await client.rawRequest({
+				method: "POST",
+				url: "/rpc?_m=aidbox.introspector/list-package-resource-types",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					method: "aidbox.introspector/list-package-resource-types",
+					params: { "package-coordinate": packageId },
+				}),
+			});
+			const json = await response.response.json();
+			return json.result?.["resource-types"] ?? [];
 		},
-		[width, onWidthChange],
-	);
+	});
+}
+
+function pickEntityTitle(r: PackageEntity): string {
+	return r.name || r.title || r.id;
+}
+
+function pickEntityDescription(r: PackageEntity): string | undefined {
+	return r.description || r.url;
+}
+
+const PER_RESOURCE_TYPE_TAG_FIELDS: Record<string, (keyof PackageEntity)[]> = {
+	StructureDefinition: ["type", "derivation"],
+	SearchParameter: ["base"],
+};
+
+const COMMON_TAG_FIELDS: (keyof PackageEntity)[] = ["status"];
+
+function pickEntityTags(r: PackageEntity): string[] {
+	const fields = [
+		...(PER_RESOURCE_TYPE_TAG_FIELDS[r.resourceType] ?? []),
+		...COMMON_TAG_FIELDS,
+	];
+	return fields.flatMap((f) => {
+		const v = r[f];
+		if (typeof v === "string" && v.length > 0) return [v];
+		if (Array.isArray(v))
+			return v.filter(
+				(x): x is string => typeof x === "string" && x.length > 0,
+			);
+		return [];
+	});
+}
+
+function PackageEntityCard({
+	packageId,
+	resource,
+	focused,
+}: {
+	packageId: string;
+	resource: PackageEntity;
+	focused: boolean;
+}) {
+	const tags = pickEntityTags(resource);
+	const title = pickEntityTitle(resource);
+	const description = pickEntityDescription(resource);
 
 	return (
-		<div
-			onMouseDown={handleMouseDown}
-			className="absolute top-0 right-0 h-full w-1 cursor-col-resize opacity-0 hover:opacity-100 bg-border-secondary"
-			style={{ userSelect: "none", touchAction: "none" }}
-		/>
+		<li
+			className={`relative transition-colors hover:bg-bg-secondary border-b border-border-default ${focused ? "bg-bg-secondary" : ""}`}
+		>
+			<Link
+				to="/ig/$packageId/resource/$resourceType/$resourceId"
+				params={{
+					packageId,
+					resourceType: resource.resourceType,
+					resourceId: resource.id,
+				}}
+				search={{ view: undefined }}
+				className="block"
+			>
+				<div className="flex flex-col px-4 py-3 min-w-0">
+					<div className="typo-body text-text-primary truncate">{title}</div>
+					{description && description !== title && (
+						<div className="typo-body-xs text-text-secondary mt-0.5 line-clamp-1">
+							{description}
+						</div>
+					)}
+					{tags.length > 0 && (
+						<div className="flex flex-nowrap items-center gap-x-2 mt-2 overflow-hidden">
+							{tags.map((tag) => (
+								<span
+									key={tag}
+									className="shrink-0 text-[11px] leading-4 normal-case whitespace-nowrap text-text-info-primary"
+								>
+									#{tag}
+								</span>
+							))}
+						</div>
+					)}
+				</div>
+			</Link>
+		</li>
 	);
 }
 
-function CanonicalsContent({
+function PackageEntityCardSkeleton({ index }: { index: number }) {
+	return (
+		<li className="border-b border-border-default">
+			<div className="flex flex-col gap-2 px-4 py-3">
+				<HSComp.Skeleton
+					className="h-5"
+					style={{ width: `${140 + ((index * 23) % 200)}px` }}
+				/>
+				<HSComp.Skeleton
+					className="h-4"
+					style={{ width: `${200 + ((index * 17) % 200)}px` }}
+				/>
+				<div className="flex gap-2">
+					<HSComp.Skeleton className="h-4 w-12" />
+					<HSComp.Skeleton className="h-4 w-16" />
+				</div>
+			</div>
+		</li>
+	);
+}
+
+function EntitiesContent({
 	packageId,
+	resourceType,
 	actionsRef,
 }: {
 	packageId: string;
+	resourceType: string;
 	actionsRef: RefObject<PackageDetailActions>;
 }) {
 	const client = useAidboxClient();
 	const navigate = useNavigate();
-	const { q, page: urlPage } = useSearch({ from: "/ig/$packageId/" });
-	const substring = q ?? "";
-	const page = urlPage ?? 1;
-	const [search, setSearch] = useState(substring);
-	const [resourceTypeWidth, setResourceTypeWidth] = useState(192);
-	const [titleWidth, setTitleWidth] = useState(256);
+	const { q } = useSearch({ from: "/ig/$packageId/" });
+	const urlText = q ?? "";
+
+	const [inputText, setInputText] = useState(urlText);
+	const substring = useDeferredValue(inputText);
+
+	const lastUrlTextRef = useRef(urlText);
+	useEffect(() => {
+		if (urlText !== lastUrlTextRef.current) {
+			lastUrlTextRef.current = urlText;
+			setInputText(urlText);
+		}
+	}, [urlText]);
+
+	const urlSyncTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const setUrlText = useCallback(
+		(next: string) => {
+			if (urlSyncTimerRef.current) clearTimeout(urlSyncTimerRef.current);
+			urlSyncTimerRef.current = setTimeout(() => {
+				lastUrlTextRef.current = next;
+				navigate({
+					from: "/ig/$packageId/",
+					search: (prev) => ({ ...prev, q: next || undefined }),
+					replace: true,
+				});
+			}, 200);
+		},
+		[navigate],
+	);
+	useEffect(
+		() => () => {
+			if (urlSyncTimerRef.current) clearTimeout(urlSyncTimerRef.current);
+		},
+		[],
+	);
+
+	const handleSearchChange = (next: string) => {
+		setInputText(next);
+		setUrlText(next);
+	};
+
+	const { data, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } =
+		usePackageEntitiesInfinite(packageId, resourceType, substring);
+
+	const items = useMemo(
+		() => data?.pages.flatMap((p) => p.entry) ?? [],
+		[data],
+	);
+
+	const scrollRef = useRef<HTMLDivElement | null>(null);
+	const searchWrapperRef = useRef<HTMLDivElement | null>(null);
+	useEffect(() => {
+		const id = requestAnimationFrame(() => {
+			searchWrapperRef.current
+				?.querySelector<HTMLInputElement>("input")
+				?.focus();
+		});
+		return () => cancelAnimationFrame(id);
+	}, []);
+
+	const rowVirtualizer = useVirtualizer({
+		count: items.length,
+		getScrollElement: () => scrollRef.current,
+		estimateSize: () => 90,
+		overscan: 8,
+		getItemKey: (i) => items[i]?.resource.id ?? i,
+	});
+
+	const virtualItems = rowVirtualizer.getVirtualItems();
+	useEffect(() => {
+		const last = virtualItems[virtualItems.length - 1];
+		if (!last) return;
+		if (last.index >= items.length - 5 && hasNextPage && !isFetchingNextPage) {
+			fetchNextPage();
+		}
+	}, [
+		virtualItems,
+		items.length,
+		hasNextPage,
+		isFetchingNextPage,
+		fetchNextPage,
+	]);
+
+	const [focusedIndex, setFocusedIndex] = useState(-1);
+	useEffect(() => {
+		if (focusedIndex < 0) return;
+		rowVirtualizer.scrollToIndex(focusedIndex, { align: "auto" });
+	}, [focusedIndex, rowVirtualizer]);
 
 	useEffect(() => {
-		setSearch(substring);
-	}, [substring]);
+		if (substring && items.length > 0) setFocusedIndex(0);
+		else setFocusedIndex(-1);
+	}, [substring, items.length]);
 
-	const debouncedNavigate = useDebounce((value: string) => {
-		navigate({
-			from: "/ig/$packageId/",
-			search: (prev) => ({
-				...prev,
-				q: value || undefined,
-				page: undefined,
-			}),
-		});
-	}, 300);
+	const navigateToResource = useCallback(
+		(resource: PackageEntity) => {
+			navigate({
+				to: "/ig/$packageId/resource/$resourceType/$resourceId",
+				params: {
+					packageId,
+					resourceType: resource.resourceType,
+					resourceId: resource.id,
+				},
+				search: { view: undefined },
+			});
+		},
+		[navigate, packageId],
+	);
 
-	const handleSearchChange = (value: string) => {
-		setSearch(value);
-		debouncedNavigate(value);
+	const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+		if (e.key === "ArrowDown" || (e.key === "Tab" && !e.shiftKey)) {
+			e.preventDefault();
+			setFocusedIndex((p) => Math.min(p + 1, items.length - 1));
+		} else if (e.key === "ArrowUp" || (e.key === "Tab" && e.shiftKey)) {
+			e.preventDefault();
+			setFocusedIndex((p) => Math.max(p - 1, -1));
+		} else if (e.key === "Enter") {
+			if (focusedIndex < 0) return;
+			const it = items[focusedIndex];
+			if (!it) return;
+			e.preventDefault();
+			navigateToResource(it.resource);
+		}
 	};
-
-	const setPage = (p: number) => {
-		navigate({
-			from: "/ig/$packageId/",
-			search: (prev) => ({
-				...prev,
-				page: p === 1 ? undefined : p,
-			}),
-		});
-	};
-
-	const { data, isLoading } = useCanonicals(packageId, substring, page);
-	const totalPages = data ? Math.ceil(data.total / PAGE_SIZE) : 0;
 
 	useEffect(() => {
 		actionsRef.current.searchCanonicals = async (
@@ -759,23 +917,18 @@ function CanonicalsContent({
 			const targetPage = p ?? 1;
 
 			if (query !== undefined) {
-				setSearch(query);
+				setInputText(query);
+				lastUrlTextRef.current = query;
 				navigate({
 					from: "/ig/$packageId/",
-					search: (prev) => ({
-						...prev,
-						q: query || undefined,
-						page: targetPage === 1 ? undefined : targetPage,
-					}),
+					search: (prev) => ({ ...prev, q: query || undefined }),
 				});
 			}
-			if (p !== undefined) {
-				setPage(p);
-			}
 
-			const result = await fetchCanonicals(
+			const result = await fetchPackageEntities(
 				client,
 				packageId,
+				resourceType,
 				targetQuery,
 				targetPage,
 			);
@@ -794,162 +947,85 @@ function CanonicalsContent({
 		};
 
 		actionsRef.current.selectCanonical = (id: string) => {
-			const entry = data?.entry.find((item) => item.resource.id === id);
-			if (entry) {
-				navigate({
-					to: "/ig/$packageId/resource/$resourceType/$resourceId",
-					params: {
-						packageId,
-						resourceType: entry.resource.resourceType,
-						resourceId: entry.resource.id,
-					},
-					search: { view: undefined },
-				});
-			}
+			const entry = items.find((item) => item.resource.id === id);
+			if (entry) navigateToResource(entry.resource);
 		};
 	});
 
 	return (
-		<div className="flex flex-col h-full min-h-0">
-			<div className="flex gap-4 items-center px-4 py-3 border-b border-border-secondary flex-none">
-				<HSComp.Input
-					type="text"
-					className="flex-1 bg-bg-primary"
-					placeholder="Search by resource type or URL, e.g. valueset birthsex"
-					autoFocus
-					value={search}
-					onChange={(e) => handleSearchChange(e.target.value)}
-					rightSlot={
-						search && (
-							<HSComp.IconButton
-								icon={<X />}
-								aria-label="Clear"
-								variant="link"
-								onClick={() => handleSearchChange("")}
-							/>
-						)
-					}
-				/>
-			</div>
-			<div className="grow min-h-0 overflow-hidden [&_[data-slot=table-container]]:overflow-visible [&_[data-slot=table-container]]:h-full [&_table]:flex [&_table]:flex-col [&_table]:h-full">
-				<HSComp.Table zebra className="typo-code">
-					<HSComp.TableHeader className="block shrink-0 overflow-y-scroll scrollbar-none [&_tr]:table [&_tr]:table-fixed [&_tr]:w-full">
-						<HSComp.TableRow>
-							<HSComp.TableHead
-								className="relative pl-7!"
-								style={{ width: resourceTypeWidth }}
-							>
-								Resource Type
-								<ResizeHandle
-									width={resourceTypeWidth}
-									onWidthChange={setResourceTypeWidth}
+		<div ref={scrollRef} className="h-full overflow-y-auto pb-[250px]">
+			<div className="sticky top-0 z-10 bg-bg-primary py-4 shadow-[0_10px_10px_0_var(--color-bg-primary)]">
+				<div ref={searchWrapperRef} className="mx-auto max-w-[990px] px-8">
+					<HSComp.Input
+						type="text"
+						className="bg-bg-primary"
+						placeholder={`Search ${resourceType}`}
+						leftSlot={<Search />}
+						value={inputText}
+						onChange={(e) => handleSearchChange(e.target.value)}
+						onKeyDown={handleKeyDown}
+						rightSlot={
+							inputText && (
+								<HSComp.IconButton
+									icon={<X />}
+									aria-label="Clear"
+									variant="link"
+									onClick={() => handleSearchChange("")}
 								/>
-							</HSComp.TableHead>
-							<HSComp.TableHead
-								className="relative"
-								style={{ width: titleWidth }}
-							>
-								Title
-								<ResizeHandle
-									width={titleWidth}
-									onWidthChange={setTitleWidth}
-								/>
-							</HSComp.TableHead>
-							<HSComp.TableHead>URL</HSComp.TableHead>
-						</HSComp.TableRow>
-					</HSComp.TableHeader>
-					<HSComp.TableBody className="block grow min-h-0 overflow-y-auto pb-10 [&_tr]:table [&_tr]:table-fixed [&_tr]:w-full">
-						{isLoading
-							? Array.from({ length: 30 }, (_, i) => (
-									// biome-ignore lint/suspicious/noArrayIndexKey: static skeleton
-									<HSComp.TableRow key={i} zebra index={i}>
-										<HSComp.TableCell
-											className="pl-7!"
-											style={{ width: resourceTypeWidth }}
-										>
-											<HSComp.Skeleton
-												className="h-5"
-												style={{
-													width: `${80 + ((i * 23) % 60)}px`,
-												}}
-											/>
-										</HSComp.TableCell>
-										<HSComp.TableCell style={{ width: titleWidth }}>
-											<HSComp.Skeleton
-												className="h-5"
-												style={{
-													width: `${100 + ((i * 17) % 120)}px`,
-												}}
-											/>
-										</HSComp.TableCell>
-										<HSComp.TableCell>
-											<HSComp.Skeleton
-												className="h-5"
-												style={{
-													width: `${200 + ((i * 31) % 200)}px`,
-												}}
-											/>
-										</HSComp.TableCell>
-									</HSComp.TableRow>
-								))
-							: data?.entry.map((item, index) => (
-									<HSComp.TableRow
-										key={item.resource.id}
-										zebra
-										index={index}
-										className="cursor-pointer"
-										onClick={() =>
-											navigate({
-												to: "/ig/$packageId/resource/$resourceType/$resourceId",
-												params: {
-													packageId,
-													resourceType: item.resource.resourceType,
-													resourceId: item.resource.id,
-												},
-												search: { view: undefined },
-											})
-										}
-									>
-										<HSComp.TableCell
-											className="text-text-secondary text-sm pl-7!"
-											style={{ width: resourceTypeWidth }}
-										>
-											{item.resource.resourceType}
-										</HSComp.TableCell>
-										<HSComp.TableCell
-											className="text-text-secondary text-sm truncate"
-											style={{ width: titleWidth }}
-											title={item.resource.name}
-										>
-											{item.resource.title ?? item.resource.name}
-										</HSComp.TableCell>
-										<HSComp.TableCell className="text-text-primary text-sm">
-											<Link
-												to="/ig/$packageId/resource/$resourceType/$resourceId"
-												params={{
-													packageId,
-													resourceType: item.resource.resourceType,
-													resourceId: item.resource.id,
-												}}
-												search={{ view: undefined }}
-												className="text-text-link hover:underline"
-												onClick={(e) => e.stopPropagation()}
-											>
-												{item.resource.url}
-											</Link>
-										</HSComp.TableCell>
-									</HSComp.TableRow>
-								))}
-					</HSComp.TableBody>
-				</HSComp.Table>
-			</div>
-			<div className="flex items-center justify-end border-t bg-bg-secondary px-4 h-10 flex-none">
-				{totalPages > 1 && (
-					<PaginationPages
-						currentPage={page}
-						totalPages={totalPages}
-						onPageChange={setPage}
+							)
+						}
 					/>
+				</div>
+			</div>
+			<div className="mx-auto max-w-[990px] px-8 bg-bg-primary">
+				{isLoading ? (
+					<ul>
+						{Array.from({ length: 15 }, (_, i) => (
+							<PackageEntityCardSkeleton
+								// biome-ignore lint/suspicious/noArrayIndexKey: static skeleton rows
+								key={`skeleton-${i}`}
+								index={i}
+							/>
+						))}
+					</ul>
+				) : (
+					<ul
+						style={{
+							position: "relative",
+							height: rowVirtualizer.getTotalSize(),
+						}}
+					>
+						{virtualItems.map((vi) => {
+							const it = items[vi.index];
+							if (!it) return null;
+							return (
+								<div
+									key={it.resource.id}
+									ref={rowVirtualizer.measureElement}
+									data-index={vi.index}
+									style={{
+										position: "absolute",
+										top: 0,
+										left: 0,
+										right: 0,
+										transform: `translateY(${vi.start}px)`,
+									}}
+								>
+									<PackageEntityCard
+										packageId={packageId}
+										resource={it.resource}
+										focused={vi.index === focusedIndex}
+									/>
+								</div>
+							);
+						})}
+					</ul>
+				)}
+				{isFetchingNextPage && (
+					<div className="flex items-center justify-center py-4 text-text-secondary text-sm">
+						<Loader2Icon className="size-4 animate-spin mr-2" />
+						Loading more…
+					</div>
 				)}
 			</div>
 		</div>
@@ -1010,11 +1086,19 @@ export function PackageDetail() {
 	const client = useAidboxClient();
 	const queryClient = useQueryClient();
 	const { data, isLoading } = usePackageMeta(packageId);
+	const { data: resourceTypes, isPending: resourceTypesPending } =
+		usePackageResourceTypes(packageId);
 	const [storedTab, setStoredTab] = useLocalStorage<string>({
 		key: IG_TAB_KEY,
-		defaultValue: "canonicals",
+		defaultValue: "",
 	});
-	const currentTab = tab ?? storedTab;
+	const defaultTab = resourceTypes?.[0] ?? "package-info";
+	const requestedTab = tab ?? storedTab;
+	const currentTab =
+		requestedTab &&
+		(requestedTab === "package-info" || resourceTypes?.includes(requestedTab))
+			? requestedTab
+			: defaultTab;
 
 	const switchTab = (v: string) => {
 		setStoredTab(v);
@@ -1022,8 +1106,9 @@ export function PackageDetail() {
 			from: "/ig/$packageId/",
 			search: (prev) => ({
 				...prev,
-				tab: (v === "canonicals" ? undefined : v) as "package-info" | undefined,
+				tab: v,
 				view: v === "package-info" ? prev.view : undefined,
+				q: undefined,
 			}),
 			replace: true,
 		});
@@ -1074,12 +1159,9 @@ export function PackageDetail() {
 			void v;
 		},
 		searchCanonicals: async () => {
-			switchTab("canonicals");
 			return { total: 0, page: 1, totalPages: 0, entries: [] };
 		},
-		selectCanonical: () => {
-			switchTab("canonicals");
-		},
+		selectCanonical: () => {},
 		reinstallPackage: () => reinstallMutation.mutate(),
 		deletePackage: () => deleteMutation.mutate(),
 	});
@@ -1097,6 +1179,10 @@ export function PackageDetail() {
 
 	useWebMCPPackageDetail(actionsRef);
 
+	if (resourceTypesPending) {
+		return <LoadingSkeleton />;
+	}
+
 	return (
 		<HSComp.Tabs
 			value={currentTab}
@@ -1105,18 +1191,16 @@ export function PackageDetail() {
 		>
 			<div className="flex items-center bg-bg-primary flex-none border-b border-border-secondary">
 				<HSComp.TabsList className="pl-4">
-					<HSComp.TabsTrigger value="canonicals">Canonicals</HSComp.TabsTrigger>
 					<HSComp.TabsTrigger value="package-info">
 						Package Info
 					</HSComp.TabsTrigger>
+					{(resourceTypes ?? []).map((rt) => (
+						<HSComp.TabsTrigger key={rt} value={rt}>
+							{rt}
+						</HSComp.TabsTrigger>
+					))}
 				</HSComp.TabsList>
 			</div>
-			<HSComp.TabsContent
-				value="canonicals"
-				className="grow min-h-0 flex flex-col"
-			>
-				<CanonicalsContent packageId={packageId} actionsRef={actionsRef} />
-			</HSComp.TabsContent>
 			<HSComp.TabsContent value="package-info" className="overflow-auto">
 				{isLoading ? (
 					<LoadingSkeleton />
@@ -1131,6 +1215,21 @@ export function PackageDetail() {
 					/>
 				) : null}
 			</HSComp.TabsContent>
+			{(resourceTypes ?? []).map((rt) => (
+				<HSComp.TabsContent
+					key={rt}
+					value={rt}
+					className="grow min-h-0 flex flex-col"
+				>
+					{currentTab === rt && (
+						<EntitiesContent
+							packageId={packageId}
+							resourceType={rt}
+							actionsRef={actionsRef}
+						/>
+					)}
+				</HSComp.TabsContent>
+			))}
 		</HSComp.Tabs>
 	);
 }

--- a/src/components/IGBrowser/package-detail.tsx
+++ b/src/components/IGBrowser/package-detail.tsx
@@ -1057,7 +1057,7 @@ export function PackageDetail() {
 		onError: Utils.onMutationError,
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: ["ig-browser-packages"] });
-			navigate({ to: "/ig", search: { q: undefined, sort: undefined } });
+			navigate({ to: "/ig", search: { q: undefined, tags: undefined } });
 		},
 	});
 

--- a/src/components/ResourceBrowser/browser.tsx
+++ b/src/components/ResourceBrowser/browser.tsx
@@ -496,6 +496,7 @@ export function Browser() {
 		getScrollElement: () => scrollRef.current,
 		estimateSize: () => 90,
 		overscan: 8,
+		getItemKey: (index) => items[index]?.resourceType ?? index,
 	});
 
 	useEffect(() => {

--- a/src/layout/sidebar.tsx
+++ b/src/layout/sidebar.tsx
@@ -103,7 +103,7 @@ const mainMenuItems: {
 		url: "/ig",
 		title: "FHIR packages",
 		link: (
-			<Link to="/ig" search={{ q: undefined, sort: undefined }}>
+			<Link to="/ig" search={{ q: undefined, tags: undefined }}>
 				<Package />
 				FHIR packages
 			</Link>

--- a/src/routes/ig.$packageId.index.tsx
+++ b/src/routes/ig.$packageId.index.tsx
@@ -3,10 +3,12 @@ import { PackageDetail } from "../components/IGBrowser/package-detail";
 
 export const Route = createFileRoute("/ig/$packageId/")({
 	component: PackageDetail,
-	validateSearch: (search) => ({
-		tab: search.tab === "package-info" ? ("package-info" as const) : undefined,
+	validateSearch: (search): { tab?: string; view?: "json"; q?: string } => ({
+		tab:
+			typeof search.tab === "string" && search.tab.length > 0
+				? search.tab
+				: undefined,
 		view: search.view === "json" ? ("json" as const) : undefined,
 		q: typeof search.q === "string" ? search.q : undefined,
-		page: typeof search.page === "number" ? search.page : undefined,
 	}),
 });

--- a/src/routes/ig.index.tsx
+++ b/src/routes/ig.index.tsx
@@ -3,11 +3,22 @@ import { Browser } from "../components/IGBrowser/browser";
 
 export const Route = createFileRoute("/ig/")({
 	component: RouteComponent,
-	validateSearch: (search) => ({
-		q: typeof search.q === "string" && search.q ? search.q : undefined,
-		sort:
-			typeof search.sort === "string" && search.sort ? search.sort : undefined,
-	}),
+	validateSearch: (search: {
+		q?: unknown;
+		tags?: unknown;
+	}): { q?: string; tags?: string[] } => {
+		const out: { q?: string; tags?: string[] } = {};
+		if (typeof search.q === "string" && search.q.length > 0) out.q = search.q;
+		if (Array.isArray(search.tags)) {
+			const tags = search.tags.filter(
+				(t): t is string => typeof t === "string" && t.length > 0,
+			);
+			if (tags.length > 0) out.tags = tags;
+		} else if (typeof search.tags === "string" && search.tags.length > 0) {
+			out.tags = [search.tags];
+		}
+		return out;
+	},
 });
 
 function RouteComponent() {

--- a/src/webmcp/ig-browser-context.ts
+++ b/src/webmcp/ig-browser-context.ts
@@ -3,18 +3,11 @@ import { createContext, use } from "react";
 export interface IGBrowserPackage {
 	name: string;
 	version: string;
-	type: string;
-}
-
-export interface IGBrowserSort {
-	column: "name" | "type";
-	direction: "asc" | "desc";
+	tags: string[];
 }
 
 export interface IGBrowserActions {
 	listPackages: (query?: string) => IGBrowserPackage[];
-	getSort: () => IGBrowserSort;
-	sortPackages: (column: "name" | "type") => void;
 	selectPackage: (id: string) => void;
 	openInstallationPage: () => void;
 }

--- a/src/webmcp/ig-browser.ts
+++ b/src/webmcp/ig-browser.ts
@@ -8,7 +8,6 @@ function textResult(text: string) {
 
 const TOOL_NAMES = [
 	"list_packages",
-	"sort_packages",
 	"select_package",
 	"open_installation_page",
 ] as const;
@@ -21,14 +20,16 @@ export function useWebMCPIGBrowser(actionsRef: RefObject<IGBrowserActions>) {
 			name: "list_packages",
 			description:
 				"[FHIR Packages] Set the search filter and return the filtered list of installed FHIR packages. " +
-				"Returns an array of {name, version, type} objects.",
+				"The query supports tag chips combined with free text matched against name, version and description. " +
+				"Tags include the install kind (#system, #direct, #transitive) and the package type (e.g. #fhir.core, #fhir.ig, #ig, #conformance). " +
+				"Returns an array of {name, version, tags} objects.",
 			inputSchema: {
 				type: "object",
 				properties: {
 					query: {
 						type: "string",
 						description:
-							"Optional search query to filter packages by name or type",
+							"Optional search query. Free text is fuzzy-matched against name, version and description; tokens prefixed with # (e.g. #system #direct #transitive) filter by tag.",
 					},
 				},
 			},
@@ -37,11 +38,9 @@ export function useWebMCPIGBrowser(actionsRef: RefObject<IGBrowserActions>) {
 					| string
 					| undefined;
 				const packages = actionsRef.current.listPackages(query);
-				const sort = actionsRef.current.getSort();
 				return textResult(
 					JSON.stringify(
 						{
-							sort,
 							total: packages.length,
 							packages,
 						},
@@ -49,30 +48,6 @@ export function useWebMCPIGBrowser(actionsRef: RefObject<IGBrowserActions>) {
 						2,
 					),
 				);
-			},
-		});
-
-		navigator.modelContext.registerTool({
-			name: "sort_packages",
-			description:
-				"[FHIR Packages] Sort the packages table by clicking a column header. " +
-				"Works like a toggle: first call sorts asc, second call on the same column flips to desc. " +
-				"Returns the resulting sort state.",
-			inputSchema: {
-				type: "object",
-				properties: {
-					column: {
-						type: "string",
-						enum: ["name", "type"],
-						description: "Column to sort by",
-					},
-				},
-				required: ["column"],
-			},
-			execute: async (args: { column: "name" | "type" }) => {
-				actionsRef.current.sortPackages(args.column);
-				const result = actionsRef.current.getSort();
-				return textResult(JSON.stringify(result));
 			},
 		});
 


### PR DESCRIPTION
## Summary

Two-step redesign of the IG / FHIR-packages screens to match the Resource Browser UX.

- **Package list (`/ig`) and add-package screen** moved to the 990px centred container and the card layout used by the Resource Browser (title, description, tags), replacing the dense table on `/ig/<package>`.
- **Package detail** now renders one tab per resource type actually present in the package (driven by the new backend `aidbox.introspector/list-package-resource-types` RPC) plus the existing **Package Info** tab. The legacy single "Canonicals" tab is gone.
- Each resource-type tab uses **`get-package-entities`** (`search-canonical` underneath) with the same UX as the Resource Browser:
  - Magnifying-glass search input with autofocus on tab switch.
  - Whitespace-tokens AND search against `url` (backed by the new multi-token `url:contains` handler in FAR).
  - Keyboard nav (arrows / Tab / Enter) over a virtualized list.
  - Infinite scroll (`useInfiniteQuery`, 50 per page).
  - Card layout — `name || title || id`, `description || url`, tags.
- **Per-resource-type tags** with a common `status` suffix:
  - `StructureDefinition` → `type`, `derivation`, `status`
  - `SearchParameter` → `base[]`, `status`
  - others → `status`

Tab order is curated on the backend (StructureDefinition → SearchParameter → ValueSet → CodeSystem → ConceptMap → NamingSystem → TerminologyCapabilities → others alphabetically), so deep-link `?tab=...` is stable. `FHIRSchema` / `ImplementationGuide` are intentionally excluded.

Initial render no longer flashes the wrong tab — we wait for the resource-types query before mounting `<Tabs>`.

Companion backend changes: HealthSamurai/box `#6320` (`list-package-resource-types` RPC + multi-token `url:contains`).

## Test plan
- [ ] `/u/ig` shows the card list with the 990px container.
- [ ] `/u/ig/add` shows the same container.
- [ ] Navigating into a package: tabs match the types in the package (e.g. for `hl7.fhir.us.core#7.0.0` — `StructureDefinition`, `ValueSet`, `CodeSystem`), no `FHIRSchema`/`ImplementationGuide`.
- [ ] Switching tabs autofocuses the search input.
- [ ] Searching with multiple space-separated tokens combines them as AND against the URL.
- [ ] Arrow keys / Tab navigate the list; Enter opens the focused entry.
- [ ] Scrolling near the bottom fetches the next page (50 entries).
- [ ] Deep-link `?tab=ValueSet&q=race` restores state.
- [ ] `StructureDefinition` cards show `type`, `derivation`, `status` tags; `SearchParameter` cards show one tag per `base` plus `status`.