### PR TITLE
Terminology UI: CodeSystem & ValueSet Builders + dependency graph

### DIFF
--- a/src/components/CodeSystem/builder-content.tsx
+++ b/src/components/CodeSystem/builder-content.tsx
@@ -1,0 +1,107 @@
+import * as HSComp from "@health-samurai/react-components";
+import { useMutation } from "@tanstack/react-query";
+import { useAidboxClient } from "../../AidboxClient";
+import * as Utils from "../../api/utils";
+import { cleanEmptyValues } from "../../utils/clean-empty-values";
+import { addUrlToHistory } from "../../utils/url-history";
+import { useCodeSystemContext } from "./context";
+import { EditorHeaderMenu } from "./header-menu";
+import { PropertiesTree } from "./properties-tree";
+import type { CodeSystem } from "./types";
+
+function toOperationOutcome(err: unknown): HSComp.OperationOutcome {
+	if (
+		typeof err === "object" &&
+		err !== null &&
+		"resourceType" in err &&
+		(err as { resourceType: string }).resourceType === "OperationOutcome"
+	) {
+		return err as unknown as HSComp.OperationOutcome;
+	}
+	return {
+		resourceType: "OperationOutcome",
+		issue: [
+			{
+				severity: "error",
+				code: "exception",
+				diagnostics: err instanceof Error ? err.message : String(err),
+			},
+		],
+	};
+}
+
+export const CodeSystemBuilderContent = () => {
+	const client = useAidboxClient();
+	const { codeSystem, setMissingFields, setIsDirty } = useCodeSystemContext();
+
+	const saveMutation = useMutation({
+		mutationFn: async () => {
+			const missing = new Set<string>();
+			if (!codeSystem.status) missing.add("status");
+			if (missing.size > 0) {
+				setMissingFields(missing);
+				throw {
+					resourceType: "OperationOutcome",
+					issue: [
+						{
+							severity: "error",
+							code: "required",
+							diagnostics: `Missing required field${missing.size > 1 ? "s" : ""}: ${[...missing].join(", ")}`,
+						},
+					],
+				};
+			}
+			setMissingFields(new Set());
+			const payload = cleanEmptyValues(codeSystem);
+			if (payload.id) {
+				const result = await client.request<CodeSystem>({
+					method: "PUT",
+					url: `/fhir/CodeSystem/${payload.id}`,
+					body: JSON.stringify(payload),
+					headers: { "Content-Type": "application/json" },
+				});
+				if (result.isErr()) throw result.value.resource;
+				return result.value.resource;
+			}
+			const result = await client.request<CodeSystem>({
+				method: "POST",
+				url: "/fhir/CodeSystem",
+				body: JSON.stringify(payload),
+				headers: { "Content-Type": "application/json" },
+			});
+			if (result.isErr()) throw result.value.resource;
+			return result.value.resource;
+		},
+		onSuccess: () => {
+			addUrlToHistory("codesystem-builder:url-history", codeSystem.url);
+			setIsDirty(false);
+			HSComp.toast.success("CodeSystem saved successfully", {
+				position: "bottom-right",
+				style: { margin: "1rem" },
+			});
+		},
+		onError: (err) => {
+			const oo = toOperationOutcome(err);
+			Utils.toastError(
+				"Failed to save CodeSystem",
+				oo.issue?.[0]?.diagnostics ?? undefined,
+			);
+		},
+	});
+
+	return (
+		<div className="relative h-full grow min-h-0 flex flex-col">
+			<div className="flex flex-col h-full">
+				<EditorHeaderMenu
+					onSave={() => saveMutation.mutate()}
+					isSaveDisabled={saveMutation.isPending}
+				/>
+				<div className="flex-1 min-h-0 overflow-auto">
+					<div className="min-h-full bg-bg-primary px-2.5 pt-3 pb-[250px]">
+						<PropertiesTree />
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+};

--- a/src/components/CodeSystem/codesystem-hash.ts
+++ b/src/components/CodeSystem/codesystem-hash.ts
@@ -1,0 +1,6 @@
+import { cleanEmptyValues } from "../../utils/clean-empty-values";
+import type { CodeSystem } from "./types";
+
+export function computeCodeSystemHash(cs: CodeSystem): string {
+	return JSON.stringify(cleanEmptyValues(cs));
+}

--- a/src/components/CodeSystem/context.ts
+++ b/src/components/CodeSystem/context.ts
@@ -1,0 +1,24 @@
+import * as React from "react";
+import type { CodeSystem } from "./types";
+
+export type CodeSystemContextValue = {
+	codeSystem: CodeSystem;
+	updateCodeSystem: (updater: (cs: CodeSystem) => CodeSystem) => void;
+	missingFields: Set<string>;
+	setMissingFields: React.Dispatch<React.SetStateAction<Set<string>>>;
+	isDirty: boolean;
+	setIsDirty: (value: boolean) => void;
+};
+
+export const CodeSystemContext =
+	React.createContext<CodeSystemContextValue | null>(null);
+
+export function useCodeSystemContext(): CodeSystemContextValue {
+	const ctx = React.useContext(CodeSystemContext);
+	if (!ctx) {
+		throw new Error(
+			"useCodeSystemContext must be used within CodeSystemProvider",
+		);
+	}
+	return ctx;
+}

--- a/src/components/CodeSystem/header-menu.tsx
+++ b/src/components/CodeSystem/header-menu.tsx
@@ -1,0 +1,27 @@
+import * as HSComp from "@health-samurai/react-components";
+import { SaveIcon } from "lucide-react";
+
+export function EditorHeaderMenu({
+	onSave,
+	isSaveDisabled,
+}: {
+	onSave: () => void;
+	isSaveDisabled?: boolean;
+}) {
+	return (
+		<div className="flex items-center justify-between bg-bg-secondary flex-none h-10 border-b">
+			<div className="flex items-center gap-4 px-4">
+				<HSComp.Button
+					variant="ghost"
+					size="small"
+					className="px-0!"
+					onClick={onSave}
+					disabled={isSaveDisabled}
+				>
+					<SaveIcon className="w-4 h-4" />
+					Save
+				</HSComp.Button>
+			</div>
+		</div>
+	);
+}

--- a/src/components/CodeSystem/page.tsx
+++ b/src/components/CodeSystem/page.tsx
@@ -2,47 +2,48 @@ import type { Resource } from "@aidbox-ui/fhir-types/hl7-fhir-r5-core";
 import * as HSComp from "@health-samurai/react-components";
 import { useBlocker } from "@tanstack/react-router";
 import * as React from "react";
-import { ValueSetContext } from "./context";
-import type { ValueSet, ValueSetExpansion } from "./types";
-import { computeValueSetHash } from "./valueset-hash";
+import { computeCodeSystemHash } from "./codesystem-hash";
+import { CodeSystemContext } from "./context";
+import type { CodeSystem } from "./types";
 
-export function ValueSetProvider({
+export function CodeSystemProvider({
 	initialResource,
 	children,
 }: {
 	initialResource: Resource;
 	children: React.ReactNode;
 }) {
-	const [valueSet, setValueSet] = React.useState<ValueSet>(() => {
-		const vs = initialResource as ValueSet;
-		if (vs.id) return vs;
-		const patch: Partial<ValueSet> = {};
-		if (!vs.version) patch.version = "1.0.0";
-		if (!vs.status) patch.status = "draft";
-		return Object.keys(patch).length > 0 ? { ...vs, ...patch } : vs;
+	const [codeSystem, setCodeSystem] = React.useState<CodeSystem>(() => {
+		const cs = initialResource as CodeSystem;
+		if (cs.id) return cs;
+		const patch: Partial<CodeSystem> = {};
+		if (!cs.version) patch.version = "1.0.0";
+		if (!cs.status) patch.status = "draft";
+		if (!cs.content) patch.content = "complete";
+		return Object.keys(patch).length > 0 ? { ...cs, ...patch } : cs;
 	});
-	const valueSetRef = React.useRef(valueSet);
-	valueSetRef.current = valueSet;
+	const codeSystemRef = React.useRef(codeSystem);
+	codeSystemRef.current = codeSystem;
 
-	const updateValueSet = React.useCallback(
-		(updater: (vs: ValueSet) => ValueSet) => {
-			setValueSet((prev) => updater(prev));
+	const updateCodeSystem = React.useCallback(
+		(updater: (cs: CodeSystem) => CodeSystem) => {
+			setCodeSystem((prev) => updater(prev));
 		},
 		[],
 	);
 
 	const [baselineHash, setBaselineHash] = React.useState<string>(() =>
-		computeValueSetHash(valueSet),
+		computeCodeSystemHash(codeSystem),
 	);
 	const isDeletedRef = React.useRef(false);
 	const isDirty =
-		!isDeletedRef.current && computeValueSetHash(valueSet) !== baselineHash;
+		!isDeletedRef.current && computeCodeSystemHash(codeSystem) !== baselineHash;
 	const isDirtyRef = React.useRef(false);
 	isDirtyRef.current = isDirty;
 
 	const setIsDirty = React.useCallback((value: boolean) => {
 		if (!value) {
-			setBaselineHash(computeValueSetHash(valueSetRef.current));
+			setBaselineHash(computeCodeSystemHash(codeSystemRef.current));
 			isDirtyRef.current = false;
 		}
 	}, []);
@@ -56,15 +57,6 @@ export function ValueSetProvider({
 		return () => window.removeEventListener("aidbox-resource-deleted", handler);
 	}, []);
 
-	const [expansion, setExpansion] = React.useState<ValueSetExpansion | null>(
-		null,
-	);
-	const [expandError, setExpandError] =
-		React.useState<HSComp.OperationOutcome | null>(null);
-	const [isExpanding, setIsExpanding] = React.useState(false);
-	const [expandDurationMs, setExpandDurationMs] = React.useState<number | null>(
-		null,
-	);
 	const [missingFields, setMissingFields] = React.useState<Set<string>>(
 		() => new Set(),
 	);
@@ -80,18 +72,10 @@ export function ValueSetProvider({
 	});
 
 	return (
-		<ValueSetContext.Provider
+		<CodeSystemContext.Provider
 			value={{
-				valueSet,
-				updateValueSet,
-				expansion,
-				setExpansion,
-				expandError,
-				setExpandError,
-				isExpanding,
-				setIsExpanding,
-				expandDurationMs,
-				setExpandDurationMs,
+				codeSystem,
+				updateCodeSystem,
 				missingFields,
 				setMissingFields,
 				isDirty,
@@ -131,6 +115,6 @@ export function ValueSetProvider({
 					</HSComp.AlertDialogFooter>
 				</HSComp.AlertDialogContent>
 			</HSComp.AlertDialog>
-		</ValueSetContext.Provider>
+		</CodeSystemContext.Provider>
 	);
 }

--- a/src/components/CodeSystem/properties-tree.tsx
+++ b/src/components/CodeSystem/properties-tree.tsx
@@ -1,0 +1,1032 @@
+import * as HSComp from "@health-samurai/react-components";
+import {
+	type ItemInstance,
+	TreeView,
+	type TreeViewItem,
+} from "@health-samurai/react-components";
+import { Plus, Tag, X } from "lucide-react";
+import * as React from "react";
+import { readUrlHistory } from "../../utils/url-history";
+import { useCodeSystemContext } from "./context";
+import type {
+	CodeSystemConcept,
+	CodeSystemConceptProperty,
+	CodeSystemContent,
+	CodeSystemHierarchyMeaning,
+	CodeSystemStatus,
+} from "./types";
+
+const URL_HISTORY_KEY = "codesystem-builder:url-history";
+
+type ItemMeta = {
+	type:
+		| "properties"
+		| "url"
+		| "version"
+		| "content"
+		| "hierarchyMeaning"
+		| "status"
+		| "name"
+		| "description"
+		| "concept"
+		| "concept-row"
+		| "concept-add"
+		| "concept-nested-add"
+		| "concept-child-section"
+		| "concept-property-section"
+		| "concept-property-row"
+		| "concept-property-add";
+	conceptPath?: number[];
+	propertyIndex?: number;
+};
+
+const STATUSES = ["draft", "active", "retired", "unknown"] as const;
+const CONTENT_TYPES = [
+	"not-present",
+	"example",
+	"fragment",
+	"complete",
+	"supplement",
+] as const;
+const HIERARCHY_MEANINGS = [
+	"grouped-by",
+	"is-a",
+	"part-of",
+	"classified-with",
+] as const;
+const PROPERTY_TYPES = [
+	"code",
+	"string",
+	"integer",
+	"boolean",
+	"dateTime",
+	"decimal",
+] as const;
+type PropertyType = (typeof PROPERTY_TYPES)[number];
+
+const detectPropertyType = (p: CodeSystemConceptProperty): PropertyType => {
+	if (p.valueCode !== undefined) return "code";
+	if (p.valueInteger !== undefined) return "integer";
+	if (p.valueBoolean !== undefined) return "boolean";
+	if (p.valueDateTime !== undefined) return "dateTime";
+	if (p.valueDecimal !== undefined) return "decimal";
+	return "string";
+};
+
+const emptyValuePatch = (): Partial<CodeSystemConceptProperty> => ({
+	valueCode: undefined,
+	valueString: undefined,
+	valueInteger: undefined,
+	valueBoolean: undefined,
+	valueDateTime: undefined,
+	valueDecimal: undefined,
+});
+
+const LABEL_OVERRIDES: Partial<Record<ItemMeta["type"], string>> = {
+	hierarchyMeaning: "hierarchy meaning",
+	concept: "concepts",
+	"concept-property-section": "properties",
+	"concept-child-section": "child concepts",
+};
+
+const pathsEqual = (a: number[], b: number[]) =>
+	a.length === b.length && a.every((x, i) => x === b[i]);
+
+const conceptRowId = (path: number[]) => `_concept_${path.join("_")}`;
+const conceptIndexLabel = (path: number[]) => path.map((i) => i + 1).join(".");
+
+function InputView({
+	placeholder,
+	value,
+	onChange,
+	autoFocusToken,
+	className,
+	name,
+	autoComplete,
+	list,
+}: {
+	placeholder: string;
+	value?: string;
+	onChange?: (value: string) => void;
+	autoFocusToken?: number | null;
+	className?: string;
+	name?: string;
+	autoComplete?: string;
+	list?: string;
+}) {
+	const [localValue, setLocalValue] = React.useState(value ?? "");
+	const inputRef = React.useRef<HTMLInputElement | null>(null);
+
+	React.useEffect(() => {
+		setLocalValue(value ?? "");
+	}, [value]);
+
+	React.useEffect(() => {
+		if (autoFocusToken != null) inputRef.current?.focus();
+	}, [autoFocusToken]);
+
+	const timeoutRef = React.useRef<ReturnType<typeof setTimeout> | undefined>(
+		undefined,
+	);
+
+	const handleChange = (newValue: string) => {
+		setLocalValue(newValue);
+		if (timeoutRef.current) clearTimeout(timeoutRef.current);
+		timeoutRef.current = setTimeout(() => {
+			if (onChange && newValue !== value) onChange(newValue);
+		}, 500);
+	};
+
+	return (
+		<HSComp.Input
+			ref={inputRef}
+			name={name}
+			autoComplete={autoComplete}
+			list={list}
+			className={`h-7 py-1 px-2 bg-bg-primary border-none hover:bg-bg-quaternary focus:bg-bg-primary group-hover/tree-item-label:bg-bg-tertiary focus:ring-1 focus:ring-border-link ${className ?? ""}`}
+			placeholder={placeholder}
+			value={localValue}
+			onChange={(e) => handleChange(e.target.value)}
+			onClick={(e) => e.stopPropagation()}
+			onMouseDown={(e) => e.stopPropagation()}
+		/>
+	);
+}
+
+function labelView(item: ItemInstance<TreeViewItem<ItemMeta>>) {
+	const metaType = item.getItemData()?.meta?.type;
+	const isFolder = item.isFolder();
+	const isTopSectionFolder =
+		metaType === "properties" || metaType === "concept";
+
+	const additionalClass = isTopSectionFolder
+		? "text-text-info-primary px-1!"
+		: "inline-flex items-center justify-center min-w-7 min-h-7 text-text-info-primary bg-bg-info-primary";
+
+	const label = (metaType && LABEL_OVERRIDES[metaType]) ?? metaType;
+
+	const onLabelClickFn = (e: React.MouseEvent) => {
+		if (!isFolder) return;
+		e.stopPropagation();
+		if (item.isExpanded()) item.collapse();
+		else item.expand();
+	};
+
+	return (
+		<button
+			type="button"
+			tabIndex={-1}
+			className={`uppercase px-1.5 py-0.5 ${isFolder ? "cursor-pointer" : ""} rounded-md ${additionalClass}`}
+			onClick={onLabelClickFn}
+		>
+			{label}
+		</button>
+	);
+}
+
+export function PropertiesTree() {
+	const { codeSystem, updateCodeSystem, missingFields, setMissingFields } =
+		useCodeSystemContext();
+	const [urlHistory] = React.useState<string[]>(() =>
+		readUrlHistory(URL_HISTORY_KEY),
+	);
+
+	const dismissMissing = React.useCallback(
+		(field: string) => {
+			setMissingFields((prev) => {
+				if (!prev.has(field)) return prev;
+				const next = new Set(prev);
+				next.delete(field);
+				return next;
+			});
+		},
+		[setMissingFields],
+	);
+
+	const updateUrl = (value: string) =>
+		updateCodeSystem((cs) => ({ ...cs, url: value || undefined }));
+	const updateVersion = (value: string) =>
+		updateCodeSystem((cs) => ({ ...cs, version: value || undefined }));
+	const updateName = (value: string) =>
+		updateCodeSystem((cs) => ({ ...cs, name: value || undefined }));
+	const updateDescription = (value: string) =>
+		updateCodeSystem((cs) => ({ ...cs, description: value || undefined }));
+	const updateHierarchyMeaning = (value: string) =>
+		updateCodeSystem((cs) => ({
+			...cs,
+			hierarchyMeaning: (value || undefined) as
+				| CodeSystemHierarchyMeaning
+				| undefined,
+		}));
+	const updateStatus = (value: string) => {
+		updateCodeSystem((cs) => ({
+			...cs,
+			status: (value || undefined) as CodeSystemStatus | undefined,
+		}));
+		if (value) dismissMissing("status");
+	};
+	const updateContent = (value: string) =>
+		updateCodeSystem((cs) => ({
+			...cs,
+			content: (value || undefined) as CodeSystemContent | undefined,
+		}));
+
+	const getConceptAt = (path: number[]): CodeSystemConcept | undefined => {
+		let arr: CodeSystemConcept[] | undefined = codeSystem.concept;
+		let c: CodeSystemConcept | undefined;
+		for (const i of path) {
+			c = arr?.[i];
+			if (!c) return undefined;
+			arr = c.concept;
+		}
+		return c;
+	};
+
+	const mutateConcepts = (
+		fn: (arr: CodeSystemConcept[]) => CodeSystemConcept[] | undefined,
+	) =>
+		updateCodeSystem((cs) => {
+			const next = fn((cs.concept ?? []).slice());
+			return { ...cs, concept: next && next.length > 0 ? next : undefined };
+		});
+
+	const updateAtPath = (
+		arr: CodeSystemConcept[],
+		path: number[],
+		fn: (c: CodeSystemConcept) => CodeSystemConcept,
+	): CodeSystemConcept[] => {
+		const head = path[0];
+		if (head === undefined) return arr;
+		const rest = path.slice(1);
+		const target = arr[head];
+		if (!target) return arr;
+		const next = arr.slice();
+		if (rest.length === 0) {
+			next[head] = fn(target);
+		} else {
+			next[head] = {
+				...target,
+				concept: updateAtPath(target.concept ?? [], rest, fn),
+			};
+		}
+		return next;
+	};
+
+	const removeAtPath = (
+		arr: CodeSystemConcept[],
+		path: number[],
+	): CodeSystemConcept[] => {
+		const head = path[0];
+		if (head === undefined) return arr;
+		const rest = path.slice(1);
+		if (rest.length === 0) return arr.filter((_, i) => i !== head);
+		const target = arr[head];
+		if (!target) return arr;
+		const next = arr.slice();
+		const childArr = removeAtPath(target.concept ?? [], rest);
+		next[head] = {
+			...target,
+			concept: childArr.length > 0 ? childArr : undefined,
+		};
+		return next;
+	};
+
+	const [expandedItems, setExpandedItems] = React.useState<string[]>(() => {
+		const out = ["_properties", "_concept"];
+		const root = codeSystem.concept ?? [];
+		let total = 0;
+		const count = (arr: CodeSystemConcept[]) => {
+			arr.forEach((c) => {
+				total++;
+				if (c.concept) count(c.concept);
+			});
+		};
+		count(root);
+		if (total > 1000) return out;
+		const walk = (path: number[], arr: CodeSystemConcept[]) => {
+			arr.forEach((c, i) => {
+				const myPath = [...path, i];
+				const hasChildren = (c.concept?.length ?? 0) > 0;
+				if (hasChildren) {
+					const rowId = conceptRowId(myPath);
+					out.push(rowId, `${rowId}_child_section`);
+					walk(myPath, c.concept ?? []);
+				}
+			});
+		};
+		walk([], root);
+		return out;
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	});
+
+	const [focusTarget, setFocusTarget] = React.useState<{
+		path: number[];
+		tick: number;
+	} | null>(null);
+
+	// max number-of-digits per sibling group, keyed by parent path
+	const maxDigitsByParent = React.useMemo(() => {
+		const map = new Map<string, number>();
+		const walk = (path: number[], arr: CodeSystemConcept[]) => {
+			map.set(path.join("."), String(Math.max(arr.length, 1)).length);
+			arr.forEach((c, i) => {
+				if (c.concept && c.concept.length > 0) {
+					walk([...path, i], c.concept);
+				}
+			});
+		};
+		walk([], codeSystem.concept ?? []);
+		return map;
+	}, [codeSystem.concept]);
+
+	const addConceptAt = (parentPath: number[]) => {
+		const parentChildrenLen =
+			parentPath.length === 0
+				? (codeSystem.concept?.length ?? 0)
+				: (getConceptAt(parentPath)?.concept?.length ?? 0);
+		const newPath = [...parentPath, parentChildrenLen];
+		mutateConcepts((arr) => {
+			if (parentPath.length === 0) {
+				return [...arr, {}];
+			}
+			return updateAtPath(arr, parentPath, (c) => ({
+				...c,
+				concept: [...(c.concept ?? []), {}],
+			}));
+		});
+		const toExpand: string[] = [];
+		if (parentPath.length === 0) {
+			toExpand.push("_concept");
+		} else {
+			const parentRowId = conceptRowId(parentPath);
+			toExpand.push(parentRowId, `${parentRowId}_child_section`);
+		}
+		setExpandedItems((prev) => Array.from(new Set([...prev, ...toExpand])));
+		setFocusTarget({ path: newPath, tick: Date.now() });
+	};
+
+	const removeConceptAt = (path: number[]) =>
+		mutateConcepts((arr) => removeAtPath(arr, path));
+
+	const updateConceptField = (
+		path: number[],
+		patch: Partial<CodeSystemConcept>,
+	) =>
+		mutateConcepts((arr) =>
+			updateAtPath(arr, path, (c) => ({ ...c, ...patch })),
+		);
+
+	const addPropertyAt = (path: number[]) => {
+		mutateConcepts((arr) =>
+			updateAtPath(arr, path, (c) => ({
+				...c,
+				property: [...(c.property ?? []), {}],
+			})),
+		);
+		const rowId = conceptRowId(path);
+		setExpandedItems((prev) =>
+			Array.from(new Set([...prev, rowId, `${rowId}_props_section`])),
+		);
+	};
+
+	const updatePropertyAt = (
+		path: number[],
+		pi: number,
+		patch: Partial<CodeSystemConceptProperty>,
+	) =>
+		mutateConcepts((arr) =>
+			updateAtPath(arr, path, (c) => {
+				const props = (c.property ?? []).slice();
+				props[pi] = { ...props[pi], ...patch };
+				return { ...c, property: props };
+			}),
+		);
+
+	const setPropertyType = (path: number[], pi: number, type: PropertyType) => {
+		const defaults: Partial<CodeSystemConceptProperty> = {
+			...emptyValuePatch(),
+		};
+		switch (type) {
+			case "code":
+				defaults.valueCode = "";
+				break;
+			case "string":
+				defaults.valueString = "";
+				break;
+			case "integer":
+				defaults.valueInteger = 0;
+				break;
+			case "boolean":
+				defaults.valueBoolean = false;
+				break;
+			case "dateTime":
+				defaults.valueDateTime = "";
+				break;
+			case "decimal":
+				defaults.valueDecimal = 0;
+				break;
+		}
+		updatePropertyAt(path, pi, defaults);
+	};
+
+	const setPropertyValueString = (
+		path: number[],
+		pi: number,
+		type: PropertyType,
+		raw: string,
+	) => {
+		const patch: Partial<CodeSystemConceptProperty> = { ...emptyValuePatch() };
+		switch (type) {
+			case "code":
+				patch.valueCode = raw;
+				break;
+			case "string":
+				patch.valueString = raw;
+				break;
+			case "dateTime":
+				patch.valueDateTime = raw;
+				break;
+			case "integer": {
+				const n = Number.parseInt(raw, 10);
+				patch.valueInteger = Number.isFinite(n) ? n : undefined;
+				break;
+			}
+			case "decimal": {
+				const n = Number.parseFloat(raw);
+				patch.valueDecimal = Number.isFinite(n) ? n : undefined;
+				break;
+			}
+			case "boolean":
+				break;
+		}
+		updatePropertyAt(path, pi, patch);
+	};
+
+	const removePropertyAt = (path: number[], pi: number) =>
+		mutateConcepts((arr) =>
+			updateAtPath(arr, path, (c) => {
+				const props = (c.property ?? []).filter((_, i) => i !== pi);
+				return { ...c, property: props.length > 0 ? props : undefined };
+			}),
+		);
+
+	const tree: Record<string, TreeViewItem<ItemMeta>> = React.useMemo(() => {
+		const out: Record<string, TreeViewItem<ItemMeta>> = {
+			root: { name: "root", children: ["_properties", "_concept"] },
+			_properties: {
+				name: "_properties",
+				meta: { type: "properties" },
+				children: [
+					"_url",
+					"_version",
+					"_name",
+					"_description",
+					"_content",
+					"_hierarchyMeaning",
+					"_status",
+				],
+			},
+			_url: { name: "_url", meta: { type: "url" } },
+			_version: { name: "_version", meta: { type: "version" } },
+			_content: { name: "_content", meta: { type: "content" } },
+			_hierarchyMeaning: {
+				name: "_hierarchyMeaning",
+				meta: { type: "hierarchyMeaning" },
+			},
+			_status: { name: "_status", meta: { type: "status" } },
+			_name: { name: "_name", meta: { type: "name" } },
+			_description: { name: "_description", meta: { type: "description" } },
+		};
+
+		const buildConceptSubtree = (
+			path: number[],
+			concepts: CodeSystemConcept[],
+		) => {
+			concepts.forEach((c, i) => {
+				const myPath = [...path, i];
+				const rowId = conceptRowId(myPath);
+
+				const propsSectionId = `${rowId}_props_section`;
+				const propsChildren: string[] = [];
+				(c.property ?? []).forEach((_, pi) => {
+					const pid = `${rowId}_prop_${pi}`;
+					propsChildren.push(pid);
+					out[pid] = {
+						name: pid,
+						meta: {
+							type: "concept-property-row",
+							conceptPath: myPath,
+							propertyIndex: pi,
+						},
+					};
+				});
+				const propAddId = `${rowId}_prop_add`;
+				propsChildren.push(propAddId);
+				out[propAddId] = {
+					name: propAddId,
+					meta: { type: "concept-property-add", conceptPath: myPath },
+				};
+				out[propsSectionId] = {
+					name: propsSectionId,
+					meta: { type: "concept-property-section", conceptPath: myPath },
+					children: propsChildren,
+				};
+
+				const nested = c.concept ?? [];
+				buildConceptSubtree(myPath, nested);
+				const nestedIds = nested.map((_, ni) => conceptRowId([...myPath, ni]));
+
+				const conceptAddId = `${rowId}_concept_add`;
+				out[conceptAddId] = {
+					name: conceptAddId,
+					meta: { type: "concept-nested-add", conceptPath: myPath },
+				};
+
+				const childSectionId = `${rowId}_child_section`;
+				out[childSectionId] = {
+					name: childSectionId,
+					meta: { type: "concept-child-section", conceptPath: myPath },
+					children: [...nestedIds, conceptAddId],
+				};
+
+				out[rowId] = {
+					name: rowId,
+					meta: { type: "concept-row", conceptPath: myPath },
+					children: [propsSectionId, childSectionId],
+				};
+			});
+		};
+
+		const concepts = codeSystem.concept ?? [];
+		buildConceptSubtree([], concepts);
+		const conceptChildren = concepts.map((_, i) => conceptRowId([i]));
+		conceptChildren.push("_concept_add");
+		out._concept = {
+			name: "_concept",
+			meta: { type: "concept" },
+			children: conceptChildren,
+		};
+		out._concept_add = { name: "_concept_add", meta: { type: "concept-add" } };
+
+		return out;
+	}, [codeSystem.concept]);
+
+	// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: large switch over tree node types
+	const customItemView = (item: ItemInstance<TreeViewItem<ItemMeta>>) => {
+		const meta = item.getItemData()?.meta;
+		const metaType = meta?.type;
+		switch (metaType) {
+			case "properties":
+			case "concept":
+				return <div>{labelView(item)}</div>;
+			case "concept-property-section": {
+				const path = meta?.conceptPath ?? [];
+				const concept = getConceptAt(path);
+				const count = concept?.property?.length ?? 0;
+				const isFolder = item.isFolder();
+				const toggle = (e: React.MouseEvent) => {
+					if (!isFolder) return;
+					e.stopPropagation();
+					if (item.isExpanded()) item.collapse();
+					else item.expand();
+				};
+				return (
+					<div>
+						<button
+							type="button"
+							tabIndex={-1}
+							className={`inline-flex items-center justify-center min-w-7 min-h-7 uppercase px-1.5 py-0.5 ${isFolder ? "cursor-pointer" : ""} rounded-md text-text-info-primary bg-bg-info-primary`}
+							onClick={toggle}
+						>
+							properties ({count})
+						</button>
+					</div>
+				);
+			}
+			case "concept-child-section": {
+				const path = meta?.conceptPath ?? [];
+				const concept = getConceptAt(path);
+				const count = concept?.concept?.length ?? 0;
+				const isFolder = item.isFolder();
+				const toggle = (e: React.MouseEvent) => {
+					if (!isFolder) return;
+					e.stopPropagation();
+					if (item.isExpanded()) item.collapse();
+					else item.expand();
+				};
+				return (
+					<div>
+						<button
+							type="button"
+							tabIndex={-1}
+							className={`inline-flex items-center justify-center min-w-7 min-h-7 uppercase px-1.5 py-0.5 ${isFolder ? "cursor-pointer" : ""} rounded-md text-text-info-primary bg-bg-info-primary`}
+							onClick={toggle}
+						>
+							child concepts ({count})
+						</button>
+					</div>
+				);
+			}
+			case "url":
+				return (
+					<div className="flex w-full items-center gap-2">
+						<div className="w-[246px] shrink-0">{labelView(item)}</div>
+						<div className="w-[50%]">
+							<InputView
+								name="codesystem-url"
+								autoComplete="on"
+								list="codesystem-builder-url-history"
+								placeholder="Canonical identifier for this code system, represented as a URI (globally unique)"
+								value={codeSystem.url}
+								onChange={updateUrl}
+							/>
+						</div>
+					</div>
+				);
+			case "version":
+				return (
+					<div className="flex w-full items-center gap-2">
+						<div className="w-[246px] shrink-0">{labelView(item)}</div>
+						<div className="w-[50%]">
+							<InputView
+								placeholder="Business version of the code system"
+								value={codeSystem.version}
+								onChange={updateVersion}
+							/>
+						</div>
+					</div>
+				);
+			case "content":
+				return (
+					<div className="flex w-full items-center gap-2">
+						<div className="w-[246px] shrink-0">{labelView(item)}</div>
+						<div className="w-[200px]">
+							<HSComp.Select
+								value={codeSystem.content ?? ""}
+								onValueChange={updateContent}
+							>
+								<HSComp.SelectTrigger className="h-7 py-1 px-2 bg-bg-primary border-none hover:bg-bg-quaternary focus:bg-bg-primary focus:ring-1 focus:ring-border-link group-hover/tree-item-label:bg-bg-tertiary">
+									<HSComp.SelectValue placeholder="content" />
+								</HSComp.SelectTrigger>
+								<HSComp.SelectContent>
+									{CONTENT_TYPES.map((c) => (
+										<HSComp.SelectItem key={c} value={c}>
+											{c}
+										</HSComp.SelectItem>
+									))}
+								</HSComp.SelectContent>
+							</HSComp.Select>
+						</div>
+					</div>
+				);
+			case "status": {
+				const isMissing = missingFields.has("status");
+				return (
+					<div className="flex w-full items-center gap-2">
+						<div className="w-[246px] shrink-0">{labelView(item)}</div>
+						<div
+							className={`w-[200px] ${isMissing ? "ring-1 ring-border-error rounded-md" : ""}`}
+						>
+							<HSComp.Select
+								value={codeSystem.status ?? ""}
+								onValueChange={updateStatus}
+							>
+								<HSComp.SelectTrigger className="h-7 py-1 px-2 bg-bg-primary border-none hover:bg-bg-quaternary focus:bg-bg-primary focus:ring-1 focus:ring-border-link group-hover/tree-item-label:bg-bg-tertiary">
+									<HSComp.SelectValue placeholder="status" />
+								</HSComp.SelectTrigger>
+								<HSComp.SelectContent>
+									{STATUSES.map((s) => (
+										<HSComp.SelectItem key={s} value={s}>
+											{s}
+										</HSComp.SelectItem>
+									))}
+								</HSComp.SelectContent>
+							</HSComp.Select>
+						</div>
+					</div>
+				);
+			}
+			case "name":
+				return (
+					<div className="flex w-full items-center gap-2">
+						<div className="w-[246px] shrink-0">{labelView(item)}</div>
+						<div className="w-[50%]">
+							<InputView
+								placeholder="Name for this code system (computer friendly)"
+								value={codeSystem.name}
+								onChange={updateName}
+							/>
+						</div>
+					</div>
+				);
+			case "hierarchyMeaning":
+				return (
+					<div className="flex w-full items-center gap-2">
+						<div className="w-[246px] shrink-0">{labelView(item)}</div>
+						<div className="w-[200px]">
+							<HSComp.Select
+								value={codeSystem.hierarchyMeaning ?? ""}
+								onValueChange={updateHierarchyMeaning}
+							>
+								<HSComp.SelectTrigger className="h-7 py-1 px-2 bg-bg-primary border-none hover:bg-bg-quaternary focus:bg-bg-primary focus:ring-1 focus:ring-border-link group-hover/tree-item-label:bg-bg-tertiary">
+									<HSComp.SelectValue placeholder="hierarchy meaning" />
+								</HSComp.SelectTrigger>
+								<HSComp.SelectContent>
+									{HIERARCHY_MEANINGS.map((m) => (
+										<HSComp.SelectItem key={m} value={m}>
+											{m}
+										</HSComp.SelectItem>
+									))}
+								</HSComp.SelectContent>
+							</HSComp.Select>
+						</div>
+					</div>
+				);
+			case "description":
+				return (
+					<div className="flex w-full items-center gap-2">
+						<div className="w-[246px] shrink-0">{labelView(item)}</div>
+						<div className="flex-1 min-w-0">
+							<InputView
+								placeholder="Natural language description of the code system"
+								value={codeSystem.description}
+								onChange={updateDescription}
+							/>
+						</div>
+					</div>
+				);
+			case "concept-row": {
+				const path = meta?.conceptPath ?? [];
+				const concept = getConceptAt(path);
+				if (!concept) return null;
+				const focusToken =
+					focusTarget && pathsEqual(focusTarget.path, path)
+						? focusTarget.tick
+						: null;
+				const isFolder = item.isFolder();
+				const toggle = (e: React.MouseEvent) => {
+					if (!isFolder) return;
+					e.stopPropagation();
+					if (item.isExpanded()) item.collapse();
+					else item.expand();
+				};
+				const parentPath = path.slice(0, -1);
+				const prefixLabel = conceptIndexLabel(parentPath);
+				const maxDigits = maxDigitsByParent.get(parentPath.join(".")) ?? 1;
+				const labelChars =
+					(prefixLabel.length > 0 ? prefixLabel.length + 1 : 0) + maxDigits;
+				return (
+					<div className="flex w-full items-center gap-2">
+						<button
+							type="button"
+							tabIndex={-1}
+							className={`shrink-0 inline-flex items-center justify-start min-h-7 uppercase px-[2px] py-0.5 rounded-md text-text-info-primary tabular-nums ${isFolder ? "cursor-pointer" : ""}`}
+							style={{ minWidth: `calc(${labelChars}ch + 4px)` }}
+							onClick={toggle}
+						>
+							{conceptIndexLabel(path)}
+						</button>
+						<div className="w-[175px] shrink-0">
+							<InputView
+								placeholder="code"
+								value={concept.code}
+								onChange={(v) =>
+									updateConceptField(path, { code: v || undefined })
+								}
+								autoFocusToken={focusToken}
+								className="font-mono text-xs"
+							/>
+						</div>
+						<div className="w-[250px] shrink-0">
+							<InputView
+								placeholder="Text to display to the user"
+								value={concept.display}
+								onChange={(v) =>
+									updateConceptField(path, { display: v || undefined })
+								}
+							/>
+						</div>
+						<div className="flex-1 min-w-0">
+							<InputView
+								placeholder="Formal definition"
+								value={concept.definition}
+								onChange={(v) =>
+									updateConceptField(path, { definition: v || undefined })
+								}
+							/>
+						</div>
+						<HSComp.Button
+							variant="link"
+							size="small"
+							className="shrink-0 group-hover/tree-item-label:opacity-100 opacity-0 transition-opacity"
+							onClick={() => removeConceptAt(path)}
+							asChild
+						>
+							<span>
+								<X size={14} />
+							</span>
+						</HSComp.Button>
+					</div>
+				);
+			}
+			case "concept-property-row": {
+				const path = meta?.conceptPath ?? [];
+				const pi = meta?.propertyIndex ?? -1;
+				const concept = getConceptAt(path);
+				const prop = concept?.property?.[pi];
+				if (!prop) return null;
+				const type = detectPropertyType(prop);
+				const stringValue =
+					type === "code"
+						? (prop.valueCode ?? "")
+						: type === "string"
+							? (prop.valueString ?? "")
+							: type === "integer"
+								? (prop.valueInteger?.toString() ?? "")
+								: type === "dateTime"
+									? (prop.valueDateTime ?? "")
+									: type === "decimal"
+										? (prop.valueDecimal?.toString() ?? "")
+										: "";
+				return (
+					<div className="flex w-full items-center gap-2 pl-0.5">
+						<span className="text-utility-yellow bg-utility-yellow/20 rounded-md p-1 shrink-0">
+							<Tag size={12} />
+						</span>
+						<div className="w-[175px] shrink-0">
+							<InputView
+								placeholder="property name"
+								value={prop.code}
+								onChange={(v) =>
+									updatePropertyAt(path, pi, { code: v || undefined })
+								}
+								className="font-mono text-xs"
+							/>
+						</div>
+						<div className="w-[120px] shrink-0">
+							<HSComp.Select
+								value={type}
+								onValueChange={(v) =>
+									setPropertyType(path, pi, v as PropertyType)
+								}
+							>
+								<HSComp.SelectTrigger className="h-7 py-1 px-2 bg-bg-primary border-none hover:bg-bg-quaternary focus:bg-bg-primary focus:ring-1 focus:ring-border-link group-hover/tree-item-label:bg-bg-tertiary">
+									<HSComp.SelectValue placeholder="type" />
+								</HSComp.SelectTrigger>
+								<HSComp.SelectContent>
+									{PROPERTY_TYPES.map((t) => (
+										<HSComp.SelectItem key={t} value={t}>
+											{t}
+										</HSComp.SelectItem>
+									))}
+								</HSComp.SelectContent>
+							</HSComp.Select>
+						</div>
+						<div className="flex-1 min-w-0">
+							{type === "boolean" ? (
+								<div
+									className="flex items-center h-7"
+									onClick={(e) => e.stopPropagation()}
+									onMouseDown={(e) => e.stopPropagation()}
+									onKeyDown={(e) => e.stopPropagation()}
+									role="presentation"
+								>
+									<HSComp.Switch
+										checked={prop.valueBoolean === true}
+										onCheckedChange={(c) =>
+											updatePropertyAt(path, pi, {
+												...emptyValuePatch(),
+												valueBoolean: c === true,
+											})
+										}
+									/>
+								</div>
+							) : (
+								<InputView
+									placeholder="value"
+									value={stringValue}
+									onChange={(v) => setPropertyValueString(path, pi, type, v)}
+								/>
+							)}
+						</div>
+						<HSComp.Button
+							variant="link"
+							size="small"
+							className="shrink-0 group-hover/tree-item-label:opacity-100 opacity-0 transition-opacity"
+							onClick={() => removePropertyAt(path, pi)}
+							asChild
+						>
+							<span>
+								<X size={14} />
+							</span>
+						</HSComp.Button>
+					</div>
+				);
+			}
+			case "concept-add":
+				return (
+					<HSComp.Button
+						variant="link"
+						size="small"
+						className="px-0"
+						onClick={() => addConceptAt([])}
+						asChild
+					>
+						<span>
+							<Plus size={16} strokeWidth={3} />
+							<span className="text-xs typo-label">Concept</span>
+						</span>
+					</HSComp.Button>
+				);
+			case "concept-nested-add": {
+				const path = meta?.conceptPath ?? [];
+				return (
+					<HSComp.Button
+						variant="link"
+						size="small"
+						className="px-0"
+						onClick={() => addConceptAt(path)}
+						asChild
+					>
+						<span>
+							<Plus size={16} strokeWidth={3} />
+							<span className="text-xs typo-label">Concept</span>
+						</span>
+					</HSComp.Button>
+				);
+			}
+			case "concept-property-add": {
+				const path = meta?.conceptPath ?? [];
+				return (
+					<HSComp.Button
+						variant="link"
+						size="small"
+						className="px-0"
+						onClick={() => addPropertyAt(path)}
+						asChild
+					>
+						<span>
+							<Plus size={16} strokeWidth={3} />
+							<span className="text-xs typo-label">Property</span>
+						</span>
+					</HSComp.Button>
+				);
+			}
+			default:
+				return <div>{labelView(item)}</div>;
+		}
+	};
+
+	return (
+		<div>
+			<TreeView
+				items={tree}
+				rootItemId="root"
+				customItemView={customItemView}
+				disableHover={true}
+				chevronClassName="self-center cursor-pointer"
+				expandedItems={expandedItems}
+				onExpandedItemsChange={(next) => {
+					const prevSet = new Set(expandedItems);
+					const extra: string[] = [];
+					for (const id of next) {
+						if (prevSet.has(id)) continue;
+						const node = tree[id];
+						if (node?.meta?.type === "concept-row") {
+							const path = node.meta.conceptPath ?? [];
+							const hasChildren =
+								(getConceptAt(path)?.concept?.length ?? 0) > 0;
+							if (hasChildren) {
+								const childSection = `${id}_child_section`;
+								if (tree[childSection]) extra.push(childSection);
+							}
+						}
+					}
+					setExpandedItems(
+						extra.length === 0
+							? next
+							: Array.from(new Set([...next, ...extra])),
+					);
+				}}
+				onItemLabelClick={(item) => {
+					if (item.isFolder()) {
+						if (item.isExpanded()) item.collapse();
+						else item.expand();
+					}
+				}}
+				itemLabelClassFn={(item: ItemInstance<TreeViewItem<ItemMeta>>) => {
+					const metaType = item.getItemData()?.meta?.type;
+					if (metaType === "properties" || metaType === "concept") {
+						return "relative my-1.5 rounded-md bg-bg-info-primary cursor-pointer before:content-[''] before:absolute before:inset-x-0 before:top-0 before:bottom-0 before:-z-10 before:bg-bg-primary before:-my-1.5 after:content-[''] after:absolute after:inset-x-0 after:top-0 after:bottom-0 after:-z-10 after:bg-bg-primary after:rounded-md after:-my-1.5";
+					}
+					return "pr-0";
+				}}
+			/>
+			<datalist id="codesystem-builder-url-history">
+				{urlHistory.map((u) => (
+					<option key={u} value={u} />
+				))}
+			</datalist>
+		</div>
+	);
+}

--- a/src/components/CodeSystem/types.ts
+++ b/src/components/CodeSystem/types.ts
@@ -1,0 +1,46 @@
+import type { Resource } from "@aidbox-ui/fhir-types/hl7-fhir-r5-core";
+
+export type CodeSystemConceptProperty = {
+	code?: string;
+	valueCode?: string;
+	valueString?: string;
+	valueInteger?: number;
+	valueBoolean?: boolean;
+	valueDateTime?: string;
+	valueDecimal?: number;
+};
+
+export type CodeSystemConcept = {
+	code?: string;
+	display?: string;
+	definition?: string;
+	property?: CodeSystemConceptProperty[];
+	concept?: CodeSystemConcept[];
+};
+
+export type CodeSystemStatus = "draft" | "active" | "retired" | "unknown";
+
+export type CodeSystemContent =
+	| "not-present"
+	| "example"
+	| "fragment"
+	| "complete"
+	| "supplement";
+
+export type CodeSystemHierarchyMeaning =
+	| "grouped-by"
+	| "is-a"
+	| "part-of"
+	| "classified-with";
+
+export type CodeSystem = Resource & {
+	resourceType: "CodeSystem";
+	url?: string;
+	version?: string;
+	name?: string;
+	status?: CodeSystemStatus;
+	content?: CodeSystemContent;
+	hierarchyMeaning?: CodeSystemHierarchyMeaning;
+	description?: string;
+	concept?: CodeSystemConcept[];
+};

--- a/src/components/ResourceEditor/page.tsx
+++ b/src/components/ResourceEditor/page.tsx
@@ -36,6 +36,7 @@ import { LineageTab } from "../SQLQueryBuilder/lineage/lineage-tab";
 import { SQLQueryProvider } from "../SQLQueryBuilder/page";
 import { SQL_QUERY_PROFILE } from "../SQLQueryBuilder/types";
 import { ValueSetBuilderContent } from "../ValueSet/builder-content";
+import { ValueSetGraphTab } from "../ValueSet/graph/graph-tab";
 import { ValueSetProvider } from "../ValueSet/page";
 import { BuilderContent } from "../ViewDefinition/editor-panel-content";
 import { ViewDefinitionLineageTab } from "../ViewDefinition/lineage/lineage-tab";
@@ -416,6 +417,15 @@ export const ResourceEditorPage = ({
 			content: (
 				<HSComp.TabsContent value="builder" className="grow min-h-0">
 					<ValueSetBuilderContent />
+				</HSComp.TabsContent>
+			),
+		});
+		tabs.push({
+			value: "graph",
+			trigger: <HSComp.TabsTrigger value="graph">Graph</HSComp.TabsTrigger>,
+			content: (
+				<HSComp.TabsContent value="graph" className="grow min-h-0 flex">
+					<ValueSetGraphTab />
 				</HSComp.TabsContent>
 			),
 		});

--- a/src/components/ResourceEditor/page.tsx
+++ b/src/components/ResourceEditor/page.tsx
@@ -25,6 +25,8 @@ import { useWebMCPResourceEditor } from "../../webmcp/resource-editor";
 import type { ResourceEditorActions } from "../../webmcp/resource-editor-context";
 import { AccessPolicyBuilderContent } from "../AccessPolicy/builder-content";
 import { AccessPolicyProvider } from "../AccessPolicy/page";
+import { CodeSystemBuilderContent } from "../CodeSystem/builder-content";
+import { CodeSystemProvider } from "../CodeSystem/page";
 import { EmptyState } from "../empty-state";
 import { SearchParameterBuilderContent } from "../SearchParameter/builder-content";
 import { IndexesTab as SearchParameterIndexesTab } from "../SearchParameter/indexes-tab";
@@ -372,6 +374,7 @@ export const ResourceEditorPage = ({
 	const isSearchParameter = resourceType === "SearchParameter";
 	const isLibrary = resourceType === "Library";
 	const isValueSet = resourceType === "ValueSet";
+	const isCodeSystem = resourceType === "CodeSystem";
 	const isSQLQuery =
 		isLibrary &&
 		Boolean(
@@ -413,6 +416,22 @@ export const ResourceEditorPage = ({
 			content: (
 				<HSComp.TabsContent value="builder" className="grow min-h-0">
 					<ValueSetBuilderContent />
+				</HSComp.TabsContent>
+			),
+		});
+	}
+
+	if (isCodeSystem) {
+		tabs.push({
+			value: "builder",
+			trigger: (
+				<HSComp.TabsTrigger value="builder">
+					CodeSystem Builder
+				</HSComp.TabsTrigger>
+			),
+			content: (
+				<HSComp.TabsContent value="builder" className="grow min-h-0">
+					<CodeSystemBuilderContent />
 				</HSComp.TabsContent>
 			),
 		});
@@ -715,6 +734,14 @@ export const ResourceEditorPage = ({
 			<ValueSetProvider initialResource={initialResource}>
 				{content}
 			</ValueSetProvider>
+		);
+	}
+
+	if (isCodeSystem) {
+		return (
+			<CodeSystemProvider initialResource={initialResource}>
+				{content}
+			</CodeSystemProvider>
 		);
 	}
 

--- a/src/components/ResourceEditor/page.tsx
+++ b/src/components/ResourceEditor/page.tsx
@@ -33,6 +33,8 @@ import { SQLQueryBuilderContent } from "../SQLQueryBuilder/builder-content";
 import { LineageTab } from "../SQLQueryBuilder/lineage/lineage-tab";
 import { SQLQueryProvider } from "../SQLQueryBuilder/page";
 import { SQL_QUERY_PROFILE } from "../SQLQueryBuilder/types";
+import { ValueSetBuilderContent } from "../ValueSet/builder-content";
+import { ValueSetProvider } from "../ValueSet/page";
 import { BuilderContent } from "../ViewDefinition/editor-panel-content";
 import { ViewDefinitionLineageTab } from "../ViewDefinition/lineage/lineage-tab";
 import { ViewDefinitionProvider } from "../ViewDefinition/page";
@@ -369,6 +371,7 @@ export const ResourceEditorPage = ({
 	const isAccessPolicy = resourceType === "AccessPolicy";
 	const isSearchParameter = resourceType === "SearchParameter";
 	const isLibrary = resourceType === "Library";
+	const isValueSet = resourceType === "ValueSet";
 	const isSQLQuery =
 		isLibrary &&
 		Boolean(
@@ -394,6 +397,22 @@ export const ResourceEditorPage = ({
 			content: (
 				<HSComp.TabsContent value="builder" className="grow min-h-0">
 					<BuilderContent />
+				</HSComp.TabsContent>
+			),
+		});
+	}
+
+	if (isValueSet) {
+		tabs.push({
+			value: "builder",
+			trigger: (
+				<HSComp.TabsTrigger value="builder">
+					ValueSet Builder
+				</HSComp.TabsTrigger>
+			),
+			content: (
+				<HSComp.TabsContent value="builder" className="grow min-h-0">
+					<ValueSetBuilderContent />
 				</HSComp.TabsContent>
 			),
 		});
@@ -688,6 +707,14 @@ export const ResourceEditorPage = ({
 			<AccessPolicyProvider id={id} initialResource={initialResource}>
 				{content}
 			</AccessPolicyProvider>
+		);
+	}
+
+	if (isValueSet) {
+		return (
+			<ValueSetProvider initialResource={initialResource}>
+				{content}
+			</ValueSetProvider>
 		);
 	}
 

--- a/src/components/ResourceEditor/types.ts
+++ b/src/components/ResourceEditor/types.ts
@@ -37,6 +37,7 @@ export const RESOURCE_TYPES_WITH_BUILDER = new Set([
 	"ViewDefinition",
 	"AccessPolicy",
 	"SearchParameter",
+	"ValueSet",
 ]);
 
 /**

--- a/src/components/ResourceEditor/types.ts
+++ b/src/components/ResourceEditor/types.ts
@@ -38,6 +38,7 @@ export const RESOURCE_TYPES_WITH_BUILDER = new Set([
 	"AccessPolicy",
 	"SearchParameter",
 	"ValueSet",
+	"CodeSystem",
 ]);
 
 /**

--- a/src/components/ResourceEditor/types.ts
+++ b/src/components/ResourceEditor/types.ts
@@ -6,6 +6,7 @@ export const RESOURCE_EDITOR_TABS = [
 	"indexes",
 	"sqlquery",
 	"lineage",
+	"graph",
 ] as const;
 export type ResourceEditorTab = (typeof RESOURCE_EDITOR_TABS)[number];
 const resourceEditorTabSet = new Set(RESOURCE_EDITOR_TABS);

--- a/src/components/ValueSet/builder-content.tsx
+++ b/src/components/ValueSet/builder-content.tsx
@@ -1,0 +1,229 @@
+import * as HSComp from "@health-samurai/react-components";
+import { useMutation } from "@tanstack/react-query";
+import { PanelBottomOpen } from "lucide-react";
+import * as React from "react";
+import { useAidboxClient } from "../../AidboxClient";
+import * as Utils from "../../api/utils";
+import { useLocalStorage } from "../../hooks";
+import { useValueSetContext } from "./context";
+import { EditorHeaderMenu } from "./header-menu";
+import { PropertiesTree } from "./properties-tree";
+import { ResultPanel } from "./result-panel";
+import type { ValueSet } from "./types";
+
+function toOperationOutcome(err: unknown): HSComp.OperationOutcome {
+	if (
+		typeof err === "object" &&
+		err !== null &&
+		"resourceType" in err &&
+		(err as { resourceType: string }).resourceType === "OperationOutcome"
+	) {
+		return err as unknown as HSComp.OperationOutcome;
+	}
+	return {
+		resourceType: "OperationOutcome",
+		issue: [
+			{
+				severity: "error",
+				code: "exception",
+				diagnostics: err instanceof Error ? err.message : String(err),
+			},
+		],
+	};
+}
+
+export const ValueSetBuilderContent = () => {
+	const client = useAidboxClient();
+	const {
+		valueSet,
+		setExpansion,
+		setExpandError,
+		isExpanding,
+		setIsExpanding,
+		expansion,
+		expandError,
+		setExpandDurationMs,
+	} = useValueSetContext();
+
+	const saveMutation = useMutation({
+		mutationFn: async () => {
+			const payload = valueSet;
+			if (payload.id) {
+				const result = await client.request<ValueSet>({
+					method: "PUT",
+					url: `/fhir/ValueSet/${payload.id}`,
+					body: JSON.stringify(payload),
+					headers: { "Content-Type": "application/json" },
+				});
+				if (result.isErr()) throw result.value.resource;
+				return result.value.resource;
+			}
+			const result = await client.request<ValueSet>({
+				method: "POST",
+				url: "/fhir/ValueSet",
+				body: JSON.stringify(payload),
+				headers: { "Content-Type": "application/json" },
+			});
+			if (result.isErr()) throw result.value.resource;
+			return result.value.resource;
+		},
+		onSuccess: () => {
+			HSComp.toast.success("ValueSet saved successfully", {
+				position: "bottom-right",
+				style: { margin: "1rem" },
+			});
+		},
+		onError: (err) => {
+			const oo = toOperationOutcome(err);
+			Utils.toastError(
+				"Failed to save ValueSet",
+				oo.issue?.[0]?.diagnostics ?? undefined,
+			);
+		},
+	});
+
+	const expandStartRef = React.useRef<number>(0);
+	const expandMutation = useMutation({
+		mutationFn: async () => {
+			setExpandError(null);
+			setExpansion(null);
+			setExpandDurationMs(null);
+			setIsExpanding(true);
+			expandStartRef.current = performance.now();
+			const body = {
+				resourceType: "Parameters" as const,
+				parameter: [{ name: "valueSet", resource: valueSet }],
+			};
+			const result = await client.request<ValueSet>({
+				method: "POST",
+				url: "/fhir/ValueSet/$expand",
+				body: JSON.stringify(body),
+				headers: { "Content-Type": "application/fhir+json" },
+			});
+			if (result.isErr()) throw result.value.resource;
+			return result.value.resource;
+		},
+		onSuccess: (resource) => {
+			setIsExpanding(false);
+			setExpandDurationMs(performance.now() - expandStartRef.current);
+			setExpansion(resource.expansion ?? null);
+		},
+		onError: (err) => {
+			setIsExpanding(false);
+			setExpandDurationMs(performance.now() - expandStartRef.current);
+			setExpandError(toOperationOutcome(err));
+		},
+	});
+
+	const [isResultCollapsed, setIsResultCollapsed] = useLocalStorage<boolean>({
+		key: "valueset-builder:result-collapsed",
+		defaultValue: true,
+		getInitialValueInEffect: false,
+	});
+	const [isMaximized, setIsMaximized] = React.useState(false);
+
+	const handleToggleCollapse = React.useCallback(() => {
+		setIsResultCollapsed((prev) => !prev);
+		setIsMaximized(false);
+	}, [setIsResultCollapsed]);
+
+	const handleToggleMaximize = React.useCallback(() => {
+		setIsMaximized((prev) => !prev);
+	}, []);
+
+	const handleExpandResult = React.useCallback(() => {
+		setIsResultCollapsed(false);
+	}, [setIsResultCollapsed]);
+
+	React.useEffect(() => {
+		if (!isMaximized) return;
+		const onEscape = (e: KeyboardEvent) => {
+			if (e.key === "Escape") setIsMaximized(false);
+		};
+		document.addEventListener("keydown", onEscape);
+		return () => document.removeEventListener("keydown", onEscape);
+	}, [isMaximized]);
+
+	const triggerExpand = React.useCallback(() => {
+		if (expandMutation.isPending) return;
+		handleExpandResult();
+		expandMutation.mutate();
+	}, [expandMutation, handleExpandResult]);
+
+	const editorContent = (
+		<div className="flex flex-col h-full">
+			<EditorHeaderMenu
+				onExpand={triggerExpand}
+				onSave={() => saveMutation.mutate()}
+				isExpandDisabled={expandMutation.isPending}
+				isSaveDisabled={saveMutation.isPending}
+			/>
+			<div className="flex-1 min-h-0 overflow-auto">
+				<div className="min-h-full bg-bg-primary px-2.5 pt-3 pb-[250px]">
+					<PropertiesTree />
+				</div>
+			</div>
+		</div>
+	);
+
+	const hasResult = expansion !== null || isExpanding || expandError !== null;
+
+	if (!hasResult) {
+		return (
+			<div className="relative h-full grow min-h-0 flex flex-col">
+				{editorContent}
+			</div>
+		);
+	}
+
+	if (isResultCollapsed) {
+		return (
+			<div className="relative h-full grow min-h-0 flex flex-col overflow-hidden">
+				<div className="flex-1 min-h-0">{editorContent}</div>
+				<div className="flex items-center justify-between bg-bg-secondary pl-6 pr-2 py-3 border-t h-10 flex-none">
+					<span className="typo-label text-text-secondary">Expansion</span>
+					<HSComp.Tooltip>
+						<HSComp.TooltipTrigger asChild>
+							<HSComp.Button
+								variant="ghost"
+								size="small"
+								onClick={handleToggleCollapse}
+							>
+								<PanelBottomOpen className="w-4 h-4" />
+							</HSComp.Button>
+						</HSComp.TooltipTrigger>
+						<HSComp.TooltipContent align="end">Restore</HSComp.TooltipContent>
+					</HSComp.Tooltip>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="relative h-full grow min-h-0 flex flex-col overflow-hidden">
+			<HSComp.ResizablePanelGroup
+				direction="vertical"
+				autoSaveId="valueset-builder-vertical"
+				className="grow min-h-0"
+			>
+				<HSComp.ResizablePanel minSize={20}>
+					{editorContent}
+				</HSComp.ResizablePanel>
+				<HSComp.ResizableHandle />
+				<HSComp.ResizablePanel defaultSize={30} minSize={10}>
+					<div
+						className={`flex flex-col h-full ${isMaximized ? "absolute top-0 bottom-0 h-full w-full left-0 z-30 overflow-auto bg-bg-primary" : ""}`}
+					>
+						<div className="flex-1 min-h-0">
+							<ResultPanel
+								isMaximized={isMaximized}
+								onToggleMaximize={handleToggleMaximize}
+								onToggleCollapse={handleToggleCollapse}
+							/>
+						</div>
+					</div>
+				</HSComp.ResizablePanel>
+			</HSComp.ResizablePanelGroup>
+		</div>
+	);
+};

--- a/src/components/ValueSet/builder-content.tsx
+++ b/src/components/ValueSet/builder-content.tsx
@@ -5,6 +5,8 @@ import * as React from "react";
 import { useAidboxClient } from "../../AidboxClient";
 import * as Utils from "../../api/utils";
 import { useLocalStorage } from "../../hooks";
+import { cleanEmptyValues } from "../../utils/clean-empty-values";
+import { addUrlToHistory } from "../../utils/url-history";
 import { useValueSetContext } from "./context";
 import { EditorHeaderMenu } from "./header-menu";
 import { PropertiesTree } from "./properties-tree";
@@ -44,6 +46,7 @@ export const ValueSetBuilderContent = () => {
 		expandError,
 		setExpandDurationMs,
 		setMissingFields,
+		setIsDirty,
 	} = useValueSetContext();
 
 	const saveMutation = useMutation({
@@ -64,7 +67,7 @@ export const ValueSetBuilderContent = () => {
 				};
 			}
 			setMissingFields(new Set());
-			const payload = valueSet;
+			const payload = cleanEmptyValues(valueSet);
 			if (payload.id) {
 				const result = await client.request<ValueSet>({
 					method: "PUT",
@@ -85,6 +88,8 @@ export const ValueSetBuilderContent = () => {
 			return result.value.resource;
 		},
 		onSuccess: () => {
+			addUrlToHistory("valueset-builder:url-history", valueSet.url);
+			setIsDirty(false);
 			HSComp.toast.success("ValueSet saved successfully", {
 				position: "bottom-right",
 				style: { margin: "1rem" },
@@ -109,7 +114,7 @@ export const ValueSetBuilderContent = () => {
 			expandStartRef.current = performance.now();
 			const body = {
 				resourceType: "Parameters" as const,
-				parameter: [{ name: "valueSet", resource: valueSet }],
+				parameter: [{ name: "valueSet", resource: cleanEmptyValues(valueSet) }],
 			};
 			const result = await client.request<ValueSet>({
 				method: "POST",

--- a/src/components/ValueSet/builder-content.tsx
+++ b/src/components/ValueSet/builder-content.tsx
@@ -43,10 +43,27 @@ export const ValueSetBuilderContent = () => {
 		expansion,
 		expandError,
 		setExpandDurationMs,
+		setMissingFields,
 	} = useValueSetContext();
 
 	const saveMutation = useMutation({
 		mutationFn: async () => {
+			const missing = new Set<string>();
+			if (!valueSet.status) missing.add("status");
+			if (missing.size > 0) {
+				setMissingFields(missing);
+				throw {
+					resourceType: "OperationOutcome",
+					issue: [
+						{
+							severity: "error",
+							code: "required",
+							diagnostics: `Missing required field${missing.size > 1 ? "s" : ""}: ${[...missing].join(", ")}`,
+						},
+					],
+				};
+			}
+			setMissingFields(new Set());
 			const payload = valueSet;
 			if (payload.id) {
 				const result = await client.request<ValueSet>({

--- a/src/components/ValueSet/context.ts
+++ b/src/components/ValueSet/context.ts
@@ -1,0 +1,28 @@
+import type * as HSComp from "@health-samurai/react-components";
+import * as React from "react";
+import type { ValueSet, ValueSetExpansion } from "./types";
+
+export type ValueSetContextValue = {
+	valueSet: ValueSet;
+	updateValueSet: (updater: (vs: ValueSet) => ValueSet) => void;
+	expansion: ValueSetExpansion | null;
+	setExpansion: (e: ValueSetExpansion | null) => void;
+	expandError: HSComp.OperationOutcome | null;
+	setExpandError: (e: HSComp.OperationOutcome | null) => void;
+	isExpanding: boolean;
+	setIsExpanding: (b: boolean) => void;
+	expandDurationMs: number | null;
+	setExpandDurationMs: (n: number | null) => void;
+};
+
+export const ValueSetContext = React.createContext<ValueSetContextValue | null>(
+	null,
+);
+
+export function useValueSetContext(): ValueSetContextValue {
+	const ctx = React.useContext(ValueSetContext);
+	if (!ctx) {
+		throw new Error("useValueSetContext must be used within ValueSetProvider");
+	}
+	return ctx;
+}

--- a/src/components/ValueSet/context.ts
+++ b/src/components/ValueSet/context.ts
@@ -13,6 +13,8 @@ export type ValueSetContextValue = {
 	setIsExpanding: (b: boolean) => void;
 	expandDurationMs: number | null;
 	setExpandDurationMs: (n: number | null) => void;
+	missingFields: Set<string>;
+	setMissingFields: React.Dispatch<React.SetStateAction<Set<string>>>;
 };
 
 export const ValueSetContext = React.createContext<ValueSetContextValue | null>(

--- a/src/components/ValueSet/context.ts
+++ b/src/components/ValueSet/context.ts
@@ -15,6 +15,8 @@ export type ValueSetContextValue = {
 	setExpandDurationMs: (n: number | null) => void;
 	missingFields: Set<string>;
 	setMissingFields: React.Dispatch<React.SetStateAction<Set<string>>>;
+	isDirty: boolean;
+	setIsDirty: (value: boolean) => void;
 };
 
 export const ValueSetContext = React.createContext<ValueSetContextValue | null>(

--- a/src/components/ValueSet/graph/detail-panel.tsx
+++ b/src/components/ValueSet/graph/detail-panel.tsx
@@ -1,0 +1,289 @@
+import * as HSComp from "@health-samurai/react-components";
+import { Link } from "@tanstack/react-router";
+import { AlertCircle, Database, ListTree, X } from "lucide-react";
+import type * as React from "react";
+import type {
+	CodeSystemNodeData,
+	GraphNodeData,
+	UnresolvedNodeData,
+	ValueSetNodeData,
+} from "./types";
+
+function CloseButton({ onClose }: { onClose: () => void }) {
+	return (
+		<HSComp.IconButton
+			variant="ghost"
+			aria-label="Close"
+			onClick={onClose}
+			icon={<X className="w-4 h-4" />}
+		/>
+	);
+}
+
+function PanelHeader({
+	icon,
+	label,
+	color,
+	onClose,
+}: {
+	icon: React.ReactNode;
+	label: string;
+	color: string;
+	onClose: () => void;
+}) {
+	return (
+		<div className="flex items-center justify-between">
+			<div className={`flex items-center gap-2 ${color}`}>
+				{icon}
+				<span className="font-mono text-xs uppercase">{label}</span>
+			</div>
+			<CloseButton onClose={onClose} />
+		</div>
+	);
+}
+
+function Field({
+	label,
+	value,
+	mono,
+	copyable,
+}: {
+	label: string;
+	value: string;
+	mono?: boolean;
+	copyable?: boolean;
+}) {
+	return (
+		<div className="flex flex-col gap-1">
+			<span className="text-xs typo-label-tiny text-text-tertiary uppercase">
+				{label}
+			</span>
+			<div className="flex items-center gap-1 group/field">
+				<span
+					className={`text-sm ${mono ? "font-mono" : ""} text-text-primary break-all`}
+				>
+					{value}
+				</span>
+				{copyable && (
+					<span className="opacity-0 group-hover/field:opacity-100 transition-opacity [&_svg]:size-3.5 text-text-tertiary hover:text-text-primary">
+						<HSComp.CopyIcon
+							text={value}
+							tooltipText="Copy"
+							showToast={false}
+						/>
+					</span>
+				)}
+			</div>
+		</div>
+	);
+}
+
+function Section({
+	title,
+	children,
+}: {
+	title: string;
+	children: React.ReactNode;
+}) {
+	return (
+		<div className="flex flex-col gap-2">
+			<span className="text-xs typo-label-tiny text-text-tertiary uppercase">
+				{title}
+			</span>
+			{children}
+		</div>
+	);
+}
+
+function ResourceLink({
+	resourceType,
+	id,
+}: {
+	resourceType: "ValueSet" | "CodeSystem";
+	id: string;
+}) {
+	return (
+		<div className="flex flex-col gap-1">
+			<span className="text-xs typo-label-tiny text-text-tertiary uppercase">
+				ID
+			</span>
+			<Link
+				to="/resource/$resourceType/edit/$id"
+				params={{ resourceType, id }}
+				search={{
+					tab: "builder" as const,
+					mode: "json" as const,
+					builderTab: "form" as const,
+				}}
+				className="text-sm font-mono text-text-link hover:underline break-all"
+			>
+				{id}
+			</Link>
+		</div>
+	);
+}
+
+function ValueSetContent({
+	data,
+	onClose,
+}: {
+	data: ValueSetNodeData;
+	onClose: () => void;
+}) {
+	const totalIncludes = data.includeSystems + data.includeValueSets;
+	const totalExcludes = data.excludeSystems + data.excludeValueSets;
+	return (
+		<div className="h-full overflow-auto p-4 pb-20 flex flex-col gap-4 bg-bg-primary">
+			<PanelHeader
+				icon={<ListTree size={14} />}
+				label={data.isRoot ? "ValueSet (root)" : "ValueSet"}
+				color="text-text-info-primary"
+				onClose={onClose}
+			/>
+			{data.id && <ResourceLink resourceType="ValueSet" id={data.id} />}
+			<Field
+				label="Title"
+				value={data.title || data.name || data.id || "(unnamed)"}
+			/>
+			{data.name && <Field label="Name" value={data.name} mono copyable />}
+			{data.url && (
+				<Field label="Canonical URL" value={data.url} mono copyable />
+			)}
+			{data.version && <Field label="Version" value={data.version} mono />}
+			{data.status && <Field label="Status" value={data.status} mono />}
+			{data.description && (
+				<Section title="Description">
+					<p className="text-sm text-text-primary whitespace-pre-wrap break-words">
+						{data.description}
+					</p>
+				</Section>
+			)}
+			{totalIncludes > 0 && (
+				<Section title="Compose includes">
+					<ul className="list-disc pl-4 flex flex-col gap-0.5">
+						{data.includeSystems > 0 && (
+							<li className="text-xs font-mono">
+								<span className="text-text-primary">{data.includeSystems}</span>
+								<span className="text-text-tertiary"> CodeSystem(s)</span>
+							</li>
+						)}
+						{data.includeValueSets > 0 && (
+							<li className="text-xs font-mono">
+								<span className="text-text-primary">
+									{data.includeValueSets}
+								</span>
+								<span className="text-text-tertiary"> ValueSet(s)</span>
+							</li>
+						)}
+					</ul>
+				</Section>
+			)}
+			{totalExcludes > 0 && (
+				<Section title="Compose excludes">
+					<ul className="list-disc pl-4 flex flex-col gap-0.5">
+						{data.excludeSystems > 0 && (
+							<li className="text-xs font-mono">
+								<span className="text-text-primary">{data.excludeSystems}</span>
+								<span className="text-text-tertiary"> CodeSystem(s)</span>
+							</li>
+						)}
+						{data.excludeValueSets > 0 && (
+							<li className="text-xs font-mono">
+								<span className="text-text-primary">
+									{data.excludeValueSets}
+								</span>
+								<span className="text-text-tertiary"> ValueSet(s)</span>
+							</li>
+						)}
+					</ul>
+				</Section>
+			)}
+		</div>
+	);
+}
+
+function CodeSystemContent({
+	data,
+	onClose,
+}: {
+	data: CodeSystemNodeData;
+	onClose: () => void;
+}) {
+	return (
+		<div className="h-full overflow-auto p-4 pb-20 flex flex-col gap-4 bg-bg-primary">
+			<PanelHeader
+				icon={<Database size={14} />}
+				label="CodeSystem"
+				color="text-text-success-primary"
+				onClose={onClose}
+			/>
+			{data.id && <ResourceLink resourceType="CodeSystem" id={data.id} />}
+			<Field
+				label="Title"
+				value={data.title || data.name || data.id || "(unnamed)"}
+			/>
+			{data.name && <Field label="Name" value={data.name} mono copyable />}
+			{data.url && (
+				<Field label="Canonical URL" value={data.url} mono copyable />
+			)}
+			{data.version && <Field label="Version" value={data.version} mono />}
+			{data.content && <Field label="Content" value={data.content} mono />}
+			{data.status && <Field label="Status" value={data.status} mono />}
+			{typeof data.count === "number" && (
+				<Field label="Concept count" value={data.count.toLocaleString()} mono />
+			)}
+			{data.description && (
+				<Section title="Description">
+					<p className="text-sm text-text-primary whitespace-pre-wrap break-words">
+						{data.description}
+					</p>
+				</Section>
+			)}
+		</div>
+	);
+}
+
+function UnresolvedContent({
+	data,
+	onClose,
+}: {
+	data: UnresolvedNodeData;
+	onClose: () => void;
+}) {
+	const color =
+		data.resourceKind === "ValueSet"
+			? "text-text-info-primary"
+			: "text-text-success-primary";
+	return (
+		<div className="h-full overflow-auto p-4 pb-20 flex flex-col gap-4 bg-bg-primary">
+			<PanelHeader
+				icon={<AlertCircle size={14} />}
+				label={`${data.resourceKind} (unresolved)`}
+				color={color}
+				onClose={onClose}
+			/>
+			<Field label="Canonical URL" value={data.url} mono copyable />
+			{data.version && <Field label="Version" value={data.version} mono />}
+			<p className="text-xs text-text-tertiary">
+				This {data.resourceKind} is referenced by another resource but is not
+				present in the Aidbox database.
+			</p>
+		</div>
+	);
+}
+
+export function GraphDetailPanel({
+	data,
+	onClose,
+}: {
+	data: GraphNodeData;
+	onClose: () => void;
+}) {
+	if (data.kind === "value-set") {
+		return <ValueSetContent data={data} onClose={onClose} />;
+	}
+	if (data.kind === "code-system") {
+		return <CodeSystemContent data={data} onClose={onClose} />;
+	}
+	return <UnresolvedContent data={data} onClose={onClose} />;
+}

--- a/src/components/ValueSet/graph/expand-result-panel.tsx
+++ b/src/components/ValueSet/graph/expand-result-panel.tsx
@@ -1,0 +1,262 @@
+import * as HSComp from "@health-samurai/react-components";
+import { Maximize2, Minimize2, PanelBottomClose, Timer, X } from "lucide-react";
+import * as React from "react";
+import { useLocalStorage } from "../../../hooks";
+import { DataTableFooter } from "../../data-table/footer";
+import { EmptyState } from "../../empty-state";
+import { useGraphRunContext } from "./run-context";
+
+const DEFAULT_PAGE_SIZE = 30;
+const PAGE_SIZE_STORAGE_KEY = "valueset-graph:result-page-size";
+
+function ExpansionTable({
+	page,
+	pageSize,
+}: {
+	page: number;
+	pageSize: number;
+}) {
+	const { result } = useGraphRunContext();
+	if (!result || result.kind !== "expand") return null;
+	if (result.contains.length === 0) {
+		return (
+			<EmptyState
+				title="Empty expansion"
+				description="The ValueSet expanded successfully but contains no codes"
+			/>
+		);
+	}
+	const start = (page - 1) * pageSize;
+	const visibleRows = result.contains.slice(start, start + pageSize);
+	return (
+		<HSComp.Table zebra stickyHeader className="typo-code">
+			<HSComp.TableHeader className="z-0">
+				<HSComp.TableRow>
+					<HSComp.TableHead>Code</HSComp.TableHead>
+					<HSComp.TableHead>Display</HSComp.TableHead>
+					<HSComp.TableHead>System</HSComp.TableHead>
+					<HSComp.TableHead className="w-full p-0" />
+				</HSComp.TableRow>
+			</HSComp.TableHeader>
+			<HSComp.TableBody>
+				{visibleRows.map((row, i) => (
+					// biome-ignore lint/suspicious/noArrayIndexKey: row order is stable
+					<HSComp.TableRow key={start + i} zebra index={start + i}>
+						<HSComp.TableCell>{row.code ?? "—"}</HSComp.TableCell>
+						<HSComp.TableCell>{row.display ?? "—"}</HSComp.TableCell>
+						<HSComp.TableCell className="text-text-secondary">
+							{row.system ?? "—"}
+						</HSComp.TableCell>
+						<HSComp.TableCell className="p-0" />
+					</HSComp.TableRow>
+				))}
+			</HSComp.TableBody>
+		</HSComp.Table>
+	);
+}
+
+function ContentTable({ page, pageSize }: { page: number; pageSize: number }) {
+	const { result } = useGraphRunContext();
+	if (!result || result.kind !== "content") return null;
+	if (result.rows.length === 0) {
+		return (
+			<EmptyState
+				title="No concepts"
+				description="The CodeSystem returned no inline concepts"
+			/>
+		);
+	}
+	const start = (page - 1) * pageSize;
+	const visibleRows = result.rows.slice(start, start + pageSize);
+	return (
+		<HSComp.Table zebra stickyHeader className="typo-code">
+			<HSComp.TableHeader className="z-0">
+				<HSComp.TableRow>
+					<HSComp.TableHead>Code</HSComp.TableHead>
+					<HSComp.TableHead>Display</HSComp.TableHead>
+					<HSComp.TableHead>Definition</HSComp.TableHead>
+					<HSComp.TableHead>Parent</HSComp.TableHead>
+					<HSComp.TableHead>Depth</HSComp.TableHead>
+					<HSComp.TableHead className="w-full p-0" />
+				</HSComp.TableRow>
+			</HSComp.TableHeader>
+			<HSComp.TableBody>
+				{visibleRows.map((row, i) => (
+					// biome-ignore lint/suspicious/noArrayIndexKey: row order is stable
+					<HSComp.TableRow key={start + i} zebra index={start + i}>
+						<HSComp.TableCell>{row.code}</HSComp.TableCell>
+						<HSComp.TableCell>{row.display ?? "—"}</HSComp.TableCell>
+						<HSComp.TableCell className="text-text-secondary">
+							{row.definition ?? "—"}
+						</HSComp.TableCell>
+						<HSComp.TableCell className="text-text-secondary">
+							{row.parent ?? "—"}
+						</HSComp.TableCell>
+						<HSComp.TableCell className="text-text-secondary">
+							{row.depth}
+						</HSComp.TableCell>
+						<HSComp.TableCell className="p-0" />
+					</HSComp.TableRow>
+				))}
+			</HSComp.TableBody>
+		</HSComp.Table>
+	);
+}
+
+function ResultBody({ page, pageSize }: { page: number; pageSize: number }) {
+	const { runningNodeId, error, result } = useGraphRunContext();
+
+	if (runningNodeId) {
+		return (
+			<div className="flex items-center justify-center h-full w-full text-text-secondary">
+				Loading…
+			</div>
+		);
+	}
+
+	if (error) {
+		return (
+			<HSComp.OperationOutcomeView
+				resource={error}
+				className="h-full overflow-auto"
+			/>
+		);
+	}
+
+	if (!result) {
+		return (
+			<EmptyState
+				title="No result yet"
+				description="Click EXPAND or CONTENT on a node"
+				grayscale
+			/>
+		);
+	}
+
+	if (result.kind === "expand") {
+		return <ExpansionTable page={page} pageSize={pageSize} />;
+	}
+	return <ContentTable page={page} pageSize={pageSize} />;
+}
+
+function getHeaderLabel(
+	result: ReturnType<typeof useGraphRunContext>["result"] | null | undefined,
+	total: number,
+): string {
+	if (!result) return "Result";
+	if (result.kind === "expand") return `Expansion (${result.total ?? total})`;
+	return `Concepts (${total})`;
+}
+
+function getTotal(
+	result: ReturnType<typeof useGraphRunContext>["result"],
+): number {
+	if (!result) return 0;
+	if (result.kind === "expand") return result.contains.length;
+	return result.rows.length;
+}
+
+export function ExpandResultPanel({
+	isMaximized,
+	onToggleMaximize,
+	onToggleCollapse,
+	onClose,
+}: {
+	isMaximized: boolean;
+	onToggleMaximize: () => void;
+	onToggleCollapse: () => void;
+	onClose: () => void;
+}) {
+	const { result } = useGraphRunContext();
+	const [page, setPage] = React.useState(1);
+	const [pageSize, setPageSize] = useLocalStorage<number>({
+		key: PAGE_SIZE_STORAGE_KEY,
+		getInitialValueInEffect: false,
+		defaultValue: DEFAULT_PAGE_SIZE,
+	});
+	const total = getTotal(result);
+	const totalPages = Math.max(1, Math.ceil(total / pageSize));
+
+	React.useEffect(() => {
+		setPage(1);
+	}, []);
+
+	React.useEffect(() => {
+		if (page > totalPages) setPage(totalPages);
+	}, [page, totalPages]);
+
+	return (
+		<div className="flex flex-col h-full overflow-hidden">
+			<div className="flex gap-1 items-center justify-between bg-bg-secondary pl-4 pr-2 border-b h-10 shrink-0">
+				<span className="typo-label text-text-secondary">
+					{getHeaderLabel(result, total)}
+				</span>
+				<div className="flex items-center gap-2">
+					{result?.durationMs != null && (
+						<span className="flex items-center text-text-secondary text-sm pl-2">
+							<Timer className="size-4 mr-1" strokeWidth={1.5} />
+							<span className="font-bold">{Math.round(result.durationMs)}</span>
+							<span className="ml-1">ms</span>
+						</span>
+					)}
+					<HSComp.Tooltip>
+						<HSComp.TooltipTrigger asChild>
+							<HSComp.Button
+								variant="ghost"
+								size="small"
+								onClick={onToggleCollapse}
+							>
+								<PanelBottomClose className="w-4 h-4" />
+							</HSComp.Button>
+						</HSComp.TooltipTrigger>
+						<HSComp.TooltipContent align="end">Collapse</HSComp.TooltipContent>
+					</HSComp.Tooltip>
+					<HSComp.Tooltip>
+						<HSComp.TooltipTrigger asChild>
+							<HSComp.Button
+								variant="ghost"
+								size="small"
+								onClick={onToggleMaximize}
+							>
+								{isMaximized ? (
+									<Minimize2 className="w-4 h-4" />
+								) : (
+									<Maximize2 className="w-4 h-4" />
+								)}
+							</HSComp.Button>
+						</HSComp.TooltipTrigger>
+						<HSComp.TooltipContent align="end">
+							{isMaximized ? "Minimize" : "Maximize"}
+						</HSComp.TooltipContent>
+					</HSComp.Tooltip>
+					<HSComp.Tooltip>
+						<HSComp.TooltipTrigger asChild>
+							<HSComp.Button variant="ghost" size="small" onClick={onClose}>
+								<X className="w-4 h-4" />
+							</HSComp.Button>
+						</HSComp.TooltipTrigger>
+						<HSComp.TooltipContent align="end">Close</HSComp.TooltipContent>
+					</HSComp.Tooltip>
+				</div>
+			</div>
+			<div className="flex-1 min-h-0 flex flex-col">
+				<div className="flex-1 min-h-0">
+					<ResultBody page={page} pageSize={pageSize} />
+				</div>
+				{total > 0 && (
+					<DataTableFooter
+						total={total}
+						currentPage={page}
+						pageSize={pageSize}
+						selectedCount={0}
+						onPageChange={setPage}
+						onPageSizeChange={(size) => {
+							setPageSize(size);
+							setPage(1);
+						}}
+					/>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/src/components/ValueSet/graph/graph-tab.tsx
+++ b/src/components/ValueSet/graph/graph-tab.tsx
@@ -1,0 +1,641 @@
+import type { Bundle } from "@aidbox-ui/fhir-types/hl7-fhir-r5-core";
+import * as HSComp from "@health-samurai/react-components";
+import { useMutation } from "@tanstack/react-query";
+import {
+	Background,
+	Controls,
+	type Edge,
+	MarkerType,
+	type Node,
+	ReactFlow,
+	useEdgesState,
+	useNodesState,
+} from "@xyflow/react";
+import { PanelBottomOpen } from "lucide-react";
+import * as React from "react";
+import { type AidboxClientR5, useAidboxClient } from "../../../AidboxClient";
+import { useLocalStorage } from "../../../hooks";
+import { cleanEmptyValues } from "../../../utils/clean-empty-values";
+import { EmptyState } from "../../empty-state";
+import { useValueSetContext } from "../context";
+import type { ValueSet } from "../types";
+import { GraphDetailPanel } from "./detail-panel";
+import { ExpandResultPanel } from "./expand-result-panel";
+import { nodeTypes } from "./nodes";
+import { useValueSetGraph } from "./resolve-graph";
+import {
+	type ConceptRow,
+	GraphRunContext,
+	type GraphRunContextValue,
+	type GraphRunResult,
+	type RunTarget,
+} from "./run-context";
+import type { GraphEdgeData, GraphNodeData } from "./types";
+
+import "@xyflow/react/dist/style.css";
+
+type FlowNode = Node<GraphNodeData>;
+type FlowEdge = Edge<GraphEdgeData>;
+
+const DIM_COLOR = "#d4d4d8";
+
+const EDGE_COLORS: Record<string, string> = {
+	include: "#52c41a",
+	exclude: "#ff4d4f",
+	supplements: "#722ed1",
+};
+
+const EDGE_LABELS: Record<string, string> = {
+	include: "include",
+	exclude: "exclude",
+	supplements: "supplements",
+};
+
+const DEFAULT_RESULT_HEIGHT = 320;
+const MIN_RESULT_HEIGHT = 120;
+const MAX_RESULT_HEIGHT = 800;
+
+const DEFAULT_DETAILS_WIDTH = 440;
+const MIN_DETAILS_WIDTH = 280;
+const MAX_DETAILS_WIDTH = 800;
+
+function collectConnectedEdges(edges: FlowEdge[], rootId: string): Set<string> {
+	const bySource = new Map<string, FlowEdge[]>();
+	const byTarget = new Map<string, FlowEdge[]>();
+	for (const e of edges) {
+		const s = bySource.get(e.source) ?? [];
+		s.push(e);
+		bySource.set(e.source, s);
+		const t = byTarget.get(e.target) ?? [];
+		t.push(e);
+		byTarget.set(e.target, t);
+	}
+	const result = new Set<string>();
+
+	const seenDown = new Set<string>();
+	const dQ: string[] = [rootId];
+	while (dQ.length > 0) {
+		const id = dQ.shift();
+		if (!id || seenDown.has(id)) continue;
+		seenDown.add(id);
+		for (const e of bySource.get(id) ?? []) {
+			result.add(e.id);
+			dQ.push(e.target);
+		}
+	}
+
+	const seenUp = new Set<string>();
+	const uQ: string[] = [rootId];
+	while (uQ.length > 0) {
+		const id = uQ.shift();
+		if (!id || seenUp.has(id)) continue;
+		seenUp.add(id);
+		for (const e of byTarget.get(id) ?? []) {
+			result.add(e.id);
+			uQ.push(e.source);
+		}
+	}
+	return result;
+}
+
+function defaultEdgeColor(edge: FlowEdge): string {
+	const kind = edge.data?.edgeKind;
+	if (kind && EDGE_COLORS[kind]) return EDGE_COLORS[kind] as string;
+	return DIM_COLOR;
+}
+
+function toOperationOutcome(err: unknown): HSComp.OperationOutcome {
+	if (
+		typeof err === "object" &&
+		err !== null &&
+		"resourceType" in err &&
+		(err as { resourceType: string }).resourceType === "OperationOutcome"
+	) {
+		return err as unknown as HSComp.OperationOutcome;
+	}
+	return {
+		resourceType: "OperationOutcome",
+		issue: [
+			{
+				severity: "error",
+				code: "exception",
+				diagnostics: err instanceof Error ? err.message : String(err),
+			},
+		],
+	};
+}
+
+function clamp(value: number, min: number, max: number): number {
+	return Math.max(min, Math.min(max, value));
+}
+
+type RawCodeSystem = {
+	resourceType: "CodeSystem";
+	id?: string;
+	concept?: RawConcept[];
+};
+
+type RawConcept = {
+	code?: string;
+	display?: string;
+	definition?: string;
+	concept?: RawConcept[];
+};
+
+async function fetchCodeSystem(
+	client: AidboxClientR5,
+	target: { csId?: string; url?: string; version?: string },
+): Promise<RawCodeSystem> {
+	if (target.csId) {
+		const r = await client.request<RawCodeSystem>({
+			method: "GET",
+			url: `/fhir/CodeSystem/${target.csId}`,
+		});
+		if (r.isErr()) throw r.value.resource;
+		return r.value.resource;
+	}
+	if (!target.url) {
+		throw {
+			resourceType: "OperationOutcome",
+			issue: [
+				{
+					severity: "error",
+					code: "invalid",
+					diagnostics: "CodeSystem has no ID or canonical URL",
+				},
+			],
+		};
+	}
+	const params: Array<[string, string]> = [
+		["url", target.url],
+		["_count", "1"],
+		["_sort", "-_lastUpdated"],
+	];
+	if (target.version) params.push(["version", target.version]);
+	const r = await client.request<Bundle>({
+		method: "GET",
+		url: "/fhir/CodeSystem",
+		params,
+	});
+	if (r.isErr()) throw r.value.resource;
+	const entry = r.value.resource.entry?.[0];
+	const cs = entry?.resource as RawCodeSystem | undefined;
+	if (!cs) {
+		throw {
+			resourceType: "OperationOutcome",
+			issue: [
+				{
+					severity: "error",
+					code: "not-found",
+					diagnostics: `CodeSystem ${target.url} not found`,
+				},
+			],
+		};
+	}
+	return cs;
+}
+
+function flattenConcepts(
+	concepts: RawConcept[] | undefined,
+	depth = 0,
+	parent?: string,
+): ConceptRow[] {
+	if (!concepts) return [];
+	const out: ConceptRow[] = [];
+	for (const c of concepts) {
+		if (!c.code) continue;
+		out.push({
+			code: c.code,
+			display: c.display,
+			definition: c.definition,
+			parent,
+			depth,
+		});
+		if (c.concept && c.concept.length > 0) {
+			out.push(...flattenConcepts(c.concept, depth + 1, c.code));
+		}
+	}
+	return out;
+}
+
+export function ValueSetGraphTab() {
+	const client = useAidboxClient();
+	const { valueSet } = useValueSetContext();
+	const { graph, isLoading } = useValueSetGraph(valueSet);
+
+	const [nodes, setNodes, onNodesChange] = useNodesState<FlowNode>(graph.nodes);
+	const [edges, setEdges, onEdgesChange] = useEdgesState<FlowEdge>(graph.edges);
+	const [selectedId, setSelectedId] = React.useState<string | null>(null);
+
+	const [runningNodeId, setRunningNodeId] = React.useState<string | null>(null);
+	const [resultNodeId, setResultNodeId] = React.useState<string | null>(null);
+	const [result, setResult] = React.useState<GraphRunResult | null>(null);
+	const [error, setError] = React.useState<HSComp.OperationOutcome | null>(
+		null,
+	);
+
+	const [isResultCollapsed, setIsResultCollapsed] = React.useState(false);
+	const [isMaximized, setIsMaximized] = React.useState(false);
+
+	const [resultHeight, setResultHeight] = useLocalStorage<number>({
+		key: "valueset-graph:result-height",
+		defaultValue: DEFAULT_RESULT_HEIGHT,
+		getInitialValueInEffect: false,
+	});
+	const resultHeightRef = React.useRef(resultHeight);
+	resultHeightRef.current = resultHeight;
+
+	const [detailsWidth, setDetailsWidth] = useLocalStorage<number>({
+		key: "valueset-graph:details-width",
+		defaultValue: DEFAULT_DETAILS_WIDTH,
+		getInitialValueInEffect: false,
+	});
+	const detailsWidthRef = React.useRef(detailsWidth);
+	detailsWidthRef.current = detailsWidth;
+
+	const valueSetRef = React.useRef<ValueSet>(valueSet);
+	valueSetRef.current = valueSet;
+
+	React.useEffect(() => {
+		setNodes(graph.nodes);
+		setEdges(graph.edges);
+	}, [graph.nodes, graph.edges, setNodes, setEdges]);
+
+	const runStartRef = React.useRef<number>(0);
+
+	const runMutation = useMutation({
+		mutationFn: async (target: RunTarget): Promise<GraphRunResult> => {
+			setRunningNodeId(target.nodeId);
+			setResultNodeId(target.nodeId);
+			setError(null);
+			setResult(null);
+			runStartRef.current = performance.now();
+			if (target.kind === "expand") {
+				if (target.isRoot) {
+					const body = {
+						resourceType: "Parameters" as const,
+						parameter: [
+							{
+								name: "valueSet",
+								resource: cleanEmptyValues(valueSetRef.current),
+							},
+						],
+					};
+					const r = await client.request<ValueSet>({
+						method: "POST",
+						url: "/fhir/ValueSet/$expand",
+						body: JSON.stringify(body),
+						headers: { "Content-Type": "application/fhir+json" },
+					});
+					if (r.isErr()) throw r.value.resource;
+					return {
+						kind: "expand",
+						contains: r.value.resource.expansion?.contains ?? [],
+						total: r.value.resource.expansion?.total,
+						durationMs: performance.now() - runStartRef.current,
+					};
+				}
+				if (!target.url) {
+					throw {
+						resourceType: "OperationOutcome",
+						issue: [
+							{
+								severity: "error",
+								code: "invalid",
+								diagnostics: "ValueSet has no canonical URL",
+							},
+						],
+					};
+				}
+				const params: Array<[string, string]> = [["url", target.url]];
+				if (target.version) params.push(["valueSetVersion", target.version]);
+				const r = await client.request<ValueSet>({
+					method: "GET",
+					url: "/fhir/ValueSet/$expand",
+					params,
+				});
+				if (r.isErr()) throw r.value.resource;
+				return {
+					kind: "expand",
+					contains: r.value.resource.expansion?.contains ?? [],
+					total: r.value.resource.expansion?.total,
+					durationMs: performance.now() - runStartRef.current,
+				};
+			}
+			const cs = await fetchCodeSystem(client, target);
+			return {
+				kind: "content",
+				rows: flattenConcepts(cs.concept),
+				durationMs: performance.now() - runStartRef.current,
+			};
+		},
+		onSuccess: (res) => {
+			setRunningNodeId(null);
+			setResult(res);
+		},
+		onError: (err) => {
+			setRunningNodeId(null);
+			setError(toOperationOutcome(err));
+		},
+	});
+
+	const run = React.useCallback(
+		(target: RunTarget) => {
+			if (runMutation.isPending) return;
+			setIsResultCollapsed(false);
+			setIsMaximized(false);
+			runMutation.mutate(target);
+		},
+		[runMutation],
+	);
+
+	const runContextValue = React.useMemo<GraphRunContextValue>(
+		() => ({
+			runningNodeId,
+			resultNodeId,
+			result,
+			error,
+			run,
+		}),
+		[runningNodeId, resultNodeId, result, error, run],
+	);
+
+	const styledEdges = React.useMemo<FlowEdge[]>(() => {
+		const baseProps = { type: "default" as const };
+		if (!selectedId) {
+			return edges.map((e) => {
+				const color = defaultEdgeColor(e);
+				return {
+					...e,
+					...baseProps,
+					style: { stroke: color, strokeWidth: 1.5 },
+					markerEnd: { type: MarkerType.ArrowClosed, color },
+				};
+			});
+		}
+		const highlighted = collectConnectedEdges(edges, selectedId);
+		return edges.map((e) => {
+			const on = highlighted.has(e.id);
+			const color = on ? defaultEdgeColor(e) : DIM_COLOR;
+			return {
+				...e,
+				...baseProps,
+				style: {
+					stroke: on ? color : DIM_COLOR,
+					strokeWidth: on ? 2 : 1,
+				},
+				markerEnd: {
+					type: MarkerType.ArrowClosed,
+					color: on ? color : DIM_COLOR,
+				},
+				animated: on,
+			};
+		});
+	}, [edges, selectedId]);
+
+	const presentKinds = React.useMemo(() => {
+		const set = new Set<string>();
+		for (const e of edges) {
+			const k = e.data?.edgeKind;
+			if (k) set.add(k);
+		}
+		return Array.from(set);
+	}, [edges]);
+
+	const clearSelection = React.useCallback(() => {
+		setSelectedId(null);
+		setNodes((nds) =>
+			nds.map((n) => (n.selected ? { ...n, selected: false } : n)),
+		);
+	}, [setNodes]);
+
+	const handleToggleMaximize = React.useCallback(() => {
+		setIsMaximized((p) => !p);
+	}, []);
+
+	const handleToggleCollapse = React.useCallback(() => {
+		setIsResultCollapsed(true);
+		setIsMaximized(false);
+	}, []);
+
+	const handleClose = React.useCallback(() => {
+		setResultNodeId(null);
+		setResult(null);
+		setError(null);
+		setIsResultCollapsed(false);
+		setIsMaximized(false);
+	}, []);
+
+	React.useEffect(() => {
+		if (!isMaximized) return;
+		const onEscape = (e: KeyboardEvent) => {
+			if (e.key === "Escape") setIsMaximized(false);
+		};
+		document.addEventListener("keydown", onEscape);
+		return () => document.removeEventListener("keydown", onEscape);
+	}, [isMaximized]);
+
+	const startResize = React.useCallback(
+		(e: React.MouseEvent) => {
+			e.preventDefault();
+			const startY = e.clientY;
+			const startH = resultHeightRef.current;
+			const prevUserSelect = document.body.style.userSelect;
+			const prevCursor = document.body.style.cursor;
+			document.body.style.userSelect = "none";
+			document.body.style.cursor = "row-resize";
+			const onMove = (ev: MouseEvent) => {
+				const delta = startY - ev.clientY;
+				setResultHeight(
+					clamp(startH + delta, MIN_RESULT_HEIGHT, MAX_RESULT_HEIGHT),
+				);
+			};
+			const onUp = () => {
+				document.body.style.userSelect = prevUserSelect;
+				document.body.style.cursor = prevCursor;
+				document.removeEventListener("mousemove", onMove);
+				document.removeEventListener("mouseup", onUp);
+			};
+			document.addEventListener("mousemove", onMove);
+			document.addEventListener("mouseup", onUp);
+		},
+		[setResultHeight],
+	);
+
+	const startResizeDetails = React.useCallback(
+		(e: React.MouseEvent) => {
+			e.preventDefault();
+			const startX = e.clientX;
+			const startW = detailsWidthRef.current;
+			const prevUserSelect = document.body.style.userSelect;
+			const prevCursor = document.body.style.cursor;
+			document.body.style.userSelect = "none";
+			document.body.style.cursor = "col-resize";
+			const onMove = (ev: MouseEvent) => {
+				const delta = startX - ev.clientX;
+				setDetailsWidth(
+					clamp(startW + delta, MIN_DETAILS_WIDTH, MAX_DETAILS_WIDTH),
+				);
+			};
+			const onUp = () => {
+				document.body.style.userSelect = prevUserSelect;
+				document.body.style.cursor = prevCursor;
+				document.removeEventListener("mousemove", onMove);
+				document.removeEventListener("mouseup", onUp);
+			};
+			document.addEventListener("mousemove", onMove);
+			document.addEventListener("mouseup", onUp);
+		},
+		[setDetailsWidth],
+	);
+
+	if (isLoading && nodes.length === 0) {
+		return (
+			<div className="flex items-center justify-center h-full w-full text-text-secondary">
+				Resolving graph…
+			</div>
+		);
+	}
+
+	if (nodes.length === 0) {
+		return (
+			<EmptyState
+				title="No graph"
+				description="This ValueSet has no compose.include / exclude references yet."
+			/>
+		);
+	}
+
+	const selectedData =
+		(nodes.find((n) => n.id === selectedId)?.data as
+			| GraphNodeData
+			| undefined) ?? null;
+	const detailsOpen = selectedData !== null;
+
+	const hasResult = resultNodeId !== null;
+	const showResult = hasResult && !isResultCollapsed;
+	const showResultBar = hasResult && isResultCollapsed && !isMaximized;
+
+	return (
+		<GraphRunContext.Provider value={runContextValue}>
+			<div className="relative h-full w-full overflow-hidden">
+				<div className="absolute inset-0 bg-bg-primary">
+					<ReactFlow<FlowNode, FlowEdge>
+						nodes={nodes}
+						edges={styledEdges}
+						onNodesChange={onNodesChange}
+						onEdgesChange={onEdgesChange}
+						onNodeClick={(_, node) => setSelectedId(node.id)}
+						onPaneClick={clearSelection}
+						nodeTypes={nodeTypes}
+						nodesDraggable={false}
+						nodesConnectable={false}
+						fitView
+						fitViewOptions={{ padding: 0.2 }}
+						defaultEdgeOptions={{
+							type: "default",
+							markerEnd: { type: MarkerType.ArrowClosed },
+						}}
+						minZoom={0.2}
+						proOptions={{ hideAttribution: true }}
+					>
+						<Background />
+						<Controls showFitView={false} />
+					</ReactFlow>
+				</div>
+
+				{presentKinds.length > 0 && (
+					<div className="absolute top-2 right-2 z-10 rounded-md bg-bg-primary border border-border-primary shadow-sm px-2 py-1.5 flex flex-col gap-1">
+						<span className="typo-label-tiny text-text-tertiary uppercase">
+							Edges
+						</span>
+						<div className="flex flex-col gap-0.5">
+							{presentKinds.map((k) => (
+								<div key={k} className="flex items-center gap-2">
+									<span
+										className="inline-block w-4 h-0.5 rounded-sm"
+										style={{ backgroundColor: EDGE_COLORS[k] ?? DIM_COLOR }}
+									/>
+									<span className="text-xs text-text-primary">
+										{EDGE_LABELS[k] ?? k}
+									</span>
+								</div>
+							))}
+						</div>
+					</div>
+				)}
+
+				{detailsOpen && (
+					<div
+						className="absolute top-0 right-0 bottom-0 z-20 bg-bg-primary border-l border-border-primary shadow-lg"
+						style={{ width: detailsWidth }}
+					>
+						<button
+							type="button"
+							aria-label="Resize details panel"
+							className="absolute left-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-border-link/60 z-10 -translate-x-1/2 bg-transparent border-0 p-0"
+							onMouseDown={startResizeDetails}
+							style={{ touchAction: "none" }}
+						/>
+						<GraphDetailPanel data={selectedData} onClose={clearSelection} />
+					</div>
+				)}
+
+				{showResult && (
+					<div
+						className={
+							isMaximized
+								? "absolute inset-0 z-30 bg-bg-primary"
+								: "absolute bottom-0 left-0 z-20 bg-bg-primary border-t border-border-primary shadow-lg"
+						}
+						style={
+							isMaximized
+								? undefined
+								: {
+										height: resultHeight,
+										right: detailsOpen ? detailsWidth : 0,
+									}
+						}
+					>
+						{!isMaximized && (
+							<button
+								type="button"
+								aria-label="Resize result panel"
+								className="absolute left-0 right-0 top-0 h-1 cursor-row-resize hover:bg-border-link/60 z-10 -translate-y-1/2 bg-transparent border-0 p-0"
+								onMouseDown={startResize}
+								style={{ touchAction: "none" }}
+							/>
+						)}
+						<ExpandResultPanel
+							isMaximized={isMaximized}
+							onToggleMaximize={handleToggleMaximize}
+							onToggleCollapse={handleToggleCollapse}
+							onClose={handleClose}
+						/>
+					</div>
+				)}
+
+				{showResultBar && (
+					<div
+						className="absolute bottom-0 left-0 z-20 bg-bg-secondary border-t border-border-primary flex items-center justify-between pl-6 pr-2 h-10"
+						style={{ right: detailsOpen ? detailsWidth : 0 }}
+					>
+						<span className="typo-label text-text-secondary">Expansion</span>
+						<HSComp.Tooltip>
+							<HSComp.TooltipTrigger asChild>
+								<HSComp.Button
+									variant="ghost"
+									size="small"
+									onClick={() => setIsResultCollapsed(false)}
+								>
+									<PanelBottomOpen className="w-4 h-4" />
+								</HSComp.Button>
+							</HSComp.TooltipTrigger>
+							<HSComp.TooltipContent align="end">Restore</HSComp.TooltipContent>
+						</HSComp.Tooltip>
+					</div>
+				)}
+			</div>
+		</GraphRunContext.Provider>
+	);
+}

--- a/src/components/ValueSet/graph/nodes.tsx
+++ b/src/components/ValueSet/graph/nodes.tsx
@@ -1,0 +1,264 @@
+import * as HSComp from "@health-samurai/react-components";
+import { Handle, Position } from "@xyflow/react";
+import {
+	AlertCircle,
+	Database,
+	FileText,
+	ListTree,
+	PlayIcon,
+} from "lucide-react";
+import type * as React from "react";
+import {
+	BaseNode,
+	BaseNodeBody,
+	BaseNodeFooter,
+	BaseNodeHeader,
+	BaseNodeRow,
+} from "../../SQLQueryBuilder/lineage/base-node";
+import { useGraphRunContext } from "./run-context";
+import type {
+	CodeSystemNodeData,
+	UnresolvedNodeData,
+	ValueSetNodeData,
+} from "./types";
+
+type AnyNodeProps = {
+	id: string;
+	data: Record<string, unknown>;
+	selected?: boolean;
+};
+
+export const HANDLE_COUNT = 5;
+
+const HANDLE_TOPS = Array.from(
+	{ length: HANDLE_COUNT },
+	(_, i) => `${((i + 1) / (HANDLE_COUNT + 1)) * 100}%`,
+);
+
+function TargetHandles() {
+	return (
+		<>
+			{HANDLE_TOPS.map((top) => (
+				<Handle
+					key={`target-${top}`}
+					id={`target-${top}`}
+					type="target"
+					position={Position.Right}
+					className="w-2 h-2 right-0! opacity-0"
+					style={{ top }}
+				/>
+			))}
+		</>
+	);
+}
+
+function SourceHandles() {
+	return (
+		<>
+			{HANDLE_TOPS.map((top) => (
+				<Handle
+					key={`source-${top}`}
+					id={`source-${top}`}
+					type="source"
+					position={Position.Left}
+					className="w-2 h-2 left-0! opacity-0"
+					style={{ top }}
+				/>
+			))}
+		</>
+	);
+}
+
+function ExpandFooter({
+	nodeId,
+	isRoot,
+	url,
+	version,
+}: {
+	nodeId: string;
+	isRoot: boolean;
+	url?: string;
+	version?: string;
+}) {
+	const { run, runningNodeId } = useGraphRunContext();
+	const isRunningThis = runningNodeId === nodeId;
+	const disabled = !isRoot && !url;
+	const handleClick = (e: React.MouseEvent) => {
+		e.stopPropagation();
+		if (disabled) return;
+		run({ kind: "expand", nodeId, isRoot, url, version });
+	};
+	return (
+		<BaseNodeFooter className="border-t-0">
+			<HSComp.Button
+				variant="link"
+				size="small"
+				className="px-0! text-text-link! hover:text-text-link/80! disabled:opacity-50"
+				onClick={handleClick}
+				disabled={runningNodeId !== null || disabled}
+			>
+				<PlayIcon className="w-3.5 h-3.5 fill-current" />
+				{isRunningThis ? "Expanding…" : "EXPAND"}
+			</HSComp.Button>
+		</BaseNodeFooter>
+	);
+}
+
+function ContentFooter({
+	nodeId,
+	csId,
+	url,
+	version,
+}: {
+	nodeId: string;
+	csId?: string;
+	url?: string;
+	version?: string;
+}) {
+	const { run, runningNodeId } = useGraphRunContext();
+	const isRunningThis = runningNodeId === nodeId;
+	const disabled = !csId && !url;
+	const handleClick = (e: React.MouseEvent) => {
+		e.stopPropagation();
+		if (disabled) return;
+		run({ kind: "content", nodeId, csId, url, version });
+	};
+	return (
+		<BaseNodeFooter className="border-t-0">
+			<HSComp.Button
+				variant="link"
+				size="small"
+				className="px-0! text-text-link! hover:text-text-link/80! disabled:opacity-50"
+				onClick={handleClick}
+				disabled={runningNodeId !== null || disabled}
+			>
+				<FileText className="w-3.5 h-3.5" />
+				{isRunningThis ? "Loading…" : "CONTENT"}
+			</HSComp.Button>
+		</BaseNodeFooter>
+	);
+}
+
+export function ValueSetNode({ id, data, selected }: AnyNodeProps) {
+	const d = data as unknown as ValueSetNodeData;
+	const titleLine = d.title || d.name || d.id || "(unnamed)";
+	const urlLine = d.url ? `${d.url}${d.version ? `|${d.version}` : ""}` : null;
+	return (
+		<BaseNode
+			selected={selected}
+			className={`w-[350px]! ${d.isRoot ? "border-border-link" : ""}`}
+		>
+			<BaseNodeHeader>
+				<div className="flex items-center gap-2">
+					<ListTree size={14} className="text-text-info-primary shrink-0" />
+					<span className="font-mono text-xs text-text-info-primary uppercase">
+						ValueSet
+					</span>
+					{d.isRoot && (
+						<span className="font-mono text-[10px] text-text-tertiary uppercase">
+							root
+						</span>
+					)}
+				</div>
+				<div className="text-sm font-medium text-text-primary truncate">
+					{titleLine}
+				</div>
+				{urlLine && (
+					<div className="font-mono text-xs text-text-tertiary truncate">
+						{urlLine}
+					</div>
+				)}
+			</BaseNodeHeader>
+			<ExpandFooter
+				nodeId={id}
+				isRoot={d.isRoot}
+				url={d.url}
+				version={d.version}
+			/>
+			{!d.isRoot && <TargetHandles />}
+			<SourceHandles />
+		</BaseNode>
+	);
+}
+
+export function CodeSystemNode({ id, data, selected }: AnyNodeProps) {
+	const d = data as unknown as CodeSystemNodeData;
+	const titleLine = d.title || d.name || d.id || "(unnamed)";
+	const urlLine = d.url ? `${d.url}${d.version ? `|${d.version}` : ""}` : null;
+	return (
+		<BaseNode selected={selected} className="w-[350px]!">
+			<BaseNodeHeader>
+				<div className="flex items-center gap-2">
+					<Database size={14} className="text-text-success-primary shrink-0" />
+					<span className="font-mono text-xs text-text-success-primary uppercase">
+						CodeSystem
+					</span>
+				</div>
+				<div className="text-sm font-medium text-text-primary truncate">
+					{titleLine}
+				</div>
+				{urlLine && (
+					<div className="font-mono text-xs text-text-tertiary truncate">
+						{urlLine}
+					</div>
+				)}
+			</BaseNodeHeader>
+			<BaseNodeBody>
+				{typeof d.count === "number" && (
+					<BaseNodeRow>
+						<span className="font-mono text-xs text-text-tertiary">count</span>
+						<span className="font-mono text-xs text-text-primary text-right truncate">
+							{d.count.toLocaleString()}
+						</span>
+					</BaseNodeRow>
+				)}
+			</BaseNodeBody>
+			{d.content === "complete" && (
+				<ContentFooter
+					nodeId={id}
+					csId={d.id}
+					url={d.url}
+					version={d.version}
+				/>
+			)}
+			<TargetHandles />
+			<SourceHandles />
+		</BaseNode>
+	);
+}
+
+export function UnresolvedNode({ data, selected }: AnyNodeProps) {
+	const d = data as unknown as UnresolvedNodeData;
+	const color =
+		d.resourceKind === "ValueSet"
+			? "text-text-info-primary"
+			: "text-text-success-primary";
+	return (
+		<div
+			className={`rounded-md bg-bg-secondary border border-dashed shadow-sm overflow-hidden w-[350px] ${selected ? "border-border-link" : "border-border-primary"}`}
+		>
+			<div className="flex flex-col gap-2 px-3 py-2 border-b border-border-primary border-dashed">
+				<div className="flex items-center gap-2">
+					<AlertCircle size={14} className={`${color} shrink-0`} />
+					<span className={`font-mono text-xs ${color} uppercase`}>
+						{d.resourceKind}
+					</span>
+					<span className="font-mono text-[10px] text-text-tertiary uppercase">
+						unresolved
+					</span>
+				</div>
+				<div className="font-mono text-sm text-text-primary truncate">
+					{d.url}
+					{d.version ? `|${d.version}` : ""}
+				</div>
+			</div>
+			<TargetHandles />
+		</div>
+	);
+}
+
+export const nodeTypes = {
+	"value-set": ValueSetNode,
+	"code-system": CodeSystemNode,
+	unresolved: UnresolvedNode,
+};

--- a/src/components/ValueSet/graph/resolve-graph.ts
+++ b/src/components/ValueSet/graph/resolve-graph.ts
@@ -1,0 +1,621 @@
+import type { Bundle } from "@aidbox-ui/fhir-types/hl7-fhir-r5-core";
+import { useQuery } from "@tanstack/react-query";
+import { type AidboxClientR5, useAidboxClient } from "../../../AidboxClient";
+import type { ValueSet } from "../types";
+import type {
+	CodeSystemNodeData,
+	GraphEdge,
+	GraphEdgeKind,
+	GraphNode,
+	GraphNodeData,
+	UnresolvedNodeData,
+	ValueSetGraph,
+	ValueSetNodeData,
+} from "./types";
+
+const COL_WIDTH = 540;
+const ROW_HEIGHT = 320;
+
+type RawConcept = unknown;
+
+type RawValueSet = {
+	resourceType: "ValueSet";
+	id?: string;
+	url?: string;
+	version?: string;
+	name?: string;
+	title?: string;
+	description?: string;
+	status?: string;
+	compose?: {
+		include?: Array<{
+			system?: string;
+			version?: string;
+			valueSet?: string[];
+		}>;
+		exclude?: Array<{
+			system?: string;
+			version?: string;
+			valueSet?: string[];
+		}>;
+	};
+};
+
+type RawCodeSystem = {
+	resourceType: "CodeSystem";
+	id?: string;
+	url?: string;
+	version?: string;
+	name?: string;
+	title?: string;
+	description?: string;
+	status?: string;
+	content?: string;
+	count?: number;
+	valueSet?: string;
+	supplements?: string;
+	concept?: RawConcept[];
+};
+
+function buildCanonical(url?: string, version?: string): string {
+	if (!url) return "";
+	return version ? `${url}|${version}` : url;
+}
+
+function splitCanonical(canonical: string): { url: string; version?: string } {
+	const idx = canonical.indexOf("|");
+	if (idx < 0) return { url: canonical };
+	return { url: canonical.slice(0, idx), version: canonical.slice(idx + 1) };
+}
+
+async function fetchByCanonical<T extends RawValueSet | RawCodeSystem>(
+	client: AidboxClientR5,
+	resourceType: "ValueSet" | "CodeSystem",
+	canonical: string,
+): Promise<T | null> {
+	const relative = canonical.match(/^(ValueSet|CodeSystem)\/([^/?#]+)$/);
+	if (relative && relative[1] === resourceType) {
+		const result = await client.request<T>({
+			method: "GET",
+			url: `/fhir/${resourceType}/${relative[2]}`,
+		});
+		if (result.isErr()) return null;
+		return result.value.resource;
+	}
+	const { url, version } = splitCanonical(canonical);
+	if (!url) return null;
+	const params: Array<[string, string]> = [
+		["url", url],
+		["_count", "1"],
+		["_sort", "-_lastUpdated"],
+	];
+	if (version) params.push(["version", version]);
+	const result = await client.request<Bundle>({
+		method: "GET",
+		url: `/fhir/${resourceType}`,
+		params,
+	});
+	if (result.isErr()) return null;
+	const entry = result.value.resource.entry?.[0];
+	const r = entry?.resource as T | undefined;
+	if (!r || r.resourceType !== resourceType) return null;
+	return r;
+}
+
+function valueSetNodeData(vs: RawValueSet, isRoot: boolean): ValueSetNodeData {
+	const include = vs.compose?.include ?? [];
+	const exclude = vs.compose?.exclude ?? [];
+	let includeSystems = 0;
+	let includeValueSets = 0;
+	for (const inc of include) {
+		if (inc.system) includeSystems++;
+		includeValueSets += (inc.valueSet ?? []).length;
+	}
+	let excludeSystems = 0;
+	let excludeValueSets = 0;
+	for (const exc of exclude) {
+		if (exc.system) excludeSystems++;
+		excludeValueSets += (exc.valueSet ?? []).length;
+	}
+	return {
+		kind: "value-set",
+		id: vs.id,
+		url: vs.url,
+		version: vs.version,
+		name: vs.name,
+		title: vs.title,
+		description: vs.description,
+		status: vs.status,
+		isRoot,
+		includeSystems,
+		includeValueSets,
+		excludeSystems,
+		excludeValueSets,
+	};
+}
+
+function codeSystemNodeData(cs: RawCodeSystem): CodeSystemNodeData {
+	return {
+		kind: "code-system",
+		id: cs.id,
+		url: cs.url,
+		version: cs.version,
+		name: cs.name,
+		title: cs.title,
+		description: cs.description,
+		status: cs.status,
+		content: cs.content,
+		count: cs.count,
+	};
+}
+
+function unresolvedNodeData(
+	resourceKind: "ValueSet" | "CodeSystem",
+	canonical: string,
+): UnresolvedNodeData {
+	const { url, version } = splitCanonical(canonical);
+	return { kind: "unresolved", resourceKind, url, version };
+}
+
+function valueSetNodeId(vs: RawValueSet, canonical: string): string {
+	return `value-set:${vs.id ?? vs.url ?? canonical}`;
+}
+
+function codeSystemNodeId(cs: RawCodeSystem, canonical: string): string {
+	return `code-system:${cs.id ?? cs.url ?? canonical}`;
+}
+
+function unresolvedNodeId(
+	resourceKind: "ValueSet" | "CodeSystem",
+	canonical: string,
+): string {
+	return `unresolved:${resourceKind}:${canonical}`;
+}
+
+type QueueItem = {
+	canonical: string;
+	resourceKind: "ValueSet" | "CodeSystem";
+	parentId: string;
+	depth: number;
+	edgeKind: GraphEdgeKind;
+};
+
+type BuildState = {
+	nodesById: Map<string, { data: GraphNodeData; type: string }>;
+	depthById: Map<string, number>;
+	canonicalToId: Map<string, string>;
+	edges: GraphEdge[];
+	edgeKeys: Set<string>;
+};
+
+function setDepth(state: BuildState, id: string, depth: number) {
+	const prev = state.depthById.get(id);
+	state.depthById.set(id, prev === undefined ? depth : Math.max(prev, depth));
+}
+
+function pushEdge(
+	state: BuildState,
+	source: string,
+	target: string,
+	edgeKind: GraphEdgeKind,
+) {
+	const id = `${source}->${target}:${edgeKind}`;
+	if (state.edgeKeys.has(id)) return;
+	state.edgeKeys.add(id);
+	state.edges.push({
+		id,
+		source,
+		target,
+		data: { edgeKind },
+	});
+}
+
+function rootCanonical(vs: RawValueSet): string {
+	const canonical = buildCanonical(vs.url, vs.version);
+	if (canonical) return canonical;
+	if (vs.id) return `ValueSet/${vs.id}`;
+	return "ValueSet/root";
+}
+
+function processValueSetNode(
+	state: BuildState,
+	canonical: string,
+	vs: RawValueSet,
+	isRoot: boolean,
+): { id: string; isNew: boolean } {
+	const id = valueSetNodeId(vs, canonical);
+	if (state.nodesById.has(id)) return { id, isNew: false };
+	state.nodesById.set(id, {
+		type: "value-set",
+		data: valueSetNodeData(vs, isRoot),
+	});
+	state.canonicalToId.set(canonical, id);
+	return { id, isNew: true };
+}
+
+function processCodeSystemNode(
+	state: BuildState,
+	canonical: string,
+	cs: RawCodeSystem,
+): { id: string; isNew: boolean } {
+	const id = codeSystemNodeId(cs, canonical);
+	if (state.nodesById.has(id)) return { id, isNew: false };
+	state.nodesById.set(id, {
+		type: "code-system",
+		data: codeSystemNodeData(cs),
+	});
+	state.canonicalToId.set(canonical, id);
+	return { id, isNew: true };
+}
+
+function processUnresolvedNode(
+	state: BuildState,
+	resourceKind: "ValueSet" | "CodeSystem",
+	canonical: string,
+): { id: string; isNew: boolean } {
+	const id = unresolvedNodeId(resourceKind, canonical);
+	if (state.nodesById.has(id)) return { id, isNew: false };
+	state.nodesById.set(id, {
+		type: "unresolved",
+		data: unresolvedNodeData(resourceKind, canonical),
+	});
+	state.canonicalToId.set(canonical, id);
+	return { id, isNew: true };
+}
+
+function collectComposeDeps(
+	vs: RawValueSet,
+	parentId: string,
+	parentDepth: number,
+): QueueItem[] {
+	const out: QueueItem[] = [];
+	const childDepth = parentDepth + 1;
+	for (const inc of vs.compose?.include ?? []) {
+		if (inc.system) {
+			const canonical = buildCanonical(inc.system, inc.version);
+			if (canonical) {
+				out.push({
+					canonical,
+					resourceKind: "CodeSystem",
+					parentId,
+					depth: childDepth,
+					edgeKind: "include",
+				});
+			}
+		}
+		for (const vsRef of inc.valueSet ?? []) {
+			out.push({
+				canonical: vsRef,
+				resourceKind: "ValueSet",
+				parentId,
+				depth: childDepth,
+				edgeKind: "include",
+			});
+		}
+	}
+	for (const exc of vs.compose?.exclude ?? []) {
+		if (exc.system) {
+			const canonical = buildCanonical(exc.system, exc.version);
+			if (canonical) {
+				out.push({
+					canonical,
+					resourceKind: "CodeSystem",
+					parentId,
+					depth: childDepth,
+					edgeKind: "exclude",
+				});
+			}
+		}
+		for (const vsRef of exc.valueSet ?? []) {
+			out.push({
+				canonical: vsRef,
+				resourceKind: "ValueSet",
+				parentId,
+				depth: childDepth,
+				edgeKind: "exclude",
+			});
+		}
+	}
+	return out;
+}
+
+function collectCodeSystemDeps(
+	cs: RawCodeSystem,
+	parentId: string,
+	parentDepth: number,
+): QueueItem[] {
+	const out: QueueItem[] = [];
+	const childDepth = parentDepth + 1;
+	if (cs.supplements) {
+		out.push({
+			canonical: cs.supplements,
+			resourceKind: "CodeSystem",
+			parentId,
+			depth: childDepth,
+			edgeKind: "supplements",
+		});
+	}
+	return out;
+}
+
+type FetchKey = { canonical: string; resourceKind: "ValueSet" | "CodeSystem" };
+
+async function fetchUniqueResources(
+	client: AidboxClientR5,
+	keys: FetchKey[],
+): Promise<Map<string, RawValueSet | RawCodeSystem | null>> {
+	const dedup = new Map<string, FetchKey>();
+	for (const k of keys) {
+		const dedupKey = `${k.resourceKind}|${k.canonical}`;
+		if (!dedup.has(dedupKey)) dedup.set(dedupKey, k);
+	}
+	const entries = await Promise.all(
+		Array.from(dedup.entries()).map(async ([dedupKey, k]) => {
+			const resource =
+				k.resourceKind === "ValueSet"
+					? await fetchByCanonical<RawValueSet>(client, "ValueSet", k.canonical)
+					: await fetchByCanonical<RawCodeSystem>(
+							client,
+							"CodeSystem",
+							k.canonical,
+						);
+			return [dedupKey, resource] as const;
+		}),
+	);
+	return new Map(entries);
+}
+
+async function buildGraph(
+	client: AidboxClientR5,
+	rootVs: RawValueSet,
+): Promise<ValueSetGraph> {
+	const rootCan = rootCanonical(rootVs);
+	const state: BuildState = {
+		nodesById: new Map(),
+		depthById: new Map(),
+		canonicalToId: new Map(),
+		edges: [],
+		edgeKeys: new Set(),
+	};
+	const { id: rootId } = processValueSetNode(state, rootCan, rootVs, true);
+	setDepth(state, rootId, 0);
+
+	const fetchedCanonicals = new Set<string>([`ValueSet|${rootCan}`]);
+	let frontier: QueueItem[] = collectComposeDeps(rootVs, rootId, 0);
+
+	while (frontier.length > 0) {
+		const toFetch = frontier.filter(
+			(q) => !fetchedCanonicals.has(`${q.resourceKind}|${q.canonical}`),
+		);
+		for (const q of toFetch) {
+			fetchedCanonicals.add(`${q.resourceKind}|${q.canonical}`);
+		}
+
+		const resources = await fetchUniqueResources(client, toFetch);
+
+		const next: QueueItem[] = [];
+
+		for (const q of frontier) {
+			const dedupKey = `${q.resourceKind}|${q.canonical}`;
+			const resource = resources.get(dedupKey);
+
+			if (resource === undefined) {
+				const existingId = state.canonicalToId.get(q.canonical);
+				if (existingId) {
+					pushEdge(state, q.parentId, existingId, q.edgeKind);
+				}
+				continue;
+			}
+
+			if (!resource) {
+				const { id } = processUnresolvedNode(
+					state,
+					q.resourceKind,
+					q.canonical,
+				);
+				setDepth(state, id, q.depth);
+				pushEdge(state, q.parentId, id, q.edgeKind);
+				continue;
+			}
+
+			if (q.resourceKind === "ValueSet") {
+				const vs = resource as RawValueSet;
+				const { id, isNew } = processValueSetNode(
+					state,
+					q.canonical,
+					vs,
+					false,
+				);
+				setDepth(state, id, q.depth);
+				pushEdge(state, q.parentId, id, q.edgeKind);
+				if (isNew) {
+					next.push(...collectComposeDeps(vs, id, q.depth));
+				}
+			} else {
+				const cs = resource as RawCodeSystem;
+				const { id, isNew } = processCodeSystemNode(state, q.canonical, cs);
+				setDepth(state, id, q.depth);
+				pushEdge(state, q.parentId, id, q.edgeKind);
+				if (isNew) {
+					next.push(...collectCodeSystemDeps(cs, id, q.depth));
+				}
+			}
+		}
+
+		frontier = next;
+	}
+
+	return layoutGraph(state);
+}
+
+function orderColumns(
+	state: BuildState,
+	byDepth: Map<number, string[]>,
+	sortedDepths: number[],
+): Map<string, number> {
+	const parentsByNode = new Map<string, string[]>();
+	const childrenByNode = new Map<string, string[]>();
+	for (const e of state.edges) {
+		const ps = parentsByNode.get(e.target) ?? [];
+		ps.push(e.source);
+		parentsByNode.set(e.target, ps);
+		const cs = childrenByNode.get(e.source) ?? [];
+		cs.push(e.target);
+		childrenByNode.set(e.source, cs);
+	}
+
+	const indexById = new Map<string, number>();
+	for (const depth of sortedDepths) {
+		const ids = byDepth.get(depth) ?? [];
+		ids.forEach((id, i) => indexById.set(id, i));
+	}
+
+	const reorderColumn = (
+		ids: string[],
+		neighborsByNode: Map<string, string[]>,
+	) => {
+		const withScore = ids.map((id, originalIdx) => {
+			const neighbors = neighborsByNode.get(id) ?? [];
+			let sum = 0;
+			let cnt = 0;
+			for (const n of neighbors) {
+				const idx = indexById.get(n);
+				if (idx !== undefined) {
+					sum += idx;
+					cnt++;
+				}
+			}
+			const bary = cnt > 0 ? sum / cnt : originalIdx;
+			return { id, bary, originalIdx };
+		});
+		withScore.sort((a, b) => {
+			if (a.bary !== b.bary) return a.bary - b.bary;
+			return a.originalIdx - b.originalIdx;
+		});
+		const sorted = withScore.map((x) => x.id);
+		sorted.forEach((id, i) => indexById.set(id, i));
+		return sorted;
+	};
+
+	const ITERATIONS = 4;
+	for (let iter = 0; iter < ITERATIONS; iter++) {
+		for (let i = 1; i < sortedDepths.length; i++) {
+			const depth = sortedDepths[i];
+			if (depth === undefined) continue;
+			const ids = byDepth.get(depth) ?? [];
+			byDepth.set(depth, reorderColumn(ids, parentsByNode));
+		}
+		for (let i = sortedDepths.length - 2; i >= 0; i--) {
+			const depth = sortedDepths[i];
+			if (depth === undefined) continue;
+			const ids = byDepth.get(depth) ?? [];
+			byDepth.set(depth, reorderColumn(ids, childrenByNode));
+		}
+	}
+
+	return indexById;
+}
+
+function layoutGraph(state: BuildState): ValueSetGraph {
+	const byDepth = new Map<number, string[]>();
+	for (const [id, depth] of state.depthById) {
+		const list = byDepth.get(depth) ?? [];
+		list.push(id);
+		byDepth.set(depth, list);
+	}
+	const sortedDepths = Array.from(byDepth.keys()).sort((a, b) => a - b);
+	orderColumns(state, byDepth, sortedDepths);
+
+	const nodes: GraphNode[] = [];
+	const yById = new Map<string, number>();
+	for (const depth of sortedDepths) {
+		const ids = byDepth.get(depth) ?? [];
+		ids.forEach((id, i) => {
+			const entry = state.nodesById.get(id);
+			if (!entry) return;
+			const x = -depth * COL_WIDTH;
+			const y = (i - (ids.length - 1) / 2) * ROW_HEIGHT;
+			yById.set(id, y);
+			nodes.push({
+				id,
+				type: entry.type,
+				position: { x, y },
+				data: entry.data,
+			});
+		});
+	}
+
+	assignHandles(state.edges, yById);
+
+	return { nodes, edges: state.edges };
+}
+
+const HANDLE_COUNT = 5;
+const HANDLE_TOPS = Array.from(
+	{ length: HANDLE_COUNT },
+	(_, i) => `${((i + 1) / (HANDLE_COUNT + 1)) * 100}%`,
+);
+
+function pickHandleTop(i: number, n: number): string {
+	const idx =
+		n <= 1
+			? Math.floor(HANDLE_COUNT / 2)
+			: Math.round((i / (n - 1)) * (HANDLE_COUNT - 1));
+	return HANDLE_TOPS[idx] ?? (HANDLE_TOPS[0] as string);
+}
+
+function assignHandles(edges: GraphEdge[], yById: Map<string, number>) {
+	const outBySrc = new Map<string, GraphEdge[]>();
+	const inByTgt = new Map<string, GraphEdge[]>();
+	for (const e of edges) {
+		const out = outBySrc.get(e.source) ?? [];
+		out.push(e);
+		outBySrc.set(e.source, out);
+		const inc = inByTgt.get(e.target) ?? [];
+		inc.push(e);
+		inByTgt.set(e.target, inc);
+	}
+	for (const [, list] of outBySrc) {
+		list.sort(
+			(a, b) => (yById.get(a.target) ?? 0) - (yById.get(b.target) ?? 0),
+		);
+		list.forEach((e, i) => {
+			e.sourceHandle = `source-${pickHandleTop(i, list.length)}`;
+		});
+	}
+	for (const [, list] of inByTgt) {
+		list.sort(
+			(a, b) => (yById.get(a.source) ?? 0) - (yById.get(b.source) ?? 0),
+		);
+		list.forEach((e, i) => {
+			e.targetHandle = `target-${pickHandleTop(i, list.length)}`;
+		});
+	}
+}
+
+export function useValueSetGraph(valueSet: ValueSet): {
+	graph: ValueSetGraph;
+	isLoading: boolean;
+} {
+	const client = useAidboxClient();
+	const composeKey = JSON.stringify(valueSet.compose ?? {});
+	const { data, isLoading } = useQuery<ValueSetGraph>({
+		queryKey: [
+			"valueset-graph",
+			valueSet.id ?? null,
+			valueSet.url ?? null,
+			valueSet.version ?? null,
+			composeKey,
+		],
+		queryFn: () => buildGraph(client, valueSet as RawValueSet),
+		placeholderData: (prev) => prev,
+		staleTime: Number.POSITIVE_INFINITY,
+		refetchOnWindowFocus: false,
+		refetchOnReconnect: false,
+		refetchOnMount: false,
+	});
+	return {
+		graph: data ?? { nodes: [], edges: [] },
+		isLoading,
+	};
+}

--- a/src/components/ValueSet/graph/run-context.ts
+++ b/src/components/ValueSet/graph/run-context.ts
@@ -1,0 +1,66 @@
+import type * as HSComp from "@health-samurai/react-components";
+import * as React from "react";
+import type { ValueSetExpansionContains } from "../types";
+
+export type ExpandTarget = {
+	kind: "expand";
+	nodeId: string;
+	isRoot: boolean;
+	url?: string;
+	version?: string;
+};
+
+export type ContentTarget = {
+	kind: "content";
+	nodeId: string;
+	csId?: string;
+	url?: string;
+	version?: string;
+};
+
+export type RunTarget = ExpandTarget | ContentTarget;
+
+export type ConceptRow = {
+	code: string;
+	display?: string;
+	definition?: string;
+	parent?: string;
+	depth: number;
+};
+
+export type ExpandRunResult = {
+	kind: "expand";
+	contains: ValueSetExpansionContains[];
+	total?: number;
+	durationMs: number;
+};
+
+export type ContentRunResult = {
+	kind: "content";
+	rows: ConceptRow[];
+	durationMs: number;
+};
+
+export type GraphRunResult = ExpandRunResult | ContentRunResult;
+
+export type GraphRunContextValue = {
+	runningNodeId: string | null;
+	resultNodeId: string | null;
+	result: GraphRunResult | null;
+	error: HSComp.OperationOutcome | null;
+	run: (target: RunTarget) => void;
+};
+
+export const GraphRunContext = React.createContext<GraphRunContextValue | null>(
+	null,
+);
+
+export function useGraphRunContext(): GraphRunContextValue {
+	const ctx = React.useContext(GraphRunContext);
+	if (!ctx) {
+		throw new Error(
+			"useGraphRunContext must be used within GraphRunContext.Provider",
+		);
+	}
+	return ctx;
+}

--- a/src/components/ValueSet/graph/types.ts
+++ b/src/components/ValueSet/graph/types.ts
@@ -1,0 +1,56 @@
+import type { Edge, Node } from "@xyflow/react";
+
+export type ValueSetNodeData = {
+	kind: "value-set";
+	id?: string;
+	url?: string;
+	version?: string;
+	name?: string;
+	title?: string;
+	description?: string;
+	status?: string;
+	isRoot: boolean;
+	includeSystems: number;
+	includeValueSets: number;
+	excludeSystems: number;
+	excludeValueSets: number;
+};
+
+export type CodeSystemNodeData = {
+	kind: "code-system";
+	id?: string;
+	url?: string;
+	version?: string;
+	name?: string;
+	title?: string;
+	description?: string;
+	status?: string;
+	content?: string;
+	count?: number;
+};
+
+export type UnresolvedNodeData = {
+	kind: "unresolved";
+	resourceKind: "ValueSet" | "CodeSystem";
+	url: string;
+	version?: string;
+};
+
+export type GraphNodeData =
+	| ValueSetNodeData
+	| CodeSystemNodeData
+	| UnresolvedNodeData;
+
+export type GraphEdgeKind = "include" | "exclude" | "supplements";
+
+export type GraphEdgeData = {
+	edgeKind: GraphEdgeKind;
+};
+
+export type GraphNode = Node<GraphNodeData>;
+export type GraphEdge = Edge<GraphEdgeData>;
+
+export type ValueSetGraph = {
+	nodes: GraphNode[];
+	edges: GraphEdge[];
+};

--- a/src/components/ValueSet/header-menu.tsx
+++ b/src/components/ValueSet/header-menu.tsx
@@ -1,0 +1,125 @@
+import * as HSComp from "@health-samurai/react-components";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuIcon,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@health-samurai/react-components";
+import { EllipsisIcon, PlayIcon, SaveIcon } from "lucide-react";
+import * as React from "react";
+
+type ToolbarMode = "full" | "icons" | "collapsed";
+
+function useToolbarMode(
+	ref: React.RefObject<HTMLDivElement | null>,
+): ToolbarMode {
+	const [mode, setMode] = React.useState<ToolbarMode>("full");
+
+	React.useEffect(() => {
+		const el = ref.current;
+		if (!el) return;
+		const observer = new ResizeObserver((entries) => {
+			const width = entries[0]?.contentRect.width;
+			if (width === undefined) return;
+			if (width >= 400) setMode("full");
+			else if (width >= 240) setMode("icons");
+			else setMode("collapsed");
+		});
+		observer.observe(el);
+		return () => observer.disconnect();
+	}, [ref]);
+
+	return mode;
+}
+
+export function EditorHeaderMenu({
+	onSave,
+	onExpand,
+	isSaveDisabled,
+	isExpandDisabled,
+}: {
+	onSave: () => void;
+	onExpand: () => void;
+	isSaveDisabled?: boolean;
+	isExpandDisabled?: boolean;
+}) {
+	const containerRef = React.useRef<HTMLDivElement>(null);
+	const mode = useToolbarMode(containerRef);
+
+	return (
+		<div
+			ref={containerRef}
+			className="flex items-center justify-between bg-bg-secondary flex-none h-10 border-b"
+		>
+			{mode === "collapsed" ? (
+				<div className="flex items-center gap-1 px-2">
+					<DropdownMenu>
+						<DropdownMenuTrigger asChild>
+							<HSComp.IconButton
+								variant="ghost"
+								aria-label="More actions"
+								icon={<EllipsisIcon className="w-4 h-4" />}
+							/>
+						</DropdownMenuTrigger>
+						<DropdownMenuContent align="start">
+							<DropdownMenuItem
+								onSelect={onExpand}
+								disabled={isExpandDisabled}
+								className="text-text-link!"
+							>
+								EXPAND
+								<DropdownMenuIcon>
+									<PlayIcon className="fill-current text-text-link" />
+								</DropdownMenuIcon>
+							</DropdownMenuItem>
+							<DropdownMenuItem onSelect={onSave} disabled={isSaveDisabled}>
+								Save
+								<DropdownMenuIcon>
+									<SaveIcon />
+								</DropdownMenuIcon>
+							</DropdownMenuItem>
+						</DropdownMenuContent>
+					</DropdownMenu>
+				</div>
+			) : (
+				<div className="flex items-center gap-4 px-4">
+					<Tooltip disableHoverableContent={mode === "full"}>
+						<TooltipTrigger asChild>
+							<HSComp.Button
+								variant="link"
+								size="small"
+								className="px-0! text-text-link! hover:text-text-link/80!"
+								onClick={onExpand}
+								disabled={isExpandDisabled}
+							>
+								<PlayIcon className="w-4 h-4 fill-current" />
+								{mode === "full" && "EXPAND"}
+							</HSComp.Button>
+						</TooltipTrigger>
+						{mode !== "full" && <TooltipContent>Expand</TooltipContent>}
+					</Tooltip>
+					<HSComp.Separator orientation="vertical" className="h-6!" />
+					<Tooltip disableHoverableContent={mode === "full"}>
+						<TooltipTrigger asChild>
+							<HSComp.Button
+								variant="ghost"
+								size="small"
+								className="px-0!"
+								onClick={onSave}
+								disabled={isSaveDisabled}
+							>
+								<SaveIcon className="w-4 h-4" />
+								{mode === "full" && "Save"}
+							</HSComp.Button>
+						</TooltipTrigger>
+						{mode !== "full" && <TooltipContent>Save</TooltipContent>}
+					</Tooltip>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/src/components/ValueSet/page.tsx
+++ b/src/components/ValueSet/page.tsx
@@ -31,6 +31,9 @@ export function ValueSetProvider({
 	const [expandDurationMs, setExpandDurationMs] = React.useState<number | null>(
 		null,
 	);
+	const [missingFields, setMissingFields] = React.useState<Set<string>>(
+		() => new Set(),
+	);
 
 	return (
 		<ValueSetContext.Provider
@@ -45,6 +48,8 @@ export function ValueSetProvider({
 				setIsExpanding,
 				expandDurationMs,
 				setExpandDurationMs,
+				missingFields,
+				setMissingFields,
 			}}
 		>
 			{children}

--- a/src/components/ValueSet/page.tsx
+++ b/src/components/ValueSet/page.tsx
@@ -1,0 +1,53 @@
+import type { Resource } from "@aidbox-ui/fhir-types/hl7-fhir-r5-core";
+import type * as HSComp from "@health-samurai/react-components";
+import * as React from "react";
+import { ValueSetContext } from "./context";
+import type { ValueSet, ValueSetExpansion } from "./types";
+
+export function ValueSetProvider({
+	initialResource,
+	children,
+}: {
+	initialResource: Resource;
+	children: React.ReactNode;
+}) {
+	const [valueSet, setValueSet] = React.useState<ValueSet>(
+		initialResource as ValueSet,
+	);
+
+	const updateValueSet = React.useCallback(
+		(updater: (vs: ValueSet) => ValueSet) => {
+			setValueSet((prev) => updater(prev));
+		},
+		[],
+	);
+
+	const [expansion, setExpansion] = React.useState<ValueSetExpansion | null>(
+		null,
+	);
+	const [expandError, setExpandError] =
+		React.useState<HSComp.OperationOutcome | null>(null);
+	const [isExpanding, setIsExpanding] = React.useState(false);
+	const [expandDurationMs, setExpandDurationMs] = React.useState<number | null>(
+		null,
+	);
+
+	return (
+		<ValueSetContext.Provider
+			value={{
+				valueSet,
+				updateValueSet,
+				expansion,
+				setExpansion,
+				expandError,
+				setExpandError,
+				isExpanding,
+				setIsExpanding,
+				expandDurationMs,
+				setExpandDurationMs,
+			}}
+		>
+			{children}
+		</ValueSetContext.Provider>
+	);
+}

--- a/src/components/ValueSet/properties-tree.tsx
+++ b/src/components/ValueSet/properties-tree.tsx
@@ -378,14 +378,15 @@ function CodeSystemPicker({
 												itemRefs.current[i] = el;
 											}}
 											type="button"
-											onClick={() =>
+											onClick={(e) => {
+												e.stopPropagation();
 												selectVersionHit(
 													h as CodeSystemHit & {
 														url: string;
 														version: string;
 													},
-												)
-											}
+												);
+											}}
 											onMouseEnter={() => setActiveIndex(i)}
 											className={`w-full text-left px-3 py-1.5 focus:outline-none ${isActive ? "bg-bg-tertiary" : ""}`}
 										>
@@ -408,7 +409,10 @@ function CodeSystemPicker({
 											itemRefs.current[i] = el;
 										}}
 										type="button"
-										onClick={() => selectSystemHit(h)}
+										onClick={(e) => {
+											e.stopPropagation();
+											selectSystemHit(h);
+										}}
 										onMouseEnter={() => setActiveIndex(i)}
 										className={`w-full text-left px-3 py-1.5 focus:outline-none ${isActive ? "bg-bg-tertiary" : ""}`}
 									>
@@ -664,11 +668,12 @@ function ValueSetPicker({
 												itemRefs.current[i] = el;
 											}}
 											type="button"
-											onClick={() =>
+											onClick={(e) => {
+												e.stopPropagation();
 												selectVersionHit(
 													h as ValueSetHit & { url: string; version: string },
-												)
-											}
+												);
+											}}
 											onMouseEnter={() => setActiveIndex(i)}
 											className={`w-full text-left px-3 py-1.5 focus:outline-none ${isActive ? "bg-bg-tertiary" : ""}`}
 										>
@@ -691,7 +696,10 @@ function ValueSetPicker({
 											itemRefs.current[i] = el;
 										}}
 										type="button"
-										onClick={() => selectUrlHit(h)}
+										onClick={(e) => {
+											e.stopPropagation();
+											selectUrlHit(h);
+										}}
 										onMouseEnter={() => setActiveIndex(i)}
 										className={`w-full text-left px-3 py-1.5 focus:outline-none ${isActive ? "bg-bg-tertiary" : ""}`}
 									>
@@ -880,7 +888,10 @@ function ConceptCodePicker({
 											itemRefs.current[i] = el;
 										}}
 										type="button"
-										onClick={() => selectHit(h)}
+										onClick={(e) => {
+											e.stopPropagation();
+											selectHit(h);
+										}}
 										onMouseEnter={() => setActiveIndex(i)}
 										className={`w-full text-left px-3 py-1.5 focus:outline-none ${isActive ? "bg-bg-tertiary" : ""}`}
 									>
@@ -1096,11 +1107,14 @@ export function PropertiesTree() {
 		const need: string[] = [];
 		const collect = (kind: IncludeKind, arr: typeof includes) => {
 			arr.forEach((entry, i) => {
-				// row is a folder only when it has concept or filter rows;
-				// CS-only / VS-only entries are leaves with nothing to expand.
-				const hasChildren =
-					(entry.concept?.length ?? 0) > 0 || (entry.filter?.length ?? 0) > 0;
-				if (!hasChildren) return;
+				// row becomes a folder whenever concept/filter rows exist OR
+				// the add-buttons are enabled (i.e. system is set). Auto-expand
+				// in either case so the user sees the contents straight away
+				// — picking a CodeSystem URL otherwise collapses the row.
+				const hasConcept = (entry.concept?.length ?? 0) > 0;
+				const hasFilter = (entry.filter?.length ?? 0) > 0;
+				const hasSystem = !!entry.system;
+				if (!hasConcept && !hasFilter && !hasSystem) return;
 				const row = `_${kind}_${i}`;
 				if (!autoExpandedRef.current.has(row)) {
 					autoExpandedRef.current.add(row);

--- a/src/components/ValueSet/properties-tree.tsx
+++ b/src/components/ValueSet/properties-tree.tsx
@@ -1,0 +1,1413 @@
+import * as HSComp from "@health-samurai/react-components";
+import {
+	type ItemInstance,
+	TreeView,
+	type TreeViewItem,
+} from "@health-samurai/react-components";
+import { useQuery } from "@tanstack/react-query";
+import { Filter, Plus, Tag, X } from "lucide-react";
+import * as React from "react";
+import { useAidboxClient } from "../../AidboxClient";
+import { useValueSetContext } from "./context";
+
+type IncludeKind = "include" | "exclude";
+
+type ItemMeta = {
+	type:
+		| "properties"
+		| "url"
+		| "version"
+		| "title"
+		| "description"
+		| "include"
+		| "include-row"
+		| "include-add"
+		| "include-concept"
+		| "include-concept-row"
+		| "include-concept-add"
+		| "include-filter"
+		| "include-filter-row"
+		| "include-filter-add";
+	kind?: IncludeKind;
+	includeIndex?: number;
+	conceptIndex?: number;
+	filterIndex?: number;
+};
+
+const isVsInclude = (inc: { valueSet?: string[]; system?: string }) =>
+	(inc.valueSet?.length ?? 0) > 0;
+
+// Sorted by real-world usage in fhir-packages (n = 309 601 filters across
+// 803 559 ValueSets). `is-a` alone is 77%, top-4 cover >99.7%, the rest is
+// the long tail. `generalizes` had zero occurrences but is kept last for
+// spec completeness.
+const FILTER_OPS = [
+	"is-a",
+	"=",
+	"in",
+	"descendent-of",
+	"regex",
+	"exists",
+	"is-not-a",
+	"not-in",
+	"generalizes",
+];
+
+function InputView({
+	placeholder,
+	value,
+	onChange,
+}: {
+	placeholder: string;
+	value?: string;
+	onChange?: (value: string) => void;
+}) {
+	const [localValue, setLocalValue] = React.useState(value ?? "");
+
+	React.useEffect(() => {
+		setLocalValue(value ?? "");
+	}, [value]);
+
+	const timeoutRef = React.useRef<ReturnType<typeof setTimeout> | undefined>(
+		undefined,
+	);
+
+	const handleChange = (newValue: string) => {
+		setLocalValue(newValue);
+		if (timeoutRef.current) clearTimeout(timeoutRef.current);
+		timeoutRef.current = setTimeout(() => {
+			if (onChange && newValue !== value) onChange(newValue);
+		}, 500);
+	};
+
+	return (
+		<HSComp.Input
+			className="h-7 py-1 px-2 bg-bg-primary border-none hover:bg-bg-quaternary focus:bg-bg-primary group-hover/tree-item-label:bg-bg-tertiary focus:ring-1 focus:ring-border-link"
+			placeholder={placeholder}
+			value={localValue}
+			onChange={(e) => handleChange(e.target.value)}
+			onClick={(e) => e.stopPropagation()}
+			onMouseDown={(e) => e.stopPropagation()}
+		/>
+	);
+}
+
+type CodeSystemHit = {
+	id?: string;
+	url?: string;
+	name?: string;
+	title?: string;
+	version?: string;
+	description?: string;
+};
+
+function parseSystemPipeVersion(raw: string): {
+	system?: string;
+	version?: string;
+} {
+	const pipe = raw.indexOf("|");
+	if (pipe < 0) {
+		const s = raw.trim();
+		return { system: s || undefined, version: undefined };
+	}
+	const s = raw.slice(0, pipe).trim();
+	const v = raw.slice(pipe + 1).trim();
+	return { system: s || undefined, version: v || undefined };
+}
+
+function formatSystemPipeVersion(
+	system: string | undefined,
+	version: string | undefined,
+): string {
+	if (version) return `${system ?? ""}|${version}`;
+	return system ?? "";
+}
+
+function CodeSystemPicker({
+	system,
+	version,
+	onChange,
+}: {
+	system?: string;
+	version?: string;
+	onChange: (next: { system?: string; version?: string }) => void;
+}) {
+	const client = useAidboxClient();
+	const formatted = formatSystemPipeVersion(system, version);
+	const [local, setLocal] = React.useState(formatted);
+	const [debounced, setDebounced] = React.useState(local);
+	const [open, setOpen] = React.useState(false);
+	const [activeIndex, setActiveIndex] = React.useState(-1);
+	const itemRefs = React.useRef<Array<HTMLButtonElement | null>>([]);
+
+	React.useEffect(() => {
+		setLocal(formatted);
+	}, [formatted]);
+
+	React.useEffect(() => {
+		const t = setTimeout(() => setDebounced(local), 250);
+		return () => clearTimeout(t);
+	}, [local]);
+
+	// derive mode from the debounced input — pipe presence flips us into
+	// "pick a version for this system" mode
+	const pipeIdx = debounced.indexOf("|");
+	const mode: "system" | "version" = pipeIdx >= 0 ? "version" : "system";
+	const systemPart =
+		pipeIdx >= 0 ? debounced.slice(0, pipeIdx).trim() : debounced.trim();
+	const versionPart = pipeIdx >= 0 ? debounced.slice(pipeIdx + 1).trim() : "";
+
+	const { data: systemHits } = useQuery({
+		queryKey: ["valueset-builder", "codesystem-picker", "system", systemPart],
+		enabled: mode === "system",
+		queryFn: async () => {
+			const params = new URLSearchParams({
+				_count: "15",
+				_elements: "url,name,title,version,description",
+			});
+			if (systemPart) params.set("url:contains", systemPart);
+			const res = await client.request<{
+				entry?: Array<{ resource: CodeSystemHit }>;
+			}>({
+				method: "GET",
+				url: `/fhir/CodeSystem?${params.toString()}`,
+			});
+			if (res.isErr()) return [];
+			return (res.value.resource.entry ?? [])
+				.map((e) => e.resource)
+				.filter((r): r is CodeSystemHit & { url: string } => !!r.url);
+		},
+		staleTime: 30_000,
+	});
+
+	const { data: versionHits } = useQuery({
+		queryKey: ["valueset-builder", "codesystem-picker", "versions", systemPart],
+		enabled: mode === "version" && systemPart.length > 0,
+		queryFn: async () => {
+			const params = new URLSearchParams({
+				_count: "100",
+				_elements: "url,name,title,version",
+				url: systemPart,
+			});
+			const res = await client.request<{
+				entry?: Array<{ resource: CodeSystemHit }>;
+			}>({
+				method: "GET",
+				url: `/fhir/CodeSystem?${params.toString()}`,
+			});
+			if (res.isErr()) return [];
+			const seen = new Set<string>();
+			const out: Array<CodeSystemHit & { url: string; version: string }> = [];
+			for (const e of res.value.resource.entry ?? []) {
+				const r = e.resource;
+				if (!r.url || !r.version) continue;
+				if (seen.has(r.version)) continue;
+				seen.add(r.version);
+				out.push({ ...r, url: r.url, version: r.version });
+			}
+			return out;
+		},
+		staleTime: 30_000,
+	});
+
+	const commit = (raw: string) => {
+		setLocal(raw);
+		const parsed = parseSystemPipeVersion(raw);
+		if (parsed.system !== system || parsed.version !== version) {
+			onChange(parsed);
+		}
+	};
+
+	const selectSystemHit = (h: CodeSystemHit & { url: string }) => {
+		// Picking from the system list never auto-pins a version — even if the
+		// hit has one. To pin a version, user types `|` and picks from the
+		// version list.
+		const next = { system: h.url, version: undefined };
+		setLocal(formatSystemPipeVersion(next.system, next.version));
+		onChange(next);
+		setOpen(false);
+		setActiveIndex(-1);
+	};
+
+	const selectVersionHit = (
+		h: CodeSystemHit & { url: string; version: string },
+	) => {
+		const next = { system: systemPart || h.url, version: h.version };
+		setLocal(formatSystemPipeVersion(next.system, next.version));
+		onChange(next);
+		setOpen(false);
+		setActiveIndex(-1);
+	};
+
+	const hitsList =
+		mode === "version"
+			? (versionHits ?? []).filter(
+					(h) => !versionPart || h.version.includes(versionPart),
+				)
+			: (systemHits ?? []);
+
+	const onSelectActive = () => {
+		const h = hitsList[activeIndex];
+		if (!h) return;
+		if (mode === "version") {
+			selectVersionHit(h as CodeSystemHit & { url: string; version: string });
+		} else {
+			selectSystemHit(h);
+		}
+	};
+
+	// auto-highlight the first item so Enter selects it without arrow-down
+	const hitsLength = hitsList.length;
+	React.useEffect(() => {
+		setActiveIndex(hitsLength > 0 ? 0 : -1);
+	}, [hitsLength]);
+
+	React.useEffect(() => {
+		if (activeIndex < 0) return;
+		itemRefs.current[activeIndex]?.scrollIntoView({ block: "nearest" });
+	}, [activeIndex]);
+
+	const inputRef = React.useRef<HTMLInputElement | null>(null);
+	return (
+		<HSComp.Popover open={open} onOpenChange={setOpen}>
+			<HSComp.PopoverAnchor asChild>
+				<div className="flex-1 min-w-0">
+					<HSComp.Input
+						ref={inputRef}
+						placeholder="CodeSystem URL"
+						value={local}
+						onChange={(e) => {
+							setLocal(e.target.value);
+							setOpen(true);
+						}}
+						onClick={(e) => {
+							e.stopPropagation();
+							setOpen(true);
+						}}
+						onFocus={() => setOpen(true)}
+						onBlur={(e) => {
+							// keep open if focus moved into popover content
+							const next = e.relatedTarget as HTMLElement | null;
+							if (next?.closest("[data-cs-picker-popover='true']")) return;
+							commit(local);
+							setOpen(false);
+						}}
+						onKeyDown={(e) => {
+							if (e.key === "ArrowDown") {
+								e.preventDefault();
+								if (hitsList.length === 0) return;
+								setOpen(true);
+								setActiveIndex((i) => (i + 1) % hitsList.length);
+							} else if (e.key === "ArrowUp") {
+								e.preventDefault();
+								if (hitsList.length === 0) return;
+								setOpen(true);
+								setActiveIndex((i) => (i <= 0 ? hitsList.length - 1 : i - 1));
+							} else if (e.key === "Enter") {
+								e.preventDefault();
+								if (open && activeIndex >= 0 && hitsList[activeIndex]) {
+									onSelectActive();
+								} else {
+									commit(local);
+									setOpen(false);
+								}
+							} else if (e.key === "Escape") {
+								setOpen(false);
+								setActiveIndex(-1);
+							}
+						}}
+						onMouseDown={(e) => e.stopPropagation()}
+						className="h-7 py-1 px-2 bg-bg-primary border-none hover:bg-bg-quaternary focus:bg-bg-primary group-hover/tree-item-label:bg-bg-tertiary focus:ring-1 focus:ring-border-link font-mono text-xs"
+					/>
+				</div>
+			</HSComp.PopoverAnchor>
+			<HSComp.PopoverContent
+				data-cs-picker-popover="true"
+				className="w-[var(--radix-popover-trigger-width)] min-w-[480px] p-0 max-h-80 overflow-auto"
+				align="start"
+				onOpenAutoFocus={(e) => e.preventDefault()}
+				onInteractOutside={(e) => {
+					// don't close when the user interacts with the anchored input —
+					// otherwise focusing the input fires a "pointer-down-outside"
+					// that immediately closes the popover that focus just opened
+					if (e.target === inputRef.current) e.preventDefault();
+				}}
+			>
+				{mode === "version" && !systemPart ? (
+					<div className="px-3 py-2 text-text-secondary text-sm">
+						Type a CodeSystem URL before <code>|</code>
+					</div>
+				) : hitsList.length === 0 ? (
+					<div className="px-3 py-2 text-text-secondary text-sm">
+						{mode === "version" ? "No versions found" : "No matches"}
+					</div>
+				) : (
+					<ul className="py-1">
+						{hitsList.map((h, i) => {
+							const isActive = i === activeIndex;
+							if (mode === "version") {
+								const ver = h.version ?? "";
+								const secondary = h.title || h.name || h.id || h.url;
+								return (
+									<li key={`${h.url}|${ver}`}>
+										<button
+											ref={(el) => {
+												itemRefs.current[i] = el;
+											}}
+											type="button"
+											onClick={() =>
+												selectVersionHit(
+													h as CodeSystemHit & {
+														url: string;
+														version: string;
+													},
+												)
+											}
+											onMouseEnter={() => setActiveIndex(i)}
+											className={`w-full text-left px-3 py-1.5 focus:outline-none ${isActive ? "bg-bg-tertiary" : ""}`}
+										>
+											<div className="typo-body text-text-primary truncate font-mono">
+												{ver}
+											</div>
+											<div className="typo-body-xs text-text-secondary line-clamp-1">
+												{secondary}
+											</div>
+										</button>
+									</li>
+								);
+							}
+							const title = h.title || h.name || h.id || h.url;
+							const secondary = h.description || h.url;
+							return (
+								<li key={`${h.url}|${h.version ?? ""}`}>
+									<button
+										ref={(el) => {
+											itemRefs.current[i] = el;
+										}}
+										type="button"
+										onClick={() => selectSystemHit(h)}
+										onMouseEnter={() => setActiveIndex(i)}
+										className={`w-full text-left px-3 py-1.5 focus:outline-none ${isActive ? "bg-bg-tertiary" : ""}`}
+									>
+										<div className="typo-body text-text-primary truncate">
+											{title}
+										</div>
+										<div className="typo-body-xs text-text-secondary line-clamp-1 font-mono">
+											{secondary}
+										</div>
+									</button>
+								</li>
+							);
+						})}
+					</ul>
+				)}
+			</HSComp.PopoverContent>
+		</HSComp.Popover>
+	);
+}
+
+type ValueSetHit = {
+	id?: string;
+	url?: string;
+	name?: string;
+	title?: string;
+	description?: string;
+};
+
+function ValueSetPicker({
+	value,
+	onChange,
+}: {
+	value?: string;
+	onChange: (next: string | undefined) => void;
+}) {
+	const client = useAidboxClient();
+	const [local, setLocal] = React.useState(value ?? "");
+	const [debounced, setDebounced] = React.useState(local);
+	const [open, setOpen] = React.useState(false);
+	const [activeIndex, setActiveIndex] = React.useState(-1);
+	const itemRefs = React.useRef<Array<HTMLButtonElement | null>>([]);
+	const inputRef = React.useRef<HTMLInputElement | null>(null);
+
+	React.useEffect(() => {
+		setLocal(value ?? "");
+	}, [value]);
+
+	React.useEffect(() => {
+		const t = setTimeout(() => setDebounced(local), 250);
+		return () => clearTimeout(t);
+	}, [local]);
+
+	const { data: hits } = useQuery({
+		queryKey: ["valueset-builder", "valueset-picker", debounced],
+		queryFn: async () => {
+			const q = debounced.trim();
+			const params = new URLSearchParams({
+				_count: "15",
+				_elements: "url,name,title,description",
+			});
+			if (q) params.set("url:contains", q);
+			const res = await client.request<{
+				entry?: Array<{ resource: ValueSetHit }>;
+			}>({
+				method: "GET",
+				url: `/fhir/ValueSet?${params.toString()}`,
+			});
+			if (res.isErr()) return [];
+			return (res.value.resource.entry ?? [])
+				.map((e) => e.resource)
+				.filter((r): r is ValueSetHit & { url: string } => !!r.url);
+		},
+		staleTime: 30_000,
+	});
+
+	const commit = (raw: string) => {
+		setLocal(raw);
+		const next = raw.trim() || undefined;
+		if (next !== value) onChange(next);
+	};
+
+	const selectHit = (h: ValueSetHit & { url: string }) => {
+		setLocal(h.url);
+		onChange(h.url);
+		setOpen(false);
+		setActiveIndex(-1);
+	};
+
+	const hitsList = hits ?? [];
+	const hitsLength = hitsList.length;
+
+	React.useEffect(() => {
+		setActiveIndex(hitsLength > 0 ? 0 : -1);
+	}, [hitsLength]);
+
+	React.useEffect(() => {
+		if (activeIndex < 0) return;
+		itemRefs.current[activeIndex]?.scrollIntoView({ block: "nearest" });
+	}, [activeIndex]);
+
+	return (
+		<HSComp.Popover open={open} onOpenChange={setOpen}>
+			<HSComp.PopoverAnchor asChild>
+				<div className="flex-1 min-w-0">
+					<HSComp.Input
+						ref={inputRef}
+						placeholder="ValueSet canonical URL"
+						value={local}
+						onChange={(e) => {
+							setLocal(e.target.value);
+							setOpen(true);
+						}}
+						onClick={(e) => {
+							e.stopPropagation();
+							setOpen(true);
+						}}
+						onFocus={() => setOpen(true)}
+						onBlur={(e) => {
+							const next = e.relatedTarget as HTMLElement | null;
+							if (next?.closest("[data-vs-picker-popover='true']")) return;
+							commit(local);
+							setOpen(false);
+						}}
+						onKeyDown={(e) => {
+							if (e.key === "ArrowDown") {
+								e.preventDefault();
+								if (hitsLength === 0) return;
+								setOpen(true);
+								setActiveIndex((i) => (i + 1) % hitsLength);
+							} else if (e.key === "ArrowUp") {
+								e.preventDefault();
+								if (hitsLength === 0) return;
+								setOpen(true);
+								setActiveIndex((i) => (i <= 0 ? hitsLength - 1 : i - 1));
+							} else if (e.key === "Enter") {
+								e.preventDefault();
+								if (open && activeIndex >= 0 && hitsList[activeIndex]) {
+									selectHit(hitsList[activeIndex]);
+								} else {
+									commit(local);
+									setOpen(false);
+								}
+							} else if (e.key === "Escape") {
+								setOpen(false);
+								setActiveIndex(-1);
+							}
+						}}
+						onMouseDown={(e) => e.stopPropagation()}
+						className="h-7 py-1 px-2 bg-bg-primary border-none hover:bg-bg-quaternary focus:bg-bg-primary group-hover/tree-item-label:bg-bg-tertiary focus:ring-1 focus:ring-border-link font-mono text-xs"
+					/>
+				</div>
+			</HSComp.PopoverAnchor>
+			<HSComp.PopoverContent
+				data-vs-picker-popover="true"
+				className="w-[var(--radix-popover-trigger-width)] min-w-[480px] p-0 max-h-80 overflow-auto"
+				align="start"
+				onOpenAutoFocus={(e) => e.preventDefault()}
+				onInteractOutside={(e) => {
+					if (e.target === inputRef.current) e.preventDefault();
+				}}
+			>
+				{hitsList.length === 0 ? (
+					<div className="px-3 py-2 text-text-secondary text-sm">
+						No matches
+					</div>
+				) : (
+					<ul className="py-1">
+						{hitsList.map((h, i) => {
+							const isActive = i === activeIndex;
+							const title = h.title || h.name || h.id || h.url;
+							const secondary = h.description || h.url;
+							return (
+								<li key={h.url}>
+									<button
+										ref={(el) => {
+											itemRefs.current[i] = el;
+										}}
+										type="button"
+										onClick={() => selectHit(h)}
+										onMouseEnter={() => setActiveIndex(i)}
+										className={`w-full text-left px-3 py-1.5 focus:outline-none ${isActive ? "bg-bg-tertiary" : ""}`}
+									>
+										<div className="typo-body text-text-primary truncate">
+											{title}
+										</div>
+										<div className="typo-body-xs text-text-secondary line-clamp-1 font-mono">
+											{secondary}
+										</div>
+									</button>
+								</li>
+							);
+						})}
+					</ul>
+				)}
+			</HSComp.PopoverContent>
+		</HSComp.Popover>
+	);
+}
+
+type ConceptHit = { code: string; display?: string; system?: string };
+
+function ConceptCodePicker({
+	system,
+	code,
+	onChange,
+}: {
+	system?: string;
+	code?: string;
+	onChange: (next: { code?: string; display?: string }) => void;
+}) {
+	const client = useAidboxClient();
+	const [local, setLocal] = React.useState(code ?? "");
+	const [debounced, setDebounced] = React.useState(local);
+	const [open, setOpen] = React.useState(false);
+	const [activeIndex, setActiveIndex] = React.useState(-1);
+	const itemRefs = React.useRef<Array<HTMLButtonElement | null>>([]);
+	const inputRef = React.useRef<HTMLInputElement | null>(null);
+
+	React.useEffect(() => {
+		setLocal(code ?? "");
+	}, [code]);
+
+	React.useEffect(() => {
+		const t = setTimeout(() => setDebounced(local), 250);
+		return () => clearTimeout(t);
+	}, [local]);
+
+	const { data: hits } = useQuery({
+		queryKey: ["valueset-builder", "concept-picker", system, debounced],
+		enabled: !!system,
+		queryFn: async () => {
+			if (!system) return [];
+			const body = {
+				resourceType: "Parameters" as const,
+				parameter: [
+					{
+						name: "valueSet",
+						resource: {
+							resourceType: "ValueSet" as const,
+							status: "active" as const,
+							compose: { include: [{ system }] },
+						},
+					},
+					...(debounced.trim()
+						? [{ name: "filter", valueString: debounced.trim() }]
+						: []),
+					{ name: "count", valueInteger: 15 },
+				],
+			};
+			const res = await client.request<{
+				expansion?: { contains?: ConceptHit[] };
+			}>({
+				method: "POST",
+				url: "/fhir/ValueSet/$expand",
+				body: JSON.stringify(body),
+				headers: { "Content-Type": "application/fhir+json" },
+			});
+			if (res.isErr()) return [];
+			return res.value.resource.expansion?.contains ?? [];
+		},
+		staleTime: 30_000,
+	});
+
+	const commit = (raw: string) => {
+		setLocal(raw);
+		if (raw !== code) onChange({ code: raw || undefined });
+	};
+
+	const selectHit = (h: ConceptHit) => {
+		setLocal(h.code);
+		onChange({ code: h.code, display: h.display });
+		setOpen(false);
+		setActiveIndex(-1);
+	};
+
+	const hitsList = hits ?? [];
+	const hitsLength = hitsList.length;
+
+	React.useEffect(() => {
+		setActiveIndex(hitsLength > 0 ? 0 : -1);
+	}, [hitsLength]);
+
+	React.useEffect(() => {
+		if (activeIndex < 0) return;
+		itemRefs.current[activeIndex]?.scrollIntoView({ block: "nearest" });
+	}, [activeIndex]);
+
+	return (
+		<HSComp.Popover open={open} onOpenChange={setOpen}>
+			<HSComp.PopoverAnchor asChild>
+				<div className="w-full">
+					<HSComp.Input
+						ref={inputRef}
+						placeholder="code"
+						value={local}
+						onChange={(e) => {
+							setLocal(e.target.value);
+							setOpen(true);
+						}}
+						onClick={(e) => {
+							e.stopPropagation();
+							setOpen(true);
+						}}
+						onFocus={() => setOpen(true)}
+						onBlur={(e) => {
+							const next = e.relatedTarget as HTMLElement | null;
+							if (next?.closest("[data-concept-picker-popover='true']")) return;
+							commit(local);
+							setOpen(false);
+						}}
+						onKeyDown={(e) => {
+							if (e.key === "ArrowDown") {
+								e.preventDefault();
+								if (hitsLength === 0) return;
+								setOpen(true);
+								setActiveIndex((i) => (i + 1) % hitsLength);
+							} else if (e.key === "ArrowUp") {
+								e.preventDefault();
+								if (hitsLength === 0) return;
+								setOpen(true);
+								setActiveIndex((i) => (i <= 0 ? hitsLength - 1 : i - 1));
+							} else if (e.key === "Enter") {
+								e.preventDefault();
+								if (open && activeIndex >= 0 && hitsList[activeIndex]) {
+									selectHit(hitsList[activeIndex]);
+								} else {
+									commit(local);
+									setOpen(false);
+								}
+							} else if (e.key === "Escape") {
+								setOpen(false);
+								setActiveIndex(-1);
+							}
+						}}
+						onMouseDown={(e) => e.stopPropagation()}
+						className="h-7 py-1 px-2 bg-bg-primary border-none hover:bg-bg-quaternary focus:bg-bg-primary group-hover/tree-item-label:bg-bg-tertiary focus:ring-1 focus:ring-border-link font-mono text-xs"
+					/>
+				</div>
+			</HSComp.PopoverAnchor>
+			<HSComp.PopoverContent
+				data-concept-picker-popover="true"
+				className="w-[var(--radix-popover-trigger-width)] min-w-[360px] p-0 max-h-80 overflow-auto"
+				align="start"
+				onOpenAutoFocus={(e) => e.preventDefault()}
+				onInteractOutside={(e) => {
+					if (e.target === inputRef.current) e.preventDefault();
+				}}
+			>
+				{!system ? (
+					<div className="px-3 py-2 text-text-secondary text-sm">
+						Pick a CodeSystem URL above to enable code search
+					</div>
+				) : hitsLength === 0 ? (
+					<div className="px-3 py-2 text-text-secondary text-sm">
+						No matches
+					</div>
+				) : (
+					<ul className="py-1">
+						{hitsList.map((h, i) => {
+							const isActive = i === activeIndex;
+							return (
+								<li key={`${h.code}|${h.system ?? ""}`}>
+									<button
+										ref={(el) => {
+											itemRefs.current[i] = el;
+										}}
+										type="button"
+										onClick={() => selectHit(h)}
+										onMouseEnter={() => setActiveIndex(i)}
+										className={`w-full text-left px-3 py-1.5 focus:outline-none ${isActive ? "bg-bg-tertiary" : ""}`}
+									>
+										<div className="typo-body text-text-primary truncate font-mono">
+											{h.code}
+										</div>
+										{h.display && (
+											<div className="typo-body-xs text-text-secondary line-clamp-1">
+												{h.display}
+											</div>
+										)}
+									</button>
+								</li>
+							);
+						})}
+					</ul>
+				)}
+			</HSComp.PopoverContent>
+		</HSComp.Popover>
+	);
+}
+
+function labelView(item: ItemInstance<TreeViewItem<ItemMeta>>) {
+	const metaType = item.getItemData()?.meta?.type;
+	const isFolder = item.isFolder();
+	const isSectionFolder = metaType === "properties" || metaType === "include";
+
+	const additionalClass = isSectionFolder
+		? "text-text-info-primary px-1!"
+		: "text-text-info-primary bg-bg-info-primary";
+
+	const kind = item.getItemData()?.meta?.kind;
+	let label: string | undefined = metaType;
+	if (metaType === "include") label = kind ?? "include";
+	else if (metaType === "include-row") label = "codesystem";
+	else if (metaType === "include-concept") label = "concept";
+	else if (metaType === "include-filter") label = "filter";
+
+	const onLabelClickFn = (e: React.MouseEvent) => {
+		if (!isFolder) return;
+		e.stopPropagation();
+		if (item.isExpanded()) item.collapse();
+		else item.expand();
+	};
+
+	return (
+		<button
+			type="button"
+			className={`uppercase px-1.5 py-0.5 ${isFolder ? "cursor-pointer" : ""} rounded-md ${additionalClass}`}
+			onClick={onLabelClickFn}
+		>
+			{label}
+		</button>
+	);
+}
+
+export function PropertiesTree() {
+	const { valueSet, updateValueSet } = useValueSetContext();
+
+	const updateUrl = (value: string) => {
+		updateValueSet((vs) => ({ ...vs, url: value || undefined }));
+	};
+	const updateVersion = (value: string) => {
+		updateValueSet((vs) => ({ ...vs, version: value || undefined }));
+	};
+	const updateTitle = (value: string) => {
+		updateValueSet((vs) => ({ ...vs, title: value || undefined }));
+	};
+	const updateDescription = (value: string) => {
+		updateValueSet((vs) => ({ ...vs, description: value || undefined }));
+	};
+
+	const includes = valueSet.compose?.include ?? [];
+	const excludes = valueSet.compose?.exclude ?? [];
+	const entriesOf = (kind: IncludeKind) =>
+		kind === "include" ? includes : excludes;
+
+	const tree: Record<string, TreeViewItem<ItemMeta>> = React.useMemo(() => {
+		const out: Record<string, TreeViewItem<ItemMeta>> = {
+			root: {
+				name: "root",
+				children: ["_properties", "_include", "_exclude"],
+			},
+			_properties: {
+				name: "_properties",
+				meta: { type: "properties" },
+				children: ["_url", "_version", "_title", "_description"],
+			},
+			_url: { name: "_url", meta: { type: "url" } },
+			_version: { name: "_version", meta: { type: "version" } },
+			_title: { name: "_title", meta: { type: "title" } },
+			_description: { name: "_description", meta: { type: "description" } },
+		};
+
+		const buildKind = (kind: IncludeKind, entries: typeof includes) => {
+			const sectionId = `_${kind}`;
+			const addId = `_${kind}_add`;
+			const entryIds = entries.map((_, i) => `${sectionId}_${i}`);
+			out[sectionId] = {
+				name: sectionId,
+				meta: { type: "include", kind },
+				children: [...entryIds, addId],
+			};
+			out[addId] = {
+				name: addId,
+				meta: { type: "include-add", kind },
+			};
+			// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: large nested tree-node builder
+			entries.forEach((entry, i) => {
+				const rowId = `${sectionId}_${i}`;
+				const conceptChildren = (entry.concept ?? []).map(
+					(_, ci) => `${rowId}_concept_${ci}`,
+				);
+				const filterChildren = (entry.filter ?? []).map(
+					(_, fi) => `${rowId}_filter_${fi}`,
+				);
+				const hasConcept = (entry.concept?.length ?? 0) > 0;
+				const hasFilter = (entry.filter?.length ?? 0) > 0;
+				// vsd-3 inherited via contentReference — applies to exclude too
+				const showConcept = hasConcept || !hasFilter;
+				const showFilter = hasFilter || !hasConcept;
+				const rowChildren: string[] = [];
+				if (showConcept) rowChildren.push(`${rowId}_concept`);
+				if (showFilter) rowChildren.push(`${rowId}_filter`);
+				out[rowId] = {
+					name: rowId,
+					meta: { type: "include-row", kind, includeIndex: i },
+					children: rowChildren,
+				};
+
+				if (showConcept) {
+					const conceptSectionChildren = hasFilter
+						? conceptChildren
+						: [...conceptChildren, `${rowId}_concept_add`];
+					out[`${rowId}_concept`] = {
+						name: `${rowId}_concept`,
+						meta: { type: "include-concept", kind, includeIndex: i },
+						...(conceptSectionChildren.length > 0
+							? { children: conceptSectionChildren }
+							: {}),
+					};
+					if (!hasFilter) {
+						out[`${rowId}_concept_add`] = {
+							name: `${rowId}_concept_add`,
+							meta: { type: "include-concept-add", kind, includeIndex: i },
+						};
+					}
+					(entry.concept ?? []).forEach((_, ci) => {
+						out[`${rowId}_concept_${ci}`] = {
+							name: `${rowId}_concept_${ci}`,
+							meta: {
+								type: "include-concept-row",
+								kind,
+								includeIndex: i,
+								conceptIndex: ci,
+							},
+						};
+					});
+				}
+
+				if (showFilter) {
+					const filterSectionChildren = hasConcept
+						? filterChildren
+						: [...filterChildren, `${rowId}_filter_add`];
+					out[`${rowId}_filter`] = {
+						name: `${rowId}_filter`,
+						meta: { type: "include-filter", kind, includeIndex: i },
+						...(filterSectionChildren.length > 0
+							? { children: filterSectionChildren }
+							: {}),
+					};
+					if (!hasConcept) {
+						out[`${rowId}_filter_add`] = {
+							name: `${rowId}_filter_add`,
+							meta: { type: "include-filter-add", kind, includeIndex: i },
+						};
+					}
+					(entry.filter ?? []).forEach((_, fi) => {
+						out[`${rowId}_filter_${fi}`] = {
+							name: `${rowId}_filter_${fi}`,
+							meta: {
+								type: "include-filter-row",
+								kind,
+								includeIndex: i,
+								filterIndex: fi,
+							},
+						};
+					});
+				}
+			});
+		};
+
+		buildKind("include", includes);
+		buildKind("exclude", excludes);
+		return out;
+	}, [includes, excludes]);
+
+	const [expandedItems, setExpandedItems] = React.useState<string[]>([
+		"_properties",
+		"_include",
+		"_exclude",
+	]);
+
+	// auto-expand each entry's nested sections so they're always visible
+	// when the row is opened (applies to both include and exclude)
+	React.useEffect(() => {
+		setExpandedItems((prev) => {
+			const need: string[] = [];
+			const collect = (kind: IncludeKind, arr: typeof includes) => {
+				arr.forEach((_, i) => {
+					const row = `_${kind}_${i}`;
+					const c = `${row}_concept`;
+					const f = `${row}_filter`;
+					if (!prev.includes(row)) need.push(row);
+					if (!prev.includes(c)) need.push(c);
+					if (!prev.includes(f)) need.push(f);
+				});
+			};
+			collect("include", includes);
+			collect("exclude", excludes);
+			if (need.length === 0) return prev;
+			return [...prev, ...need];
+		});
+	}, [includes, excludes]);
+
+	const mutateCompose = (
+		kind: IncludeKind,
+		fn: (arr: typeof includes) => typeof includes,
+	) => {
+		updateValueSet((vs) => {
+			const arr = (vs.compose?.[kind] ?? []).slice();
+			const next = fn(arr);
+			return {
+				...vs,
+				compose: {
+					...(vs.compose ?? {}),
+					[kind]: next.length > 0 ? next : undefined,
+				},
+			};
+		});
+	};
+
+	const addCodeSystem = (kind: IncludeKind) =>
+		mutateCompose(kind, (arr) => [...arr, { system: "" }]);
+
+	const addValueSetEntry = (kind: IncludeKind) =>
+		mutateCompose(kind, (arr) => [...arr, { valueSet: [""] }]);
+
+	const updateEntrySystemVersion = (
+		kind: IncludeKind,
+		i: number,
+		next: { system?: string; version?: string },
+	) =>
+		mutateCompose(kind, (arr) => {
+			const a = arr.slice();
+			a[i] = { ...a[i], system: next.system, version: next.version };
+			return a;
+		});
+
+	const removeEntry = (kind: IncludeKind, i: number) =>
+		mutateCompose(kind, (arr) => arr.filter((_, idx) => idx !== i));
+
+	const mutateEntry = (
+		kind: IncludeKind,
+		i: number,
+		fn: (
+			inc: NonNullable<typeof includes>[number],
+		) => (typeof includes)[number],
+	) =>
+		mutateCompose(kind, (arr) => {
+			const a = arr.slice();
+			a[i] = fn(a[i] ?? {});
+			return a;
+		});
+
+	const addConcept = (kind: IncludeKind, i: number) =>
+		mutateEntry(kind, i, (inc) => ({
+			...inc,
+			concept: [...(inc.concept ?? []), {}],
+		}));
+	const updateConcept = (
+		kind: IncludeKind,
+		i: number,
+		ci: number,
+		patch: { code?: string; display?: string },
+	) =>
+		mutateEntry(kind, i, (inc) => {
+			const arr = (inc.concept ?? []).slice();
+			arr[ci] = { ...arr[ci], ...patch };
+			return { ...inc, concept: arr };
+		});
+	const removeConcept = (kind: IncludeKind, i: number, ci: number) =>
+		mutateEntry(kind, i, (inc) => {
+			const arr = (inc.concept ?? []).filter((_, idx) => idx !== ci);
+			return { ...inc, concept: arr.length > 0 ? arr : undefined };
+		});
+
+	const updateEntryValueSet = (
+		kind: IncludeKind,
+		i: number,
+		url: string | undefined,
+	) =>
+		mutateEntry(kind, i, (inc) => ({
+			...inc,
+			valueSet: url ? [url] : [""],
+		}));
+
+	const addFilter = (kind: IncludeKind, i: number) =>
+		mutateEntry(kind, i, (inc) => ({
+			...inc,
+			filter: [...(inc.filter ?? []), { op: "is-a" }],
+		}));
+	const updateFilter = (
+		kind: IncludeKind,
+		i: number,
+		fi: number,
+		patch: { property?: string; op?: string; value?: string },
+	) =>
+		mutateEntry(kind, i, (inc) => {
+			const arr = (inc.filter ?? []).slice();
+			arr[fi] = { ...arr[fi], ...patch };
+			return { ...inc, filter: arr };
+		});
+	const removeFilter = (kind: IncludeKind, i: number, fi: number) =>
+		mutateEntry(kind, i, (inc) => {
+			const arr = (inc.filter ?? []).filter((_, idx) => idx !== fi);
+			return { ...inc, filter: arr.length > 0 ? arr : undefined };
+		});
+
+	// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: large switch over tree node types
+	const customItemView = (item: ItemInstance<TreeViewItem<ItemMeta>>) => {
+		const meta = item.getItemData()?.meta;
+		const metaType = meta?.type;
+		switch (metaType) {
+			case "properties":
+			case "include":
+				return <div>{labelView(item)}</div>;
+			case "include-row": {
+				const kind = meta?.kind ?? "include";
+				const idx = meta?.includeIndex ?? -1;
+				const entry = entriesOf(kind)[idx];
+				if (!entry) return null;
+				if (isVsInclude(entry)) {
+					return (
+						<div className="flex w-full items-center gap-2">
+							<div className="w-[226px] shrink-0">
+								<button
+									type="button"
+									className="uppercase px-1.5 py-0.5 cursor-pointer rounded-md text-text-info-primary bg-bg-info-primary"
+								>
+									valueset
+								</button>
+							</div>
+							<ValueSetPicker
+								value={entry.valueSet?.[0]}
+								onChange={(v) => updateEntryValueSet(kind, idx, v)}
+							/>
+							<HSComp.Button
+								variant="link"
+								size="small"
+								className="shrink-0 group-hover/tree-item-label:opacity-100 opacity-0 transition-opacity"
+								onClick={() => removeEntry(kind, idx)}
+								asChild
+							>
+								<span>
+									<X size={14} />
+								</span>
+							</HSComp.Button>
+						</div>
+					);
+				}
+				return (
+					<div className="flex w-full items-center gap-2">
+						<div className="w-[226px] shrink-0">{labelView(item)}</div>
+						<CodeSystemPicker
+							system={entry.system}
+							version={entry.version}
+							onChange={(next) => updateEntrySystemVersion(kind, idx, next)}
+						/>
+						<HSComp.Button
+							variant="link"
+							size="small"
+							className="shrink-0 group-hover/tree-item-label:opacity-100 opacity-0 transition-opacity"
+							onClick={() => removeEntry(kind, idx)}
+							asChild
+						>
+							<span>
+								<X size={14} />
+							</span>
+						</HSComp.Button>
+					</div>
+				);
+			}
+			case "include-concept":
+			case "include-filter":
+				return <div>{labelView(item)}</div>;
+			case "include-concept-row": {
+				const kind = meta?.kind ?? "include";
+				const idx = meta?.includeIndex ?? -1;
+				const ci = meta?.conceptIndex ?? -1;
+				const parent = entriesOf(kind)[idx];
+				const entry = parent?.concept?.[ci];
+				if (!entry) return null;
+				return (
+					<div className="flex w-full items-center gap-2 pl-0.5">
+						<span className="text-utility-yellow bg-utility-yellow/20 rounded-md p-1 shrink-0">
+							<Tag size={12} />
+						</span>
+						<div className="w-[200px] shrink-0">
+							<ConceptCodePicker
+								system={parent?.system}
+								code={entry.code}
+								onChange={(next) =>
+									updateConcept(kind, idx, ci, {
+										code: next.code,
+										// auto-fill display only when picked from suggestions
+										...(next.display !== undefined
+											? { display: next.display }
+											: {}),
+									})
+								}
+							/>
+						</div>
+						<div className="flex-1 min-w-0">
+							<InputView
+								placeholder="display (optional)"
+								value={entry.display}
+								onChange={(v) =>
+									updateConcept(kind, idx, ci, { display: v || undefined })
+								}
+							/>
+						</div>
+						<HSComp.Button
+							variant="link"
+							size="small"
+							className="shrink-0 group-hover/tree-item-label:opacity-100 opacity-0 transition-opacity"
+							onClick={() => removeConcept(kind, idx, ci)}
+							asChild
+						>
+							<span>
+								<X size={14} />
+							</span>
+						</HSComp.Button>
+					</div>
+				);
+			}
+			case "include-concept-add": {
+				const kind = meta?.kind ?? "include";
+				const idx = meta?.includeIndex ?? -1;
+				if ((entriesOf(kind)[idx]?.filter?.length ?? 0) > 0) return null;
+				return (
+					<HSComp.Button
+						variant="link"
+						size="small"
+						className="px-0"
+						onClick={() => addConcept(kind, idx)}
+						asChild
+					>
+						<span>
+							<Plus size={16} strokeWidth={3} />
+							<span className="text-xs typo-label">Concept</span>
+						</span>
+					</HSComp.Button>
+				);
+			}
+			case "include-filter-row": {
+				const kind = meta?.kind ?? "include";
+				const idx = meta?.includeIndex ?? -1;
+				const fi = meta?.filterIndex ?? -1;
+				const entry = entriesOf(kind)[idx]?.filter?.[fi];
+				if (!entry) return null;
+				return (
+					<div className="flex w-full items-center gap-2 pl-0.5">
+						<span className="text-utility-yellow bg-utility-yellow/20 rounded-md p-1 shrink-0">
+							<Filter size={12} />
+						</span>
+						<div className="w-[160px] shrink-0">
+							<InputView
+								placeholder="property"
+								value={entry.property}
+								onChange={(v) =>
+									updateFilter(kind, idx, fi, { property: v || undefined })
+								}
+							/>
+						</div>
+						<div className="w-[140px] shrink-0">
+							<HSComp.Select
+								value={entry.op ?? ""}
+								onValueChange={(v) => updateFilter(kind, idx, fi, { op: v })}
+							>
+								<HSComp.SelectTrigger className="h-7 py-1 px-2 bg-bg-primary border-none hover:bg-bg-quaternary focus:bg-bg-primary focus:ring-1 focus:ring-border-link group-hover/tree-item-label:bg-bg-tertiary">
+									<HSComp.SelectValue placeholder="op" />
+								</HSComp.SelectTrigger>
+								<HSComp.SelectContent>
+									{FILTER_OPS.map((op) => (
+										<HSComp.SelectItem key={op} value={op}>
+											{op}
+										</HSComp.SelectItem>
+									))}
+								</HSComp.SelectContent>
+							</HSComp.Select>
+						</div>
+						<div className="flex-1 min-w-0">
+							<InputView
+								placeholder="value"
+								value={entry.value}
+								onChange={(v) =>
+									updateFilter(kind, idx, fi, { value: v || undefined })
+								}
+							/>
+						</div>
+						<HSComp.Button
+							variant="link"
+							size="small"
+							className="shrink-0 group-hover/tree-item-label:opacity-100 opacity-0 transition-opacity"
+							onClick={() => removeFilter(kind, idx, fi)}
+							asChild
+						>
+							<span>
+								<X size={14} />
+							</span>
+						</HSComp.Button>
+					</div>
+				);
+			}
+			case "include-filter-add": {
+				const kind = meta?.kind ?? "include";
+				const idx = meta?.includeIndex ?? -1;
+				if ((entriesOf(kind)[idx]?.concept?.length ?? 0) > 0) return null;
+				return (
+					<HSComp.Button
+						variant="link"
+						size="small"
+						className="px-0"
+						onClick={() => addFilter(kind, idx)}
+						asChild
+					>
+						<span>
+							<Plus size={16} strokeWidth={3} />
+							<span className="text-xs typo-label">Filter</span>
+						</span>
+					</HSComp.Button>
+				);
+			}
+			case "include-add": {
+				const kind = meta?.kind ?? "include";
+				const label = kind === "include" ? "Include" : "Exclude";
+				return (
+					<HSComp.DropdownMenu>
+						<HSComp.DropdownMenuTrigger asChild>
+							<HSComp.Button
+								variant="link"
+								size="small"
+								className="px-0"
+								asChild
+							>
+								<span>
+									<Plus size={16} strokeWidth={3} />
+									<span className="text-xs typo-label">{label}</span>
+								</span>
+							</HSComp.Button>
+						</HSComp.DropdownMenuTrigger>
+						<HSComp.DropdownMenuContent align="start">
+							<HSComp.DropdownMenuItem onSelect={() => addCodeSystem(kind)}>
+								CodeSystem
+							</HSComp.DropdownMenuItem>
+							<HSComp.DropdownMenuItem onSelect={() => addValueSetEntry(kind)}>
+								ValueSet
+							</HSComp.DropdownMenuItem>
+						</HSComp.DropdownMenuContent>
+					</HSComp.DropdownMenu>
+				);
+			}
+			case "url":
+				return (
+					<div className="flex w-full items-center gap-2">
+						<div className="w-[226px] shrink-0">{labelView(item)}</div>
+						<div className="w-[50%]">
+							<InputView
+								placeholder="Canonical identifier for this value set, represented as a URI (globally unique)"
+								value={valueSet.url}
+								onChange={updateUrl}
+							/>
+						</div>
+					</div>
+				);
+			case "version":
+				return (
+					<div className="flex w-full items-center gap-2">
+						<div className="w-[226px] shrink-0">{labelView(item)}</div>
+						<div className="w-[50%]">
+							<InputView
+								placeholder="Business version of the value set"
+								value={valueSet.version}
+								onChange={updateVersion}
+							/>
+						</div>
+					</div>
+				);
+			case "title":
+				return (
+					<div className="flex w-full items-center gap-2">
+						<div className="w-[226px] shrink-0">{labelView(item)}</div>
+						<div className="w-[50%]">
+							<InputView
+								placeholder="Name for this value set (human friendly)"
+								value={valueSet.title}
+								onChange={updateTitle}
+							/>
+						</div>
+					</div>
+				);
+			case "description":
+				return (
+					<div className="flex w-full items-center gap-2">
+						<div className="w-[226px] shrink-0">{labelView(item)}</div>
+						<div className="flex-1 min-w-0">
+							<InputView
+								placeholder="Natural language description of the value set"
+								value={valueSet.description}
+								onChange={updateDescription}
+							/>
+						</div>
+					</div>
+				);
+			default:
+				return <div>{labelView(item)}</div>;
+		}
+	};
+
+	return (
+		<div>
+			<TreeView
+				items={tree}
+				rootItemId="root"
+				customItemView={customItemView}
+				disableHover={true}
+				chevronClassName="self-center cursor-pointer"
+				expandedItems={expandedItems}
+				onExpandedItemsChange={setExpandedItems}
+				onItemLabelClick={(item) => {
+					if (item.isFolder()) {
+						if (item.isExpanded()) item.collapse();
+						else item.expand();
+					}
+				}}
+				itemLabelClassFn={(item: ItemInstance<TreeViewItem<ItemMeta>>) => {
+					const metaType = item.getItemData()?.meta?.type;
+					if (metaType === "properties" || metaType === "include") {
+						return "relative my-1.5 rounded-md bg-bg-info-primary cursor-pointer before:content-[''] before:absolute before:inset-x-0 before:top-0 before:bottom-0 before:-z-10 before:bg-bg-primary before:-my-1.5 after:content-[''] after:absolute after:inset-x-0 after:top-0 after:bottom-0 after:-z-10 after:bg-bg-primary after:rounded-md after:-my-1.5";
+					}
+					return "pr-0";
+				}}
+			/>
+		</div>
+	);
+}

--- a/src/components/ValueSet/properties-tree.tsx
+++ b/src/components/ValueSet/properties-tree.tsx
@@ -8,8 +8,11 @@ import { useQuery } from "@tanstack/react-query";
 import { Filter, Plus, Tag, X } from "lucide-react";
 import * as React from "react";
 import { useAidboxClient } from "../../AidboxClient";
+import { readUrlHistory } from "../../utils/url-history";
 import { useValueSetContext } from "./context";
 import type { ValueSetStatus } from "./types";
+
+const URL_HISTORY_KEY = "valueset-builder:url-history";
 
 type IncludeKind = "include" | "exclude";
 
@@ -59,10 +62,16 @@ function InputView({
 	placeholder,
 	value,
 	onChange,
+	name,
+	autoComplete,
+	list,
 }: {
 	placeholder: string;
 	value?: string;
 	onChange?: (value: string) => void;
+	name?: string;
+	autoComplete?: string;
+	list?: string;
 }) {
 	const [localValue, setLocalValue] = React.useState(value ?? "");
 
@@ -84,6 +93,9 @@ function InputView({
 
 	return (
 		<HSComp.Input
+			name={name}
+			autoComplete={autoComplete}
+			list={list}
 			className="h-7 py-1 px-2 bg-bg-primary border-none hover:bg-bg-quaternary focus:bg-bg-primary group-hover/tree-item-label:bg-bg-tertiary focus:ring-1 focus:ring-border-link"
 			placeholder={placeholder}
 			value={localValue}
@@ -167,6 +179,7 @@ function CodeSystemPicker({
 		queryFn: async () => {
 			const params = new URLSearchParams({
 				_count: "15",
+				_sort: "-_lastUpdated",
 				_elements: "url,name,title,version,description",
 			});
 			if (systemPart) params.set("url:contains", systemPart);
@@ -190,6 +203,7 @@ function CodeSystemPicker({
 		queryFn: async () => {
 			const params = new URLSearchParams({
 				_count: "100",
+				_sort: "-_lastUpdated",
 				_elements: "url,name,title,version",
 				url: systemPart,
 			});
@@ -463,6 +477,7 @@ function ValueSetPicker({
 		queryFn: async () => {
 			const params = new URLSearchParams({
 				_count: "15",
+				_sort: "-_lastUpdated",
 				_elements: "url,name,title,version,description",
 			});
 			if (urlPart) params.set("url:contains", urlPart);
@@ -486,6 +501,7 @@ function ValueSetPicker({
 		queryFn: async () => {
 			const params = new URLSearchParams({
 				_count: "100",
+				_sort: "-_lastUpdated",
 				_elements: "url,name,title,version",
 				url: urlPart,
 			});
@@ -910,6 +926,7 @@ function labelView(item: ItemInstance<TreeViewItem<ItemMeta>>) {
 	return (
 		<button
 			type="button"
+			tabIndex={-1}
 			className={`uppercase px-1.5 py-0.5 ${isFolder ? "cursor-pointer" : ""} rounded-md ${additionalClass}`}
 			onClick={onLabelClickFn}
 		>
@@ -921,6 +938,9 @@ function labelView(item: ItemInstance<TreeViewItem<ItemMeta>>) {
 export function PropertiesTree() {
 	const { valueSet, updateValueSet, missingFields, setMissingFields } =
 		useValueSetContext();
+	const [urlHistory] = React.useState<string[]>(() =>
+		readUrlHistory(URL_HISTORY_KEY),
+	);
 	const dismissMissing = React.useCallback(
 		(field: string) => {
 			setMissingFields((prev) => {
@@ -1256,6 +1276,7 @@ export function PropertiesTree() {
 							<div className="w-[202px] shrink-0">
 								<button
 									type="button"
+									tabIndex={-1}
 									className="uppercase px-1.5 py-0.5 rounded-md text-text-info-primary bg-bg-info-primary"
 								>
 									ValueSet
@@ -1293,6 +1314,7 @@ export function PropertiesTree() {
 						<div className="w-[202px] shrink-0">
 							<button
 								type="button"
+								tabIndex={-1}
 								className={`uppercase px-1.5 py-0.5 rounded-md text-text-info-primary bg-bg-info-primary ${isFolder ? "cursor-pointer" : ""}`}
 								onClick={toggle}
 							>
@@ -1512,6 +1534,9 @@ export function PropertiesTree() {
 						<div className="w-[226px] shrink-0">{labelView(item)}</div>
 						<div className="w-[50%]">
 							<InputView
+								name="valueset-url"
+								autoComplete="on"
+								list="valueset-builder-url-history"
 								placeholder="Canonical identifier for this value set, represented as a URI (globally unique)"
 								value={valueSet.url}
 								onChange={updateUrl}
@@ -1614,6 +1639,11 @@ export function PropertiesTree() {
 					return "pr-0";
 				}}
 			/>
+			<datalist id="valueset-builder-url-history">
+				{urlHistory.map((u) => (
+					<option key={u} value={u} />
+				))}
+			</datalist>
 		</div>
 	);
 }

--- a/src/components/ValueSet/properties-tree.tsx
+++ b/src/components/ValueSet/properties-tree.tsx
@@ -9,6 +9,7 @@ import { Filter, Plus, Tag, X } from "lucide-react";
 import * as React from "react";
 import { useAidboxClient } from "../../AidboxClient";
 import { useValueSetContext } from "./context";
+import type { ValueSetStatus } from "./types";
 
 type IncludeKind = "include" | "exclude";
 
@@ -18,14 +19,13 @@ type ItemMeta = {
 		| "url"
 		| "version"
 		| "title"
+		| "status"
 		| "description"
 		| "include"
 		| "include-row"
 		| "include-add"
-		| "include-concept"
 		| "include-concept-row"
 		| "include-concept-add"
-		| "include-filter"
 		| "include-filter-row"
 		| "include-filter-add";
 	kind?: IncludeKind;
@@ -33,6 +33,8 @@ type ItemMeta = {
 	conceptIndex?: number;
 	filterIndex?: number;
 };
+
+const STATUSES = ["draft", "active", "retired", "unknown"] as const;
 
 const isVsInclude = (inc: { valueSet?: string[]; system?: string }) =>
 	(inc.valueSet?.length ?? 0) > 0;
@@ -127,10 +129,12 @@ function CodeSystemPicker({
 	system,
 	version,
 	onChange,
+	autoFocusToken,
 }: {
 	system?: string;
 	version?: string;
 	onChange: (next: { system?: string; version?: string }) => void;
+	autoFocusToken?: number | null;
 }) {
 	const client = useAidboxClient();
 	const formatted = formatSystemPipeVersion(system, version);
@@ -268,13 +272,18 @@ function CodeSystemPicker({
 	}, [activeIndex]);
 
 	const inputRef = React.useRef<HTMLInputElement | null>(null);
+
+	React.useEffect(() => {
+		if (autoFocusToken != null) inputRef.current?.focus();
+	}, [autoFocusToken]);
+
 	return (
 		<HSComp.Popover open={open} onOpenChange={setOpen}>
 			<HSComp.PopoverAnchor asChild>
 				<div className="flex-1 min-w-0">
 					<HSComp.Input
 						ref={inputRef}
-						placeholder="CodeSystem URL"
+						placeholder="CodeSystem canonical URL"
 						value={local}
 						onChange={(e) => {
 							setLocal(e.target.value);
@@ -411,15 +420,18 @@ type ValueSetHit = {
 	url?: string;
 	name?: string;
 	title?: string;
+	version?: string;
 	description?: string;
 };
 
 function ValueSetPicker({
 	value,
 	onChange,
+	autoFocusToken,
 }: {
 	value?: string;
 	onChange: (next: string | undefined) => void;
+	autoFocusToken?: number | null;
 }) {
 	const client = useAidboxClient();
 	const [local, setLocal] = React.useState(value ?? "");
@@ -438,15 +450,22 @@ function ValueSetPicker({
 		return () => clearTimeout(t);
 	}, [local]);
 
-	const { data: hits } = useQuery({
-		queryKey: ["valueset-builder", "valueset-picker", debounced],
+	// same pipe-syntax handling as CodeSystemPicker — `url|version`
+	const pipeIdx = debounced.indexOf("|");
+	const mode: "url" | "version" = pipeIdx >= 0 ? "version" : "url";
+	const urlPart =
+		pipeIdx >= 0 ? debounced.slice(0, pipeIdx).trim() : debounced.trim();
+	const versionPart = pipeIdx >= 0 ? debounced.slice(pipeIdx + 1).trim() : "";
+
+	const { data: urlHits } = useQuery({
+		queryKey: ["valueset-builder", "valueset-picker", "url", urlPart],
+		enabled: mode === "url",
 		queryFn: async () => {
-			const q = debounced.trim();
 			const params = new URLSearchParams({
 				_count: "15",
-				_elements: "url,name,title,description",
+				_elements: "url,name,title,version,description",
 			});
-			if (q) params.set("url:contains", q);
+			if (urlPart) params.set("url:contains", urlPart);
 			const res = await client.request<{
 				entry?: Array<{ resource: ValueSetHit }>;
 			}>({
@@ -461,21 +480,77 @@ function ValueSetPicker({
 		staleTime: 30_000,
 	});
 
+	const { data: versionHits } = useQuery({
+		queryKey: ["valueset-builder", "valueset-picker", "versions", urlPart],
+		enabled: mode === "version" && urlPart.length > 0,
+		queryFn: async () => {
+			const params = new URLSearchParams({
+				_count: "100",
+				_elements: "url,name,title,version",
+				url: urlPart,
+			});
+			const res = await client.request<{
+				entry?: Array<{ resource: ValueSetHit }>;
+			}>({
+				method: "GET",
+				url: `/fhir/ValueSet?${params.toString()}`,
+			});
+			if (res.isErr()) return [];
+			const seen = new Set<string>();
+			const out: Array<ValueSetHit & { url: string; version: string }> = [];
+			for (const e of res.value.resource.entry ?? []) {
+				const r = e.resource;
+				if (!r.url || !r.version) continue;
+				if (seen.has(r.version)) continue;
+				seen.add(r.version);
+				out.push({ ...r, url: r.url, version: r.version });
+			}
+			return out;
+		},
+		staleTime: 30_000,
+	});
+
 	const commit = (raw: string) => {
 		setLocal(raw);
 		const next = raw.trim() || undefined;
 		if (next !== value) onChange(next);
 	};
 
-	const selectHit = (h: ValueSetHit & { url: string }) => {
+	const selectUrlHit = (h: ValueSetHit & { url: string }) => {
+		// picking from URL list never auto-pins version
 		setLocal(h.url);
 		onChange(h.url);
 		setOpen(false);
 		setActiveIndex(-1);
 	};
 
-	const hitsList = hits ?? [];
+	const selectVersionHit = (
+		h: ValueSetHit & { url: string; version: string },
+	) => {
+		const next = `${urlPart || h.url}|${h.version}`;
+		setLocal(next);
+		onChange(next);
+		setOpen(false);
+		setActiveIndex(-1);
+	};
+
+	const hitsList =
+		mode === "version"
+			? (versionHits ?? []).filter(
+					(h) => !versionPart || h.version.includes(versionPart),
+				)
+			: (urlHits ?? []);
 	const hitsLength = hitsList.length;
+
+	const onSelectActive = () => {
+		const h = hitsList[activeIndex];
+		if (!h) return;
+		if (mode === "version") {
+			selectVersionHit(h as ValueSetHit & { url: string; version: string });
+		} else {
+			selectUrlHit(h);
+		}
+	};
 
 	React.useEffect(() => {
 		setActiveIndex(hitsLength > 0 ? 0 : -1);
@@ -485,6 +560,10 @@ function ValueSetPicker({
 		if (activeIndex < 0) return;
 		itemRefs.current[activeIndex]?.scrollIntoView({ block: "nearest" });
 	}, [activeIndex]);
+
+	React.useEffect(() => {
+		if (autoFocusToken != null) inputRef.current?.focus();
+	}, [autoFocusToken]);
 
 	return (
 		<HSComp.Popover open={open} onOpenChange={setOpen}>
@@ -523,7 +602,7 @@ function ValueSetPicker({
 							} else if (e.key === "Enter") {
 								e.preventDefault();
 								if (open && activeIndex >= 0 && hitsList[activeIndex]) {
-									selectHit(hitsList[activeIndex]);
+									onSelectActive();
 								} else {
 									commit(local);
 									setOpen(false);
@@ -547,24 +626,56 @@ function ValueSetPicker({
 					if (e.target === inputRef.current) e.preventDefault();
 				}}
 			>
-				{hitsList.length === 0 ? (
+				{mode === "version" && !urlPart ? (
 					<div className="px-3 py-2 text-text-secondary text-sm">
-						No matches
+						Type a ValueSet URL before <code>|</code>
+					</div>
+				) : hitsLength === 0 ? (
+					<div className="px-3 py-2 text-text-secondary text-sm">
+						{mode === "version" ? "No versions found" : "No matches"}
 					</div>
 				) : (
 					<ul className="py-1">
 						{hitsList.map((h, i) => {
 							const isActive = i === activeIndex;
+							if (mode === "version") {
+								const ver = h.version ?? "";
+								const secondary = h.title || h.name || h.id || h.url;
+								return (
+									<li key={`${h.url}|${ver}`}>
+										<button
+											ref={(el) => {
+												itemRefs.current[i] = el;
+											}}
+											type="button"
+											onClick={() =>
+												selectVersionHit(
+													h as ValueSetHit & { url: string; version: string },
+												)
+											}
+											onMouseEnter={() => setActiveIndex(i)}
+											className={`w-full text-left px-3 py-1.5 focus:outline-none ${isActive ? "bg-bg-tertiary" : ""}`}
+										>
+											<div className="typo-body text-text-primary truncate font-mono">
+												{ver}
+											</div>
+											<div className="typo-body-xs text-text-secondary line-clamp-1">
+												{secondary}
+											</div>
+										</button>
+									</li>
+								);
+							}
 							const title = h.title || h.name || h.id || h.url;
 							const secondary = h.description || h.url;
 							return (
-								<li key={h.url}>
+								<li key={`${h.url}|${h.version ?? ""}`}>
 									<button
 										ref={(el) => {
 											itemRefs.current[i] = el;
 										}}
 										type="button"
-										onClick={() => selectHit(h)}
+										onClick={() => selectUrlHit(h)}
 										onMouseEnter={() => setActiveIndex(i)}
 										className={`w-full text-left px-3 py-1.5 focus:outline-none ${isActive ? "bg-bg-tertiary" : ""}`}
 									>
@@ -788,9 +899,6 @@ function labelView(item: ItemInstance<TreeViewItem<ItemMeta>>) {
 	const kind = item.getItemData()?.meta?.kind;
 	let label: string | undefined = metaType;
 	if (metaType === "include") label = kind ?? "include";
-	else if (metaType === "include-row") label = "codesystem";
-	else if (metaType === "include-concept") label = "concept";
-	else if (metaType === "include-filter") label = "filter";
 
 	const onLabelClickFn = (e: React.MouseEvent) => {
 		if (!isFolder) return;
@@ -811,7 +919,19 @@ function labelView(item: ItemInstance<TreeViewItem<ItemMeta>>) {
 }
 
 export function PropertiesTree() {
-	const { valueSet, updateValueSet } = useValueSetContext();
+	const { valueSet, updateValueSet, missingFields, setMissingFields } =
+		useValueSetContext();
+	const dismissMissing = React.useCallback(
+		(field: string) => {
+			setMissingFields((prev) => {
+				if (!prev.has(field)) return prev;
+				const next = new Set(prev);
+				next.delete(field);
+				return next;
+			});
+		},
+		[setMissingFields],
+	);
 
 	const updateUrl = (value: string) => {
 		updateValueSet((vs) => ({ ...vs, url: value || undefined }));
@@ -821,6 +941,13 @@ export function PropertiesTree() {
 	};
 	const updateTitle = (value: string) => {
 		updateValueSet((vs) => ({ ...vs, title: value || undefined }));
+	};
+	const updateStatus = (value: string) => {
+		updateValueSet((vs) => ({
+			...vs,
+			status: (value || undefined) as ValueSetStatus | undefined,
+		}));
+		if (value) dismissMissing("status");
 	};
 	const updateDescription = (value: string) => {
 		updateValueSet((vs) => ({ ...vs, description: value || undefined }));
@@ -840,11 +967,12 @@ export function PropertiesTree() {
 			_properties: {
 				name: "_properties",
 				meta: { type: "properties" },
-				children: ["_url", "_version", "_title", "_description"],
+				children: ["_url", "_version", "_status", "_title", "_description"],
 			},
 			_url: { name: "_url", meta: { type: "url" } },
 			_version: { name: "_version", meta: { type: "version" } },
 			_title: { name: "_title", meta: { type: "title" } },
+			_status: { name: "_status", meta: { type: "status" } },
 			_description: { name: "_description", meta: { type: "description" } },
 		};
 
@@ -861,88 +989,68 @@ export function PropertiesTree() {
 				name: addId,
 				meta: { type: "include-add", kind },
 			};
-			// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: large nested tree-node builder
 			entries.forEach((entry, i) => {
 				const rowId = `${sectionId}_${i}`;
-				const conceptChildren = (entry.concept ?? []).map(
-					(_, ci) => `${rowId}_concept_${ci}`,
-				);
-				const filterChildren = (entry.filter ?? []).map(
-					(_, fi) => `${rowId}_filter_${fi}`,
-				);
 				const hasConcept = (entry.concept?.length ?? 0) > 0;
 				const hasFilter = (entry.filter?.length ?? 0) > 0;
-				// vsd-3 inherited via contentReference — applies to exclude too
-				const showConcept = hasConcept || !hasFilter;
-				const showFilter = hasFilter || !hasConcept;
+				const hasSystem = !!entry.system;
+				// vsd-2: concept/filter require system. Without system we
+				// hide the add button entirely; legacy populated arrays still
+				// render so the user can clean them up.
+				// vsd-3: cannot have both concept and filter — when one is
+				// populated we hide the add button for the other.
+				const enableConceptAdd = hasSystem && !hasFilter;
+				const enableFilterAdd = hasSystem && !hasConcept;
 				const rowChildren: string[] = [];
-				if (showConcept) rowChildren.push(`${rowId}_concept`);
-				if (showFilter) rowChildren.push(`${rowId}_filter`);
+				(entry.concept ?? []).forEach((_, ci) => {
+					const id = `${rowId}_concept_${ci}`;
+					rowChildren.push(id);
+					out[id] = {
+						name: id,
+						meta: {
+							type: "include-concept-row",
+							kind,
+							includeIndex: i,
+							conceptIndex: ci,
+						},
+					};
+				});
+				(entry.filter ?? []).forEach((_, fi) => {
+					const id = `${rowId}_filter_${fi}`;
+					rowChildren.push(id);
+					out[id] = {
+						name: id,
+						meta: {
+							type: "include-filter-row",
+							kind,
+							includeIndex: i,
+							filterIndex: fi,
+						},
+					};
+				});
+				if (enableConceptAdd) {
+					const id = `${rowId}_concept_add`;
+					rowChildren.push(id);
+					out[id] = {
+						name: id,
+						meta: { type: "include-concept-add", kind, includeIndex: i },
+					};
+				}
+				if (enableFilterAdd) {
+					const id = `${rowId}_filter_add`;
+					rowChildren.push(id);
+					out[id] = {
+						name: id,
+						meta: { type: "include-filter-add", kind, includeIndex: i },
+					};
+				}
 				out[rowId] = {
 					name: rowId,
 					meta: { type: "include-row", kind, includeIndex: i },
-					children: rowChildren,
+					// leaf when no concept/filter — drops chevron. Spacer
+					// rendered in customItemView keeps horizontal alignment.
+					...(rowChildren.length > 0 ? { children: rowChildren } : {}),
 				};
-
-				if (showConcept) {
-					const conceptSectionChildren = hasFilter
-						? conceptChildren
-						: [...conceptChildren, `${rowId}_concept_add`];
-					out[`${rowId}_concept`] = {
-						name: `${rowId}_concept`,
-						meta: { type: "include-concept", kind, includeIndex: i },
-						...(conceptSectionChildren.length > 0
-							? { children: conceptSectionChildren }
-							: {}),
-					};
-					if (!hasFilter) {
-						out[`${rowId}_concept_add`] = {
-							name: `${rowId}_concept_add`,
-							meta: { type: "include-concept-add", kind, includeIndex: i },
-						};
-					}
-					(entry.concept ?? []).forEach((_, ci) => {
-						out[`${rowId}_concept_${ci}`] = {
-							name: `${rowId}_concept_${ci}`,
-							meta: {
-								type: "include-concept-row",
-								kind,
-								includeIndex: i,
-								conceptIndex: ci,
-							},
-						};
-					});
-				}
-
-				if (showFilter) {
-					const filterSectionChildren = hasConcept
-						? filterChildren
-						: [...filterChildren, `${rowId}_filter_add`];
-					out[`${rowId}_filter`] = {
-						name: `${rowId}_filter`,
-						meta: { type: "include-filter", kind, includeIndex: i },
-						...(filterSectionChildren.length > 0
-							? { children: filterSectionChildren }
-							: {}),
-					};
-					if (!hasConcept) {
-						out[`${rowId}_filter_add`] = {
-							name: `${rowId}_filter_add`,
-							meta: { type: "include-filter-add", kind, includeIndex: i },
-						};
-					}
-					(entry.filter ?? []).forEach((_, fi) => {
-						out[`${rowId}_filter_${fi}`] = {
-							name: `${rowId}_filter_${fi}`,
-							meta: {
-								type: "include-filter-row",
-								kind,
-								includeIndex: i,
-								filterIndex: fi,
-							},
-						};
-					});
-				}
 			});
 		};
 
@@ -957,7 +1065,9 @@ export function PropertiesTree() {
 		"_exclude",
 	]);
 
-	// auto-expand each entry's nested sections on first appearance only.
+	// auto-expand each entry's nested sections on first appearance only,
+	// and only once the entry has a URL (system or valueSet). New empty
+	// entries stay collapsed so focus can land on the URL input first.
 	// Without the `seen` ref this useEffect would re-expand every node on
 	// each render (because includes/excludes are re-derived arrays), undoing
 	// the user's manual collapse.
@@ -965,15 +1075,16 @@ export function PropertiesTree() {
 	React.useEffect(() => {
 		const need: string[] = [];
 		const collect = (kind: IncludeKind, arr: typeof includes) => {
-			arr.forEach((_, i) => {
+			arr.forEach((entry, i) => {
+				// row is a folder only when it has concept or filter rows;
+				// CS-only / VS-only entries are leaves with nothing to expand.
+				const hasChildren =
+					(entry.concept?.length ?? 0) > 0 || (entry.filter?.length ?? 0) > 0;
+				if (!hasChildren) return;
 				const row = `_${kind}_${i}`;
-				const c = `${row}_concept`;
-				const f = `${row}_filter`;
-				for (const id of [row, c, f]) {
-					if (!autoExpandedRef.current.has(id)) {
-						autoExpandedRef.current.add(id);
-						need.push(id);
-					}
+				if (!autoExpandedRef.current.has(row)) {
+					autoExpandedRef.current.add(row);
+					need.push(row);
 				}
 			});
 		};
@@ -986,6 +1097,12 @@ export function PropertiesTree() {
 			return [...prev, ...missing];
 		});
 	}, [includes, excludes]);
+
+	const [focusTarget, setFocusTarget] = React.useState<{
+		kind: IncludeKind;
+		idx: number;
+		tick: number;
+	} | null>(null);
 
 	const mutateCompose = (
 		kind: IncludeKind,
@@ -1004,11 +1121,23 @@ export function PropertiesTree() {
 		});
 	};
 
-	const addCodeSystem = (kind: IncludeKind) =>
-		mutateCompose(kind, (arr) => [...arr, { system: "" }]);
+	const addCodeSystem = (kind: IncludeKind, preset?: "concept" | "filter") => {
+		const nextIdx = entriesOf(kind).length;
+		const entry: (typeof includes)[number] =
+			preset === "concept"
+				? { system: "", concept: [{}] }
+				: preset === "filter"
+					? { system: "", filter: [{ op: "is-a" }] }
+					: { system: "" };
+		mutateCompose(kind, (arr) => [...arr, entry]);
+		setFocusTarget({ kind, idx: nextIdx, tick: Date.now() });
+	};
 
-	const addValueSetEntry = (kind: IncludeKind) =>
+	const addValueSetEntry = (kind: IncludeKind) => {
+		const nextIdx = entriesOf(kind).length;
 		mutateCompose(kind, (arr) => [...arr, { valueSet: [""] }]);
+		setFocusTarget({ kind, idx: nextIdx, tick: Date.now() });
+	};
 
 	const updateEntrySystemVersion = (
 		kind: IncludeKind,
@@ -1104,20 +1233,38 @@ export function PropertiesTree() {
 				const idx = meta?.includeIndex ?? -1;
 				const entry = entriesOf(kind)[idx];
 				if (!entry) return null;
+				const focusToken =
+					focusTarget?.kind === kind && focusTarget.idx === idx
+						? focusTarget.tick
+						: null;
+				// reserve the chevron slot for leaf rows so VS-only entries
+				// align with CS rows that own a chevron
+				const isFolder = item.isFolder();
+				const leadingSpacer = isFolder ? null : (
+					<span className="size-4 shrink-0" aria-hidden />
+				);
+				const toggle = (e: React.MouseEvent) => {
+					if (!isFolder) return;
+					e.stopPropagation();
+					if (item.isExpanded()) item.collapse();
+					else item.expand();
+				};
 				if (isVsInclude(entry)) {
 					return (
 						<div className="flex w-full items-center gap-2">
+							{leadingSpacer}
 							<div className="w-[202px] shrink-0">
 								<button
 									type="button"
-									className="uppercase px-1.5 py-0.5 cursor-pointer rounded-md text-text-info-primary bg-bg-info-primary"
+									className="uppercase px-1.5 py-0.5 rounded-md text-text-info-primary bg-bg-info-primary"
 								>
-									valueset
+									ValueSet
 								</button>
 							</div>
 							<ValueSetPicker
 								value={entry.valueSet?.[0]}
 								onChange={(v) => updateEntryValueSet(kind, idx, v)}
+								autoFocusToken={focusToken}
 							/>
 							<HSComp.Button
 								variant="link"
@@ -1133,13 +1280,30 @@ export function PropertiesTree() {
 						</div>
 					);
 				}
+				const hasConcept = (entry.concept?.length ?? 0) > 0;
+				const hasFilter = (entry.filter?.length ?? 0) > 0;
+				const csLabel = hasConcept
+					? "CodeSystem Concepts"
+					: hasFilter
+						? "CodeSystem Filter"
+						: "CodeSystem";
 				return (
 					<div className="flex w-full items-center gap-2">
-						<div className="w-[202px] shrink-0">{labelView(item)}</div>
+						{leadingSpacer}
+						<div className="w-[202px] shrink-0">
+							<button
+								type="button"
+								className={`uppercase px-1.5 py-0.5 rounded-md text-text-info-primary bg-bg-info-primary ${isFolder ? "cursor-pointer" : ""}`}
+								onClick={toggle}
+							>
+								{csLabel}
+							</button>
+						</div>
 						<CodeSystemPicker
 							system={entry.system}
 							version={entry.version}
 							onChange={(next) => updateEntrySystemVersion(kind, idx, next)}
+							autoFocusToken={focusToken}
 						/>
 						<HSComp.Button
 							variant="link"
@@ -1155,9 +1319,6 @@ export function PropertiesTree() {
 					</div>
 				);
 			}
-			case "include-concept":
-			case "include-filter":
-				return <div>{labelView(item)}</div>;
 			case "include-concept-row": {
 				const kind = meta?.kind ?? "include";
 				const idx = meta?.includeIndex ?? -1;
@@ -1170,7 +1331,7 @@ export function PropertiesTree() {
 						<span className="text-utility-yellow bg-utility-yellow/20 rounded-md p-1 shrink-0">
 							<Tag size={12} />
 						</span>
-						<div className="w-[152px] shrink-0">
+						<div className="w-[175px] shrink-0">
 							<ConceptCodePicker
 								system={parent?.system}
 								code={entry.code}
@@ -1238,7 +1399,7 @@ export function PropertiesTree() {
 						<span className="text-utility-yellow bg-utility-yellow/20 rounded-md p-1 shrink-0">
 							<Filter size={12} />
 						</span>
-						<div className="w-[152px] shrink-0">
+						<div className="w-[175px] shrink-0">
 							<InputView
 								placeholder="property"
 								value={entry.property}
@@ -1325,6 +1486,16 @@ export function PropertiesTree() {
 							</HSComp.Button>
 						</HSComp.DropdownMenuTrigger>
 						<HSComp.DropdownMenuContent align="start">
+							<HSComp.DropdownMenuItem
+								onSelect={() => addCodeSystem(kind, "concept")}
+							>
+								CodeSystem concepts
+							</HSComp.DropdownMenuItem>
+							<HSComp.DropdownMenuItem
+								onSelect={() => addCodeSystem(kind, "filter")}
+							>
+								CodeSystem filter
+							</HSComp.DropdownMenuItem>
 							<HSComp.DropdownMenuItem onSelect={() => addCodeSystem(kind)}>
 								CodeSystem
 							</HSComp.DropdownMenuItem>
@@ -1374,6 +1545,33 @@ export function PropertiesTree() {
 						</div>
 					</div>
 				);
+			case "status": {
+				const isMissing = missingFields.has("status");
+				return (
+					<div className="flex w-full items-center gap-2">
+						<div className="w-[226px] shrink-0">{labelView(item)}</div>
+						<div
+							className={`w-[200px] ${isMissing ? "ring-1 ring-border-error rounded-md" : ""}`}
+						>
+							<HSComp.Select
+								value={valueSet.status ?? ""}
+								onValueChange={updateStatus}
+							>
+								<HSComp.SelectTrigger className="h-7 py-1 px-2 bg-bg-primary border-none hover:bg-bg-quaternary focus:bg-bg-primary focus:ring-1 focus:ring-border-link group-hover/tree-item-label:bg-bg-tertiary">
+									<HSComp.SelectValue placeholder="status" />
+								</HSComp.SelectTrigger>
+								<HSComp.SelectContent>
+									{STATUSES.map((s) => (
+										<HSComp.SelectItem key={s} value={s}>
+											{s}
+										</HSComp.SelectItem>
+									))}
+								</HSComp.SelectContent>
+							</HSComp.Select>
+						</div>
+					</div>
+				);
+			}
 			case "description":
 				return (
 					<div className="flex w-full items-center gap-2">

--- a/src/components/ValueSet/properties-tree.tsx
+++ b/src/components/ValueSet/properties-tree.tsx
@@ -679,7 +679,7 @@ function ConceptCodePicker({
 				<div className="w-full">
 					<HSComp.Input
 						ref={inputRef}
-						placeholder="code"
+						placeholder="Code from system"
 						value={local}
 						onChange={(e) => {
 							setLocal(e.target.value);
@@ -957,25 +957,33 @@ export function PropertiesTree() {
 		"_exclude",
 	]);
 
-	// auto-expand each entry's nested sections so they're always visible
-	// when the row is opened (applies to both include and exclude)
+	// auto-expand each entry's nested sections on first appearance only.
+	// Without the `seen` ref this useEffect would re-expand every node on
+	// each render (because includes/excludes are re-derived arrays), undoing
+	// the user's manual collapse.
+	const autoExpandedRef = React.useRef<Set<string>>(new Set());
 	React.useEffect(() => {
+		const need: string[] = [];
+		const collect = (kind: IncludeKind, arr: typeof includes) => {
+			arr.forEach((_, i) => {
+				const row = `_${kind}_${i}`;
+				const c = `${row}_concept`;
+				const f = `${row}_filter`;
+				for (const id of [row, c, f]) {
+					if (!autoExpandedRef.current.has(id)) {
+						autoExpandedRef.current.add(id);
+						need.push(id);
+					}
+				}
+			});
+		};
+		collect("include", includes);
+		collect("exclude", excludes);
+		if (need.length === 0) return;
 		setExpandedItems((prev) => {
-			const need: string[] = [];
-			const collect = (kind: IncludeKind, arr: typeof includes) => {
-				arr.forEach((_, i) => {
-					const row = `_${kind}_${i}`;
-					const c = `${row}_concept`;
-					const f = `${row}_filter`;
-					if (!prev.includes(row)) need.push(row);
-					if (!prev.includes(c)) need.push(c);
-					if (!prev.includes(f)) need.push(f);
-				});
-			};
-			collect("include", includes);
-			collect("exclude", excludes);
-			if (need.length === 0) return prev;
-			return [...prev, ...need];
+			const missing = need.filter((id) => !prev.includes(id));
+			if (missing.length === 0) return prev;
+			return [...prev, ...missing];
 		});
 	}, [includes, excludes]);
 
@@ -1099,7 +1107,7 @@ export function PropertiesTree() {
 				if (isVsInclude(entry)) {
 					return (
 						<div className="flex w-full items-center gap-2">
-							<div className="w-[226px] shrink-0">
+							<div className="w-[202px] shrink-0">
 								<button
 									type="button"
 									className="uppercase px-1.5 py-0.5 cursor-pointer rounded-md text-text-info-primary bg-bg-info-primary"
@@ -1127,7 +1135,7 @@ export function PropertiesTree() {
 				}
 				return (
 					<div className="flex w-full items-center gap-2">
-						<div className="w-[226px] shrink-0">{labelView(item)}</div>
+						<div className="w-[202px] shrink-0">{labelView(item)}</div>
 						<CodeSystemPicker
 							system={entry.system}
 							version={entry.version}
@@ -1162,7 +1170,7 @@ export function PropertiesTree() {
 						<span className="text-utility-yellow bg-utility-yellow/20 rounded-md p-1 shrink-0">
 							<Tag size={12} />
 						</span>
-						<div className="w-[200px] shrink-0">
+						<div className="w-[152px] shrink-0">
 							<ConceptCodePicker
 								system={parent?.system}
 								code={entry.code}
@@ -1179,7 +1187,7 @@ export function PropertiesTree() {
 						</div>
 						<div className="flex-1 min-w-0">
 							<InputView
-								placeholder="display (optional)"
+								placeholder="Text to display for this code for this value set in this valueset"
 								value={entry.display}
 								onChange={(v) =>
 									updateConcept(kind, idx, ci, { display: v || undefined })
@@ -1230,7 +1238,7 @@ export function PropertiesTree() {
 						<span className="text-utility-yellow bg-utility-yellow/20 rounded-md p-1 shrink-0">
 							<Filter size={12} />
 						</span>
-						<div className="w-[160px] shrink-0">
+						<div className="w-[152px] shrink-0">
 							<InputView
 								placeholder="property"
 								value={entry.property}

--- a/src/components/ValueSet/result-panel.tsx
+++ b/src/components/ValueSet/result-panel.tsx
@@ -1,0 +1,175 @@
+import * as HSComp from "@health-samurai/react-components";
+import { Maximize2, Minimize2, PanelBottomClose, Timer } from "lucide-react";
+import * as React from "react";
+import { useLocalStorage } from "../../hooks";
+import { DataTableFooter } from "../data-table/footer";
+import { EmptyState } from "../empty-state";
+import { useValueSetContext } from "./context";
+
+const DEFAULT_PAGE_SIZE = 30;
+const PAGE_SIZE_STORAGE_KEY = "valueset-builder:result-page-size";
+
+function ResultBody({ page, pageSize }: { page: number; pageSize: number }) {
+	const { expansion, expandError, isExpanding } = useValueSetContext();
+
+	if (isExpanding) {
+		return (
+			<div className="flex items-center justify-center h-full text-text-secondary">
+				Expanding…
+			</div>
+		);
+	}
+
+	if (expandError) {
+		return (
+			<HSComp.OperationOutcomeView
+				resource={expandError}
+				className="h-full overflow-auto"
+			/>
+		);
+	}
+
+	if (!expansion) {
+		return (
+			<EmptyState
+				title="No expansion yet"
+				description="Click EXPAND to evaluate the ValueSet"
+				grayscale
+			/>
+		);
+	}
+
+	const contains = expansion.contains ?? [];
+	if (contains.length === 0) {
+		return (
+			<EmptyState
+				title="Empty expansion"
+				description="The ValueSet expanded successfully but contains no codes"
+			/>
+		);
+	}
+
+	const start = (page - 1) * pageSize;
+	const visibleRows = contains.slice(start, start + pageSize);
+
+	return (
+		<HSComp.Table zebra stickyHeader className="typo-code">
+			<HSComp.TableHeader className="z-0">
+				<HSComp.TableRow>
+					<HSComp.TableHead>Code</HSComp.TableHead>
+					<HSComp.TableHead>Display</HSComp.TableHead>
+					<HSComp.TableHead>System</HSComp.TableHead>
+					<HSComp.TableHead className="w-full p-0" />
+				</HSComp.TableRow>
+			</HSComp.TableHeader>
+			<HSComp.TableBody>
+				{visibleRows.map((row, i) => (
+					// biome-ignore lint/suspicious/noArrayIndexKey: row order is stable
+					<HSComp.TableRow key={start + i} zebra index={start + i}>
+						<HSComp.TableCell>{row.code ?? "—"}</HSComp.TableCell>
+						<HSComp.TableCell>{row.display ?? "—"}</HSComp.TableCell>
+						<HSComp.TableCell className="text-text-secondary">
+							{row.system ?? "—"}
+						</HSComp.TableCell>
+						<HSComp.TableCell className="p-0" />
+					</HSComp.TableRow>
+				))}
+			</HSComp.TableBody>
+		</HSComp.Table>
+	);
+}
+
+export function ResultPanel({
+	isMaximized,
+	onToggleMaximize,
+	onToggleCollapse,
+}: {
+	isMaximized: boolean;
+	onToggleMaximize: () => void;
+	onToggleCollapse: () => void;
+}) {
+	const { expansion, expandDurationMs } = useValueSetContext();
+	const [page, setPage] = React.useState(1);
+	const [pageSize, setPageSize] = useLocalStorage<number>({
+		key: PAGE_SIZE_STORAGE_KEY,
+		getInitialValueInEffect: false,
+		defaultValue: DEFAULT_PAGE_SIZE,
+	});
+	const total = expansion?.contains?.length ?? 0;
+	const totalPages = Math.max(1, Math.ceil(total / pageSize));
+
+	React.useEffect(() => {
+		setPage(1);
+	}, []);
+
+	React.useEffect(() => {
+		if (page > totalPages) setPage(totalPages);
+	}, [page, totalPages]);
+
+	return (
+		<div className="flex flex-col h-full overflow-hidden">
+			<div className="flex gap-1 items-center justify-between bg-bg-secondary pl-4 pr-2 border-b h-10 shrink-0">
+				<span className="typo-label text-text-secondary">
+					Expansion ({expansion?.total ?? total})
+				</span>
+				<div className="flex items-center gap-2">
+					{expandDurationMs != null && (
+						<span className="flex items-center text-text-secondary text-sm pl-2">
+							<Timer className="size-4 mr-1" strokeWidth={1.5} />
+							<span className="font-bold">{Math.round(expandDurationMs)}</span>
+							<span className="ml-1">ms</span>
+						</span>
+					)}
+					<HSComp.Tooltip>
+						<HSComp.TooltipTrigger asChild>
+							<HSComp.Button
+								variant="ghost"
+								size="small"
+								onClick={onToggleCollapse}
+							>
+								<PanelBottomClose className="w-4 h-4" />
+							</HSComp.Button>
+						</HSComp.TooltipTrigger>
+						<HSComp.TooltipContent align="end">Collapse</HSComp.TooltipContent>
+					</HSComp.Tooltip>
+					<HSComp.Tooltip>
+						<HSComp.TooltipTrigger asChild>
+							<HSComp.Button
+								variant="ghost"
+								size="small"
+								onClick={onToggleMaximize}
+							>
+								{isMaximized ? (
+									<Minimize2 className="w-4 h-4" />
+								) : (
+									<Maximize2 className="w-4 h-4" />
+								)}
+							</HSComp.Button>
+						</HSComp.TooltipTrigger>
+						<HSComp.TooltipContent align="end">
+							{isMaximized ? "Minimize" : "Maximize"}
+						</HSComp.TooltipContent>
+					</HSComp.Tooltip>
+				</div>
+			</div>
+			<div className="flex-1 min-h-0 flex flex-col">
+				<div className="flex-1 min-h-0">
+					<ResultBody page={page} pageSize={pageSize} />
+				</div>
+				{total > 0 && (
+					<DataTableFooter
+						total={total}
+						currentPage={page}
+						pageSize={pageSize}
+						selectedCount={0}
+						onPageChange={setPage}
+						onPageSizeChange={(size) => {
+							setPageSize(size);
+							setPage(1);
+						}}
+					/>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/src/components/ValueSet/types.ts
+++ b/src/components/ValueSet/types.ts
@@ -1,0 +1,51 @@
+import type { Resource } from "@aidbox-ui/fhir-types/hl7-fhir-r5-core";
+
+export type ValueSetExpansionContains = {
+	system?: string;
+	code?: string;
+	display?: string;
+	version?: string;
+	inactive?: boolean;
+};
+
+export type ValueSetExpansion = {
+	identifier?: string;
+	timestamp?: string;
+	total?: number;
+	offset?: number;
+	contains?: ValueSetExpansionContains[];
+};
+
+export type ValueSetIncludeConcept = {
+	code?: string;
+	display?: string;
+};
+
+export type ValueSetIncludeFilter = {
+	property?: string;
+	op?: string;
+	value?: string;
+};
+
+export type ValueSetInclude = {
+	system?: string;
+	version?: string;
+	concept?: ValueSetIncludeConcept[];
+	filter?: ValueSetIncludeFilter[];
+	valueSet?: string[];
+};
+
+export type ValueSetCompose = {
+	include?: ValueSetInclude[];
+	exclude?: ValueSetInclude[];
+};
+
+export type ValueSet = Resource & {
+	resourceType: "ValueSet";
+	url?: string;
+	version?: string;
+	title?: string;
+	description?: string;
+	compose?: ValueSetCompose;
+	expansion?: ValueSetExpansion;
+};

--- a/src/components/ValueSet/types.ts
+++ b/src/components/ValueSet/types.ts
@@ -40,11 +40,14 @@ export type ValueSetCompose = {
 	exclude?: ValueSetInclude[];
 };
 
+export type ValueSetStatus = "draft" | "active" | "retired" | "unknown";
+
 export type ValueSet = Resource & {
 	resourceType: "ValueSet";
 	url?: string;
 	version?: string;
 	title?: string;
+	status?: ValueSetStatus;
 	description?: string;
 	compose?: ValueSetCompose;
 	expansion?: ValueSetExpansion;

--- a/src/components/ValueSet/valueset-hash.ts
+++ b/src/components/ValueSet/valueset-hash.ts
@@ -1,0 +1,6 @@
+import { cleanEmptyValues } from "../../utils/clean-empty-values";
+import type { ValueSet } from "./types";
+
+export function computeValueSetHash(vs: ValueSet): string {
+	return JSON.stringify(cleanEmptyValues(vs));
+}

--- a/src/utils/clean-empty-values.ts
+++ b/src/utils/clean-empty-values.ts
@@ -1,0 +1,37 @@
+export function cleanEmptyValues<T>(obj: T): T {
+	if (Array.isArray(obj)) {
+		const cleanedArray = obj
+			.map((item) => cleanEmptyValues(item))
+			.filter((item) => {
+				if (item === null || item === undefined) return false;
+				if (typeof item === "string" && item === "") return false;
+				if (Array.isArray(item) && item.length === 0) return false;
+				if (
+					typeof item === "object" &&
+					!Array.isArray(item) &&
+					Object.keys(item as Record<string, unknown>).length === 0
+				)
+					return false;
+				return true;
+			});
+		return cleanedArray as T;
+	}
+	if (obj !== null && typeof obj === "object") {
+		const cleanedObj: Record<string, unknown> = {};
+		for (const [key, value] of Object.entries(obj)) {
+			const cleanedValue = cleanEmptyValues(value);
+			if (cleanedValue === null || cleanedValue === undefined) continue;
+			if (typeof cleanedValue === "string" && cleanedValue === "") continue;
+			if (Array.isArray(cleanedValue) && cleanedValue.length === 0) continue;
+			if (
+				typeof cleanedValue === "object" &&
+				!Array.isArray(cleanedValue) &&
+				Object.keys(cleanedValue as Record<string, unknown>).length === 0
+			)
+				continue;
+			cleanedObj[key] = cleanedValue;
+		}
+		return cleanedObj as T;
+	}
+	return obj;
+}


### PR DESCRIPTION
## Summary

- **CodeSystem Builder** — edit form with metadata, concept list, properties, hierarchical child concepts.
- **ValueSet Builder** — compose authoring (`+ Include / + Exclude` with CodeSystem concepts / CodeSystem filter / CodeSystem / ValueSet presets), URL & version pickers with `|version` pipe-syntax, concept code autocomplete via inline `$expand+filter`, filter op dropdown (sorted by corpus frequency), required-field highlighting (status), pipe-syntax for version in both CS and VS pickers.
- **ValueSet expansion preview** — bottom panel with `$expand` result table (paginated), collapse / maximize / close controls.
- **ValueSet Graph tab** — resolves `compose.include/exclude` and `CodeSystem.supplements` canonical refs into a DAG; ReactFlow with barycenter ordering, multi-handles per node, edge legend showing only present kinds. Click a node opens a resizable side detail panel with link to the resource. `EXPAND` action on every VS node (POST for unsaved root, GET by url+version for the rest); `CONTENT` action on `CodeSystem` (`content=complete`) flattens the inline concept tree into a table.

## Test plan
- [ ] Open a brand-new ValueSet, fill compose with each preset (CodeSystem concepts / filter / plain / ValueSet); confirm tree behaviour: row expands on insert, URL focus is auto-grabbed, picking a hit from the popover does **not** collapse the row, version pipe-syntax pre-fills available versions.
- [ ] Save with empty `status` — confirm red ring on the field, no PUT is sent; pick a status — ring disappears, save goes through.
- [ ] Click `EXPAND` from the editor toolbar and from a VS node in the Graph; confirm result table, pagination, timer, close / collapse / maximize buttons.
- [ ] Open the Graph tab on a rich VS (e.g. `http://hl7.org/fhir/ValueSet/use-context`); verify barycenter layout, click-to-highlight neighbours, legend shows only relevant edge kinds.
- [ ] Click `CONTENT` on a `CodeSystem` with `content=complete`; confirm the table switches columns (Code / Display / Definition / Parent / Depth).
- [ ] Click any node — side panel opens with the right metadata, resource link works.
- [ ] Open CodeSystem Builder; add metadata, concepts with child concepts and properties; save; reopen and confirm round-trip.