### PR TITLE
DB Console: show query duration next to view toggle

### DIFF
--- a/src/components/db-console/result-panel.tsx
+++ b/src/components/db-console/result-panel.tsx
@@ -10,6 +10,7 @@ import {
 	Minimize2,
 	PanelBottomClose,
 	PanelBottomOpen,
+	Timer,
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import type { QueryResultItem } from "../../webmcp/db-console-context";
@@ -66,6 +67,12 @@ export function ResultPanel({
 		[results],
 	);
 
+	const totalDuration = useMemo(
+		() =>
+			results ? results.reduce((sum, r) => sum + (r.duration ?? 0), 0) : null,
+		[results],
+	);
+
 	return (
 		<div
 			className={`flex flex-col h-full ${isMaximized ? "absolute top-0 left-0 w-full h-full z-30 bg-bg-primary" : ""}`}
@@ -77,6 +84,13 @@ export function ResultPanel({
 					</span>
 				</div>
 				<div className="flex items-center gap-2">
+					{totalDuration !== null && results && results.length > 0 && (
+						<span className="flex items-center text-text-secondary text-sm pl-2">
+							<Timer className="size-4 mr-1" strokeWidth={1.5} />
+							<span className="font-bold">{Math.round(totalDuration)}</span>
+							<span className="ml-1">ms</span>
+						</span>
+					)}
 					<SegmentControl
 						value={viewMode}
 						onValueChange={(v) => setViewMode(v as "table" | "list")}

--- a/src/components/db-console/tables-view.tsx
+++ b/src/components/db-console/tables-view.tsx
@@ -132,12 +132,14 @@ export function psqlRequest<T = Record<string, unknown>>(
 
 export function transformToQueryResultItems(
 	data: NotebookPsqlResponse,
+	blockDurationMs: number | null = null,
 ): QueryResultItem[] {
+	const blockDuration = blockDurationMs ?? data.duration;
 	if (data.status === "error") {
 		return [
 			{
 				query: data.query,
-				duration: data.duration,
+				duration: blockDuration,
 				status: "error",
 				error: data.error,
 				position: data.position,
@@ -147,11 +149,12 @@ export function transformToQueryResultItems(
 		];
 	}
 	if (!data.result) return [];
-	return data.result.map((entry) => {
+	return data.result.map((entry, idx) => {
+		const duration = idx === 0 ? blockDuration : 0;
 		if (entry.type === "rset") {
 			return {
 				query: data.query,
-				duration: data.duration,
+				duration,
 				status: "success",
 				result: entry.data,
 				rows: entry.data.length,
@@ -159,7 +162,7 @@ export function transformToQueryResultItems(
 		}
 		return {
 			query: data.query,
-			duration: data.duration,
+			duration,
 			status: "success",
 			result: [{ affected_rows: entry.data }],
 			rows: entry.data,

--- a/src/routes/db-console.tsx
+++ b/src/routes/db-console.tsx
@@ -130,7 +130,15 @@ async function fetchBlock(
 		const text = await response.text();
 		throw new Error(`HTTP ${response.status}: ${text}`);
 	}
-	return transformToQueryResultItems(await response.json());
+	const headerNum = (name: string) => {
+		const raw = response.headers.get(name);
+		if (!raw) return null;
+		const n = Number(raw);
+		return Number.isFinite(n) ? n : null;
+	};
+	const blockDuration =
+		headerNum("x-temp-dur-in-pg") ?? headerNum("x-duration");
+	return transformToQueryResultItems(await response.json(), blockDuration);
 }
 
 async function kickOffAsync(


### PR DESCRIPTION
## Summary
- Mirror the REST Console timer indicator (Timer icon + bold `Nms`) in the DB Console result panel header.
- Place it inside the right-hand controls cluster, immediately to the left of the Table/List `SegmentControl`.
- Duration is summed across all `QueryResultItem`s, so multi-statement runs report a single total.

## Test plan
- [ ] Open `/u/db-console`, run a single `SELECT`, see `<Timer> Nms` rendered right before the Table/List toggle.
- [ ] Run multi-statement SQL and confirm the value equals the sum of all block durations.
- [ ] Confirm the indicator disappears when there are no results (initial state, after error before any run).