### PR TITLE
ConceptMap Builder

### DIFF
--- a/src/components/ConceptMap/builder-content.tsx
+++ b/src/components/ConceptMap/builder-content.tsx
@@ -1,11 +1,13 @@
 import * as HSComp from "@health-samurai/react-components";
 import { useMutation } from "@tanstack/react-query";
+import * as React from "react";
 import { useAidboxClient } from "../../AidboxClient";
 import * as Utils from "../../api/utils";
 import { cleanEmptyValues } from "../../utils/clean-empty-values";
 import { useConceptMapContext } from "./context";
 import { EditorHeaderMenu } from "./header-menu";
 import { PropertiesTree } from "./properties-tree";
+import { TranslatePanel } from "./translate-panel";
 import type { ConceptMap } from "./types";
 
 function toOperationOutcome(err: unknown): HSComp.OperationOutcome {
@@ -32,6 +34,7 @@ function toOperationOutcome(err: unknown): HSComp.OperationOutcome {
 export const ConceptMapBuilderContent = () => {
 	const client = useAidboxClient();
 	const { conceptMap } = useConceptMapContext();
+	const [translateOpen, setTranslateOpen] = React.useState(false);
 
 	const saveMutation = useMutation({
 		mutationFn: async () => {
@@ -76,12 +79,17 @@ export const ConceptMapBuilderContent = () => {
 				<EditorHeaderMenu
 					onSave={() => saveMutation.mutate()}
 					isSaveDisabled={saveMutation.isPending}
+					onTranslate={() => setTranslateOpen((v) => !v)}
+					isTranslateActive={translateOpen}
 				/>
 				<div className="flex-1 min-h-0 overflow-auto">
 					<div className="min-h-full bg-bg-primary px-2.5 pt-3 pb-[250px]">
 						<PropertiesTree />
 					</div>
 				</div>
+				{translateOpen && (
+					<TranslatePanel onClose={() => setTranslateOpen(false)} />
+				)}
 			</div>
 		</div>
 	);

--- a/src/components/ConceptMap/builder-content.tsx
+++ b/src/components/ConceptMap/builder-content.tsx
@@ -1,9 +1,12 @@
 import * as HSComp from "@health-samurai/react-components";
 import { useMutation } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
 import * as React from "react";
 import { useAidboxClient } from "../../AidboxClient";
 import * as Utils from "../../api/utils";
+import { useLocalStorage } from "../../hooks";
 import { cleanEmptyValues } from "../../utils/clean-empty-values";
+import { addUrlToHistory } from "../../utils/url-history";
 import { useConceptMapContext } from "./context";
 import { EditorHeaderMenu } from "./header-menu";
 import { PropertiesTree } from "./properties-tree";
@@ -33,8 +36,24 @@ function toOperationOutcome(err: unknown): HSComp.OperationOutcome {
 
 export const ConceptMapBuilderContent = () => {
 	const client = useAidboxClient();
+	const navigate = useNavigate();
 	const { conceptMap } = useConceptMapContext();
-	const [translateOpen, setTranslateOpen] = React.useState(false);
+	const [translateOpen, setTranslateOpen] = useLocalStorage<boolean>({
+		key: "conceptMap-translatePanelOpen",
+		defaultValue: false,
+		getInitialValueInEffect: false,
+	});
+
+	const handleToggleTranslate = () => setTranslateOpen((prev) => !prev);
+
+	React.useEffect(() => {
+		if (!translateOpen) return;
+		const handleEscape = (e: KeyboardEvent) => {
+			if (e.key === "Escape") setTranslateOpen(false);
+		};
+		document.addEventListener("keydown", handleEscape);
+		return () => document.removeEventListener("keydown", handleEscape);
+	}, [translateOpen, setTranslateOpen]);
 
 	const saveMutation = useMutation({
 		mutationFn: async () => {
@@ -58,11 +77,25 @@ export const ConceptMapBuilderContent = () => {
 			if (result.isErr()) throw result.value.resource;
 			return result.value.resource;
 		},
-		onSuccess: () => {
+		onSuccess: (saved) => {
+			addUrlToHistory("conceptmap-builder:url-history", conceptMap.url);
 			HSComp.toast.success("ConceptMap saved successfully", {
 				position: "bottom-right",
 				style: { margin: "1rem" },
 			});
+			// Redirect /create → /edit/{id} after first POST so the URL reflects
+			// the freshly created resource (and reloads work).
+			if (!conceptMap.id && saved.id) {
+				navigate({
+					to: "/resource/$resourceType/edit/$id",
+					params: { resourceType: "ConceptMap", id: saved.id },
+					search: {
+						tab: "builder" as const,
+						mode: "json" as const,
+						builderTab: "form" as const,
+					},
+				});
+			}
 		},
 		onError: (err) => {
 			const oo = toOperationOutcome(err);
@@ -74,23 +107,36 @@ export const ConceptMapBuilderContent = () => {
 	});
 
 	return (
-		<div className="relative h-full grow min-h-0 flex flex-col">
-			<div className="flex flex-col h-full">
-				<EditorHeaderMenu
-					onSave={() => saveMutation.mutate()}
-					isSaveDisabled={saveMutation.isPending}
-					onTranslate={() => setTranslateOpen((v) => !v)}
-					isTranslateActive={translateOpen}
-				/>
-				<div className="flex-1 min-h-0 overflow-auto">
-					<div className="min-h-full bg-bg-primary px-2.5 pt-3 pb-[250px]">
-						<PropertiesTree />
+		<div className="relative h-full grow min-h-0 flex flex-col overflow-hidden">
+			<HSComp.ResizablePanelGroup
+				direction="horizontal"
+				autoSaveId="conceptmap-builder-horizontal"
+				className="grow min-h-0"
+			>
+				<HSComp.ResizablePanel minSize={20}>
+					<div className="flex flex-col h-full">
+						<EditorHeaderMenu
+							onSave={() => saveMutation.mutate()}
+							isSaveDisabled={saveMutation.isPending}
+							onTranslate={handleToggleTranslate}
+							isTranslateActive={translateOpen}
+						/>
+						<div className="flex-1 min-h-0 overflow-auto">
+							<div className="min-h-full bg-bg-primary px-2.5 pt-3 pb-[250px]">
+								<PropertiesTree />
+							</div>
+						</div>
 					</div>
-				</div>
+				</HSComp.ResizablePanel>
 				{translateOpen && (
-					<TranslatePanel onClose={() => setTranslateOpen(false)} />
+					<>
+						<HSComp.ResizableHandle />
+						<HSComp.ResizablePanel minSize={20}>
+							<TranslatePanel onClose={() => setTranslateOpen(false)} />
+						</HSComp.ResizablePanel>
+					</>
 				)}
-			</div>
+			</HSComp.ResizablePanelGroup>
 		</div>
 	);
 };

--- a/src/components/ConceptMap/builder-content.tsx
+++ b/src/components/ConceptMap/builder-content.tsx
@@ -1,0 +1,88 @@
+import * as HSComp from "@health-samurai/react-components";
+import { useMutation } from "@tanstack/react-query";
+import { useAidboxClient } from "../../AidboxClient";
+import * as Utils from "../../api/utils";
+import { cleanEmptyValues } from "../../utils/clean-empty-values";
+import { useConceptMapContext } from "./context";
+import { EditorHeaderMenu } from "./header-menu";
+import { PropertiesTree } from "./properties-tree";
+import type { ConceptMap } from "./types";
+
+function toOperationOutcome(err: unknown): HSComp.OperationOutcome {
+	if (
+		typeof err === "object" &&
+		err !== null &&
+		"resourceType" in err &&
+		(err as { resourceType: string }).resourceType === "OperationOutcome"
+	) {
+		return err as unknown as HSComp.OperationOutcome;
+	}
+	return {
+		resourceType: "OperationOutcome",
+		issue: [
+			{
+				severity: "error",
+				code: "exception",
+				diagnostics: err instanceof Error ? err.message : String(err),
+			},
+		],
+	};
+}
+
+export const ConceptMapBuilderContent = () => {
+	const client = useAidboxClient();
+	const { conceptMap } = useConceptMapContext();
+
+	const saveMutation = useMutation({
+		mutationFn: async () => {
+			const payload = cleanEmptyValues(conceptMap);
+			if (payload.id) {
+				const result = await client.request<ConceptMap>({
+					method: "PUT",
+					url: `/fhir/ConceptMap/${payload.id}`,
+					body: JSON.stringify(payload),
+					headers: { "Content-Type": "application/json" },
+				});
+				if (result.isErr()) throw result.value.resource;
+				return result.value.resource;
+			}
+			const result = await client.request<ConceptMap>({
+				method: "POST",
+				url: "/fhir/ConceptMap",
+				body: JSON.stringify(payload),
+				headers: { "Content-Type": "application/json" },
+			});
+			if (result.isErr()) throw result.value.resource;
+			return result.value.resource;
+		},
+		onSuccess: () => {
+			HSComp.toast.success("ConceptMap saved successfully", {
+				position: "bottom-right",
+				style: { margin: "1rem" },
+			});
+		},
+		onError: (err) => {
+			const oo = toOperationOutcome(err);
+			Utils.toastError(
+				"Failed to save ConceptMap",
+				oo.issue?.[0]?.diagnostics ?? undefined,
+			);
+		},
+	});
+
+	return (
+		<div className="relative h-full grow min-h-0 flex flex-col">
+			<div className="flex flex-col h-full">
+				<EditorHeaderMenu
+					onSave={() => saveMutation.mutate()}
+					isSaveDisabled={saveMutation.isPending}
+				/>
+				<div className="flex-1 min-h-0 overflow-auto">
+					<div className="min-h-full bg-bg-primary px-2.5 pt-3 pb-[250px]">
+						<PropertiesTree />
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+};

--- a/src/components/ConceptMap/context.ts
+++ b/src/components/ConceptMap/context.ts
@@ -1,0 +1,20 @@
+import * as React from "react";
+import type { ConceptMap } from "./types";
+
+export type ConceptMapContextValue = {
+	conceptMap: ConceptMap;
+	updateConceptMap: (updater: (cm: ConceptMap) => ConceptMap) => void;
+};
+
+export const ConceptMapContext =
+	React.createContext<ConceptMapContextValue | null>(null);
+
+export function useConceptMapContext(): ConceptMapContextValue {
+	const ctx = React.useContext(ConceptMapContext);
+	if (!ctx) {
+		throw new Error(
+			"useConceptMapContext must be used within ConceptMapProvider",
+		);
+	}
+	return ctx;
+}

--- a/src/components/ConceptMap/header-menu.tsx
+++ b/src/components/ConceptMap/header-menu.tsx
@@ -1,12 +1,16 @@
 import * as HSComp from "@health-samurai/react-components";
-import { SaveIcon } from "lucide-react";
+import { ArrowRightLeft, SaveIcon } from "lucide-react";
 
 export function EditorHeaderMenu({
 	onSave,
+	onTranslate,
 	isSaveDisabled,
+	isTranslateActive,
 }: {
 	onSave: () => void;
+	onTranslate: () => void;
 	isSaveDisabled?: boolean;
+	isTranslateActive?: boolean;
 }) {
 	return (
 		<div className="flex items-center justify-between bg-bg-secondary flex-none h-10 border-b">
@@ -20,6 +24,15 @@ export function EditorHeaderMenu({
 				>
 					<SaveIcon className="w-4 h-4" />
 					Save
+				</HSComp.Button>
+				<HSComp.Button
+					variant="ghost"
+					size="small"
+					className={`px-0! ${isTranslateActive ? "text-text-info-primary" : ""}`}
+					onClick={onTranslate}
+				>
+					<ArrowRightLeft className="w-4 h-4" />
+					Translate
 				</HSComp.Button>
 			</div>
 		</div>

--- a/src/components/ConceptMap/header-menu.tsx
+++ b/src/components/ConceptMap/header-menu.tsx
@@ -1,0 +1,27 @@
+import * as HSComp from "@health-samurai/react-components";
+import { SaveIcon } from "lucide-react";
+
+export function EditorHeaderMenu({
+	onSave,
+	isSaveDisabled,
+}: {
+	onSave: () => void;
+	isSaveDisabled?: boolean;
+}) {
+	return (
+		<div className="flex items-center justify-between bg-bg-secondary flex-none h-10 border-b">
+			<div className="flex items-center gap-4 px-4">
+				<HSComp.Button
+					variant="ghost"
+					size="small"
+					className="px-0!"
+					onClick={onSave}
+					disabled={isSaveDisabled}
+				>
+					<SaveIcon className="w-4 h-4" />
+					Save
+				</HSComp.Button>
+			</div>
+		</div>
+	);
+}

--- a/src/components/ConceptMap/header-menu.tsx
+++ b/src/components/ConceptMap/header-menu.tsx
@@ -25,15 +25,16 @@ export function EditorHeaderMenu({
 					<SaveIcon className="w-4 h-4" />
 					Save
 				</HSComp.Button>
-				<HSComp.Button
-					variant="ghost"
-					size="small"
-					className={`px-0! ${isTranslateActive ? "text-text-info-primary" : ""}`}
-					onClick={onTranslate}
+			</div>
+			<div className="flex items-center gap-1 px-2">
+				<HSComp.Toggle
+					variant="outline"
+					pressed={!!isTranslateActive}
+					onPressedChange={onTranslate}
 				>
 					<ArrowRightLeft className="w-4 h-4" />
-					Translate
-				</HSComp.Button>
+					Translation
+				</HSComp.Toggle>
 			</div>
 		</div>
 	);

--- a/src/components/ConceptMap/page.tsx
+++ b/src/components/ConceptMap/page.tsx
@@ -1,0 +1,34 @@
+import type { Resource } from "@aidbox-ui/fhir-types/hl7-fhir-r5-core";
+import * as React from "react";
+import { ConceptMapContext } from "./context";
+import type { ConceptMap } from "./types";
+
+export function ConceptMapProvider({
+	initialResource,
+	children,
+}: {
+	initialResource: Resource;
+	children: React.ReactNode;
+}) {
+	const [conceptMap, setConceptMap] = React.useState<ConceptMap>(() => {
+		const cm = initialResource as ConceptMap;
+		if (cm.id) return cm;
+		const patch: Partial<ConceptMap> = {};
+		if (!cm.version) patch.version = "1.0.0";
+		if (!cm.status) patch.status = "draft";
+		return Object.keys(patch).length > 0 ? { ...cm, ...patch } : cm;
+	});
+
+	const updateConceptMap = React.useCallback(
+		(updater: (cm: ConceptMap) => ConceptMap) => {
+			setConceptMap((prev) => updater(prev));
+		},
+		[],
+	);
+
+	return (
+		<ConceptMapContext.Provider value={{ conceptMap, updateConceptMap }}>
+			{children}
+		</ConceptMapContext.Provider>
+	);
+}

--- a/src/components/ConceptMap/properties-tree.tsx
+++ b/src/components/ConceptMap/properties-tree.tsx
@@ -15,6 +15,7 @@ import type {
 	ConceptMapGroup,
 	ConceptMapTarget,
 } from "./types";
+import { isR4Like, useFhirServerVersion } from "./version";
 
 type ItemMeta = {
 	type:
@@ -62,28 +63,6 @@ const EQUIVALENCES_R4 = [
 	"unmatched",
 	"disjoint",
 ] as const;
-
-// "4.0.x" / "4.3.x" → R4-style (equivalence). "5.x", "6.x", … → R5-style (relationship).
-const isR4Like = (fhirVersion?: string): boolean =>
-	!!fhirVersion &&
-	(fhirVersion.startsWith("4.0") || fhirVersion.startsWith("4.3"));
-
-function useFhirServerVersion(): string | undefined {
-	const client = useAidboxClient();
-	const { data } = useQuery({
-		queryKey: ["fhir-metadata-version"],
-		queryFn: async () => {
-			const res = await client.request<{ fhirVersion?: string }>({
-				method: "GET",
-				url: "/fhir/metadata?_elements=fhirVersion",
-			});
-			if (res.isErr()) return undefined;
-			return res.value.resource.fhirVersion;
-		},
-		staleTime: Number.POSITIVE_INFINITY,
-	});
-	return data;
-}
 
 type CodeSystemHit = {
 	id?: string;

--- a/src/components/ConceptMap/properties-tree.tsx
+++ b/src/components/ConceptMap/properties-tree.tsx
@@ -1,0 +1,1695 @@
+import * as HSComp from "@health-samurai/react-components";
+import {
+	type ItemInstance,
+	TreeView,
+	type TreeViewItem,
+} from "@health-samurai/react-components";
+import { useQuery } from "@tanstack/react-query";
+import { ArrowRight, Link2, Plus, X } from "lucide-react";
+import * as React from "react";
+import { useAidboxClient } from "../../AidboxClient";
+import { useConceptMapContext } from "./context";
+import type {
+	ConceptMap,
+	ConceptMapElement,
+	ConceptMapGroup,
+	ConceptMapTarget,
+} from "./types";
+
+type ItemMeta = {
+	type:
+		| "properties"
+		| "url"
+		| "version"
+		| "status"
+		| "title"
+		| "description"
+		| "source"
+		| "target"
+		| "groups"
+		| "group-row"
+		| "group-add"
+		| "elements-section"
+		| "element-row"
+		| "element-add"
+		| "unmapped-row";
+	groupIndex?: number;
+	elementIndex?: number;
+};
+
+const STATUSES = ["draft", "active", "retired", "unknown"] as const;
+type ConceptMapStatus = (typeof STATUSES)[number];
+
+// R5+ ConceptMap.group.element.target.relationship value set
+const RELATIONSHIPS_R5 = [
+	"related-to",
+	"equivalent",
+	"source-is-narrower-than-target",
+	"source-is-broader-than-target",
+	"not-related-to",
+] as const;
+
+// R4/R4B ConceptMap.group.element.target.equivalence value set
+const EQUIVALENCES_R4 = [
+	"relatedto",
+	"equivalent",
+	"equal",
+	"wider",
+	"subsumes",
+	"narrower",
+	"specializes",
+	"inexact",
+	"unmatched",
+	"disjoint",
+] as const;
+
+// "4.0.x" / "4.3.x" → R4-style (equivalence). "5.x", "6.x", … → R5-style (relationship).
+const isR4Like = (fhirVersion?: string): boolean =>
+	!!fhirVersion &&
+	(fhirVersion.startsWith("4.0") || fhirVersion.startsWith("4.3"));
+
+function useFhirServerVersion(): string | undefined {
+	const client = useAidboxClient();
+	const { data } = useQuery({
+		queryKey: ["fhir-metadata-version"],
+		queryFn: async () => {
+			const res = await client.request<{ fhirVersion?: string }>({
+				method: "GET",
+				url: "/fhir/metadata?_elements=fhirVersion",
+			});
+			if (res.isErr()) return undefined;
+			return res.value.resource.fhirVersion;
+		},
+		staleTime: Number.POSITIVE_INFINITY,
+	});
+	return data;
+}
+
+type CodeSystemHit = {
+	id?: string;
+	url?: string;
+	name?: string;
+	title?: string;
+	version?: string;
+	description?: string;
+};
+
+function parseSystemPipeVersion(raw: string): {
+	system?: string;
+	version?: string;
+} {
+	const pipe = raw.indexOf("|");
+	if (pipe < 0) {
+		const s = raw.trim();
+		return { system: s || undefined, version: undefined };
+	}
+	const s = raw.slice(0, pipe).trim();
+	const v = raw.slice(pipe + 1).trim();
+	return { system: s || undefined, version: v || undefined };
+}
+
+function formatSystemPipeVersion(
+	system: string | undefined,
+	version: string | undefined,
+): string {
+	if (version) return `${system ?? ""}|${version}`;
+	return system ?? "";
+}
+
+function CodeSystemPicker({
+	system,
+	version,
+	onChange,
+	placeholder = "CodeSystem canonical URL",
+}: {
+	system?: string;
+	version?: string;
+	onChange: (next: { system?: string; version?: string }) => void;
+	placeholder?: string;
+}) {
+	const client = useAidboxClient();
+	const formatted = formatSystemPipeVersion(system, version);
+	const [local, setLocal] = React.useState(formatted);
+	const [debounced, setDebounced] = React.useState(local);
+	const [open, setOpen] = React.useState(false);
+	const [activeIndex, setActiveIndex] = React.useState(-1);
+	const itemRefs = React.useRef<Array<HTMLButtonElement | null>>([]);
+	const inputRef = React.useRef<HTMLInputElement | null>(null);
+	const measureRef = React.useRef<HTMLSpanElement | null>(null);
+	const [inputWidthPx, setInputWidthPx] = React.useState(200);
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: deps drive re-measurement of the span when text changes
+	React.useLayoutEffect(() => {
+		const input = inputRef.current;
+		const span = measureRef.current;
+		if (!input || !span) return;
+		// Copy the real input's font + sizing onto the measuring span so the
+		// measured width matches what's actually rendered inside the input.
+		const cs = getComputedStyle(input);
+		span.style.font = cs.font;
+		span.style.fontFamily = cs.fontFamily;
+		span.style.fontSize = cs.fontSize;
+		span.style.fontWeight = cs.fontWeight;
+		span.style.letterSpacing = cs.letterSpacing;
+		const padX =
+			Number.parseFloat(cs.paddingLeft) + Number.parseFloat(cs.paddingRight);
+		const borderX =
+			Number.parseFloat(cs.borderLeftWidth) +
+			Number.parseFloat(cs.borderRightWidth);
+		const caret = 2;
+		const w = span.offsetWidth + padX + borderX + caret;
+		setInputWidthPx(Math.max(200, Math.ceil(w)));
+	}, [local, placeholder]);
+
+	React.useEffect(() => {
+		setLocal(formatted);
+	}, [formatted]);
+
+	React.useEffect(() => {
+		const t = setTimeout(() => setDebounced(local), 250);
+		return () => clearTimeout(t);
+	}, [local]);
+
+	const pipeIdx = debounced.indexOf("|");
+	const mode: "system" | "version" = pipeIdx >= 0 ? "version" : "system";
+	const systemPart =
+		pipeIdx >= 0 ? debounced.slice(0, pipeIdx).trim() : debounced.trim();
+	const versionPart = pipeIdx >= 0 ? debounced.slice(pipeIdx + 1).trim() : "";
+
+	const { data: systemHits } = useQuery({
+		queryKey: ["conceptmap-builder", "codesystem-picker", "system", systemPart],
+		enabled: mode === "system",
+		queryFn: async () => {
+			const params = new URLSearchParams({
+				_count: "15",
+				_sort: "-_lastUpdated",
+				_elements: "url,name,title,version,description",
+			});
+			if (systemPart) params.set("url:contains", systemPart);
+			const res = await client.request<{
+				entry?: Array<{ resource: CodeSystemHit }>;
+			}>({
+				method: "GET",
+				url: `/fhir/CodeSystem?${params.toString()}`,
+			});
+			if (res.isErr()) return [];
+			return (res.value.resource.entry ?? [])
+				.map((e) => e.resource)
+				.filter((r): r is CodeSystemHit & { url: string } => !!r.url);
+		},
+		staleTime: 30_000,
+	});
+
+	const { data: versionHits } = useQuery({
+		queryKey: [
+			"conceptmap-builder",
+			"codesystem-picker",
+			"versions",
+			systemPart,
+		],
+		enabled: mode === "version" && systemPart.length > 0,
+		queryFn: async () => {
+			const params = new URLSearchParams({
+				_count: "100",
+				_sort: "-_lastUpdated",
+				_elements: "url,name,title,version",
+				url: systemPart,
+			});
+			const res = await client.request<{
+				entry?: Array<{ resource: CodeSystemHit }>;
+			}>({
+				method: "GET",
+				url: `/fhir/CodeSystem?${params.toString()}`,
+			});
+			if (res.isErr()) return [];
+			const seen = new Set<string>();
+			const out: Array<CodeSystemHit & { url: string; version: string }> = [];
+			for (const e of res.value.resource.entry ?? []) {
+				const r = e.resource;
+				if (!r.url || !r.version) continue;
+				if (seen.has(r.version)) continue;
+				seen.add(r.version);
+				out.push({ ...r, url: r.url, version: r.version });
+			}
+			return out;
+		},
+		staleTime: 30_000,
+	});
+
+	const commit = (raw: string) => {
+		setLocal(raw);
+		const parsed = parseSystemPipeVersion(raw);
+		if (parsed.system !== system || parsed.version !== version) {
+			onChange(parsed);
+		}
+	};
+
+	const selectSystemHit = (h: CodeSystemHit & { url: string }) => {
+		const next = { system: h.url, version: undefined };
+		setLocal(formatSystemPipeVersion(next.system, next.version));
+		onChange(next);
+		setOpen(false);
+		setActiveIndex(-1);
+	};
+
+	const selectVersionHit = (
+		h: CodeSystemHit & { url: string; version: string },
+	) => {
+		const next = { system: systemPart || h.url, version: h.version };
+		setLocal(formatSystemPipeVersion(next.system, next.version));
+		onChange(next);
+		setOpen(false);
+		setActiveIndex(-1);
+	};
+
+	const hitsList =
+		mode === "version"
+			? (versionHits ?? []).filter(
+					(h) => !versionPart || h.version.includes(versionPart),
+				)
+			: (systemHits ?? []);
+
+	const onSelectActive = () => {
+		const h = hitsList[activeIndex];
+		if (!h) return;
+		if (mode === "version") {
+			selectVersionHit(h as CodeSystemHit & { url: string; version: string });
+		} else {
+			selectSystemHit(h);
+		}
+	};
+
+	const hitsLength = hitsList.length;
+	React.useEffect(() => {
+		setActiveIndex(hitsLength > 0 ? 0 : -1);
+	}, [hitsLength]);
+
+	React.useEffect(() => {
+		if (activeIndex < 0) return;
+		itemRefs.current[activeIndex]?.scrollIntoView({ block: "nearest" });
+	}, [activeIndex]);
+
+	return (
+		<HSComp.Popover open={open} onOpenChange={setOpen}>
+			<HSComp.PopoverAnchor asChild>
+				<div className="shrink-0" style={{ width: `${inputWidthPx}px` }}>
+					<HSComp.Input
+						ref={inputRef}
+						placeholder={placeholder}
+						value={local}
+						onChange={(e) => {
+							setLocal(e.target.value);
+							setOpen(true);
+						}}
+						onClick={(e) => {
+							e.stopPropagation();
+							setOpen(true);
+						}}
+						onFocus={() => setOpen(true)}
+						onBlur={(e) => {
+							const next = e.relatedTarget as HTMLElement | null;
+							if (next?.closest("[data-cs-picker-popover='true']")) return;
+							commit(local);
+							setOpen(false);
+						}}
+						onKeyDown={(e) => {
+							if (e.key === "ArrowDown") {
+								e.preventDefault();
+								if (hitsList.length === 0) return;
+								setOpen(true);
+								setActiveIndex((i) => (i + 1) % hitsList.length);
+							} else if (e.key === "ArrowUp") {
+								e.preventDefault();
+								if (hitsList.length === 0) return;
+								setOpen(true);
+								setActiveIndex((i) => (i <= 0 ? hitsList.length - 1 : i - 1));
+							} else if (e.key === "Enter") {
+								e.preventDefault();
+								if (open && activeIndex >= 0 && hitsList[activeIndex]) {
+									onSelectActive();
+								} else {
+									commit(local);
+									setOpen(false);
+								}
+							} else if (e.key === "Escape") {
+								setOpen(false);
+								setActiveIndex(-1);
+							}
+						}}
+						onMouseDown={(e) => e.stopPropagation()}
+						className="h-7 py-1 px-2 bg-bg-primary border-none hover:bg-bg-quaternary focus:bg-bg-primary group-hover/tree-item-label:bg-bg-tertiary focus:ring-1 focus:ring-border-link font-mono text-xs"
+					/>
+					<span
+						ref={measureRef}
+						aria-hidden="true"
+						className="input-measure font-mono text-xs"
+					>
+						{local || placeholder}
+					</span>
+				</div>
+			</HSComp.PopoverAnchor>
+			<HSComp.PopoverContent
+				data-cs-picker-popover="true"
+				className="w-[var(--radix-popover-trigger-width)] min-w-[480px] p-0 max-h-80 overflow-auto"
+				align="start"
+				onOpenAutoFocus={(e) => e.preventDefault()}
+				onInteractOutside={(e) => {
+					if (e.target === inputRef.current) e.preventDefault();
+				}}
+			>
+				{mode === "version" && !systemPart ? (
+					<div className="px-3 py-2 text-text-secondary text-sm">
+						Type a CodeSystem URL before <code>|</code>
+					</div>
+				) : hitsList.length === 0 ? (
+					<div className="px-3 py-2 text-text-secondary text-sm">
+						{mode === "version" ? "No versions found" : "No matches"}
+					</div>
+				) : (
+					<ul className="py-1">
+						{hitsList.map((h, i) => {
+							const isActive = i === activeIndex;
+							if (mode === "version") {
+								const ver = h.version ?? "";
+								const secondary = h.title || h.name || h.id || h.url;
+								return (
+									<li key={`${h.url}|${ver}`}>
+										<button
+											ref={(el) => {
+												itemRefs.current[i] = el;
+											}}
+											type="button"
+											onClick={(e) => {
+												e.stopPropagation();
+												selectVersionHit(
+													h as CodeSystemHit & {
+														url: string;
+														version: string;
+													},
+												);
+											}}
+											onMouseEnter={() => setActiveIndex(i)}
+											className={`w-full text-left px-3 py-1.5 focus:outline-none ${isActive ? "bg-bg-tertiary" : ""}`}
+										>
+											<div className="typo-body text-text-primary truncate font-mono">
+												{ver}
+											</div>
+											<div className="typo-body-xs text-text-secondary line-clamp-1">
+												{secondary}
+											</div>
+										</button>
+									</li>
+								);
+							}
+							const title = h.title || h.name || h.id || h.url;
+							const secondary = h.description || h.url;
+							return (
+								<li key={`${h.url}|${h.version ?? ""}`}>
+									<button
+										ref={(el) => {
+											itemRefs.current[i] = el;
+										}}
+										type="button"
+										onClick={(e) => {
+											e.stopPropagation();
+											selectSystemHit(h);
+										}}
+										onMouseEnter={() => setActiveIndex(i)}
+										className={`w-full text-left px-3 py-1.5 focus:outline-none ${isActive ? "bg-bg-tertiary" : ""}`}
+									>
+										<div className="typo-body text-text-primary truncate">
+											{title}
+										</div>
+										<div className="typo-body-xs text-text-secondary line-clamp-1 font-mono">
+											{secondary}
+										</div>
+									</button>
+								</li>
+							);
+						})}
+					</ul>
+				)}
+			</HSComp.PopoverContent>
+		</HSComp.Popover>
+	);
+}
+
+type CanonicalHit = {
+	id?: string;
+	url?: string;
+	name?: string;
+	title?: string;
+	version?: string;
+	description?: string;
+};
+
+function CanonicalPicker({
+	value,
+	onChange,
+	resourceType,
+	placeholder,
+}: {
+	value?: string;
+	onChange: (next: string | undefined) => void;
+	resourceType: "ValueSet" | "ConceptMap";
+	placeholder?: string;
+}) {
+	const effectivePlaceholder = placeholder ?? `${resourceType} canonical URL`;
+	const client = useAidboxClient();
+	const [local, setLocal] = React.useState(value ?? "");
+	const [debounced, setDebounced] = React.useState(local);
+	const [open, setOpen] = React.useState(false);
+	const [activeIndex, setActiveIndex] = React.useState(-1);
+	const itemRefs = React.useRef<Array<HTMLButtonElement | null>>([]);
+	const inputRef = React.useRef<HTMLInputElement | null>(null);
+	const measureRef = React.useRef<HTMLSpanElement | null>(null);
+	const [inputWidthPx, setInputWidthPx] = React.useState(200);
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: deps drive re-measurement of the span when text changes
+	React.useLayoutEffect(() => {
+		const input = inputRef.current;
+		const span = measureRef.current;
+		if (!input || !span) return;
+		const cs = getComputedStyle(input);
+		span.style.font = cs.font;
+		span.style.fontFamily = cs.fontFamily;
+		span.style.fontSize = cs.fontSize;
+		span.style.fontWeight = cs.fontWeight;
+		span.style.letterSpacing = cs.letterSpacing;
+		const padX =
+			Number.parseFloat(cs.paddingLeft) + Number.parseFloat(cs.paddingRight);
+		const borderX =
+			Number.parseFloat(cs.borderLeftWidth) +
+			Number.parseFloat(cs.borderRightWidth);
+		const caret = 2;
+		const w = span.offsetWidth + padX + borderX + caret;
+		setInputWidthPx(Math.max(200, Math.ceil(w)));
+	}, [local, effectivePlaceholder]);
+
+	React.useEffect(() => {
+		setLocal(value ?? "");
+	}, [value]);
+
+	React.useEffect(() => {
+		const t = setTimeout(() => setDebounced(local), 250);
+		return () => clearTimeout(t);
+	}, [local]);
+
+	const pipeIdx = debounced.indexOf("|");
+	const mode: "url" | "version" = pipeIdx >= 0 ? "version" : "url";
+	const urlPart =
+		pipeIdx >= 0 ? debounced.slice(0, pipeIdx).trim() : debounced.trim();
+	const versionPart = pipeIdx >= 0 ? debounced.slice(pipeIdx + 1).trim() : "";
+
+	const { data: urlHits } = useQuery({
+		queryKey: [
+			"conceptmap-builder",
+			"canonical-picker",
+			resourceType,
+			"url",
+			urlPart,
+		],
+		enabled: mode === "url",
+		queryFn: async () => {
+			const params = new URLSearchParams({
+				_count: "15",
+				_sort: "-_lastUpdated",
+				_elements: "url,name,title,version,description",
+			});
+			if (urlPart) params.set("url:contains", urlPart);
+			const res = await client.request<{
+				entry?: Array<{ resource: CanonicalHit }>;
+			}>({
+				method: "GET",
+				url: `/fhir/${resourceType}?${params.toString()}`,
+			});
+			if (res.isErr()) return [];
+			return (res.value.resource.entry ?? [])
+				.map((e) => e.resource)
+				.filter((r): r is CanonicalHit & { url: string } => !!r.url);
+		},
+		staleTime: 30_000,
+	});
+
+	const { data: versionHits } = useQuery({
+		queryKey: [
+			"conceptmap-builder",
+			"canonical-picker",
+			resourceType,
+			"versions",
+			urlPart,
+		],
+		enabled: mode === "version" && urlPart.length > 0,
+		queryFn: async () => {
+			const params = new URLSearchParams({
+				_count: "100",
+				_sort: "-_lastUpdated",
+				_elements: "url,name,title,version",
+				url: urlPart,
+			});
+			const res = await client.request<{
+				entry?: Array<{ resource: CanonicalHit }>;
+			}>({
+				method: "GET",
+				url: `/fhir/${resourceType}?${params.toString()}`,
+			});
+			if (res.isErr()) return [];
+			const seen = new Set<string>();
+			const out: Array<CanonicalHit & { url: string; version: string }> = [];
+			for (const e of res.value.resource.entry ?? []) {
+				const r = e.resource;
+				if (!r.url || !r.version) continue;
+				if (seen.has(r.version)) continue;
+				seen.add(r.version);
+				out.push({ ...r, url: r.url, version: r.version });
+			}
+			return out;
+		},
+		staleTime: 30_000,
+	});
+
+	const commit = (raw: string) => {
+		setLocal(raw);
+		const next = raw.trim() || undefined;
+		if (next !== value) onChange(next);
+	};
+
+	const selectUrlHit = (h: CanonicalHit & { url: string }) => {
+		setLocal(h.url);
+		onChange(h.url);
+		setOpen(false);
+		setActiveIndex(-1);
+	};
+
+	const selectVersionHit = (
+		h: CanonicalHit & { url: string; version: string },
+	) => {
+		const combined = `${urlPart || h.url}|${h.version}`;
+		setLocal(combined);
+		onChange(combined);
+		setOpen(false);
+		setActiveIndex(-1);
+	};
+
+	const hitsList =
+		mode === "version"
+			? (versionHits ?? []).filter(
+					(h) => !versionPart || h.version.includes(versionPart),
+				)
+			: (urlHits ?? []);
+
+	const onSelectActive = () => {
+		const h = hitsList[activeIndex];
+		if (!h) return;
+		if (mode === "version") {
+			selectVersionHit(h as CanonicalHit & { url: string; version: string });
+		} else {
+			selectUrlHit(h);
+		}
+	};
+
+	const hitsLength = hitsList.length;
+	React.useEffect(() => {
+		setActiveIndex(hitsLength > 0 ? 0 : -1);
+	}, [hitsLength]);
+
+	React.useEffect(() => {
+		if (activeIndex < 0) return;
+		itemRefs.current[activeIndex]?.scrollIntoView({ block: "nearest" });
+	}, [activeIndex]);
+
+	return (
+		<HSComp.Popover open={open} onOpenChange={setOpen}>
+			<HSComp.PopoverAnchor asChild>
+				<div className="shrink-0" style={{ width: `${inputWidthPx}px` }}>
+					<HSComp.Input
+						ref={inputRef}
+						placeholder={effectivePlaceholder}
+						value={local}
+						onChange={(e) => {
+							setLocal(e.target.value);
+							setOpen(true);
+						}}
+						onClick={(e) => {
+							e.stopPropagation();
+							setOpen(true);
+						}}
+						onFocus={() => setOpen(true)}
+						onBlur={(e) => {
+							const next = e.relatedTarget as HTMLElement | null;
+							if (next?.closest("[data-canonical-picker-popover='true']"))
+								return;
+							commit(local);
+							setOpen(false);
+						}}
+						onKeyDown={(e) => {
+							if (e.key === "ArrowDown") {
+								e.preventDefault();
+								if (hitsList.length === 0) return;
+								setOpen(true);
+								setActiveIndex((i) => (i + 1) % hitsList.length);
+							} else if (e.key === "ArrowUp") {
+								e.preventDefault();
+								if (hitsList.length === 0) return;
+								setOpen(true);
+								setActiveIndex((i) => (i <= 0 ? hitsList.length - 1 : i - 1));
+							} else if (e.key === "Enter") {
+								e.preventDefault();
+								if (open && activeIndex >= 0 && hitsList[activeIndex]) {
+									onSelectActive();
+								} else {
+									commit(local);
+									setOpen(false);
+								}
+							} else if (e.key === "Escape") {
+								setOpen(false);
+								setActiveIndex(-1);
+							}
+						}}
+						onMouseDown={(e) => e.stopPropagation()}
+						className="h-7 py-1 px-2 bg-bg-primary border-none hover:bg-bg-quaternary focus:bg-bg-primary group-hover/tree-item-label:bg-bg-tertiary focus:ring-1 focus:ring-border-link font-mono text-xs"
+					/>
+					<span
+						ref={measureRef}
+						aria-hidden="true"
+						className="input-measure font-mono text-xs"
+					>
+						{local || effectivePlaceholder}
+					</span>
+				</div>
+			</HSComp.PopoverAnchor>
+			<HSComp.PopoverContent
+				data-canonical-picker-popover="true"
+				className="w-[var(--radix-popover-trigger-width)] min-w-[480px] p-0 max-h-80 overflow-auto"
+				align="start"
+				onOpenAutoFocus={(e) => e.preventDefault()}
+				onInteractOutside={(e) => {
+					if (e.target === inputRef.current) e.preventDefault();
+				}}
+			>
+				{mode === "version" && !urlPart ? (
+					<div className="px-3 py-2 text-text-secondary text-sm">
+						Type a {resourceType} URL before <code>|</code>
+					</div>
+				) : hitsList.length === 0 ? (
+					<div className="px-3 py-2 text-text-secondary text-sm">
+						{mode === "version" ? "No versions found" : "No matches"}
+					</div>
+				) : (
+					<ul className="py-1">
+						{hitsList.map((h, i) => {
+							const isActive = i === activeIndex;
+							if (mode === "version") {
+								const ver = h.version ?? "";
+								const secondary = h.title || h.name || h.id || h.url;
+								return (
+									<li key={`${h.url}|${ver}`}>
+										<button
+											ref={(el) => {
+												itemRefs.current[i] = el;
+											}}
+											type="button"
+											onClick={(e) => {
+												e.stopPropagation();
+												selectVersionHit(
+													h as CanonicalHit & {
+														url: string;
+														version: string;
+													},
+												);
+											}}
+											onMouseEnter={() => setActiveIndex(i)}
+											className={`w-full text-left px-3 py-1.5 focus:outline-none ${isActive ? "bg-bg-tertiary" : ""}`}
+										>
+											<div className="typo-body text-text-primary truncate font-mono">
+												{ver}
+											</div>
+											<div className="typo-body-xs text-text-secondary line-clamp-1">
+												{secondary}
+											</div>
+										</button>
+									</li>
+								);
+							}
+							const title = h.title || h.name || h.id || h.url;
+							const secondary = h.description || h.url;
+							return (
+								<li key={`${h.url}|${h.version ?? ""}`}>
+									<button
+										ref={(el) => {
+											itemRefs.current[i] = el;
+										}}
+										type="button"
+										onClick={(e) => {
+											e.stopPropagation();
+											selectUrlHit(h);
+										}}
+										onMouseEnter={() => setActiveIndex(i)}
+										className={`w-full text-left px-3 py-1.5 focus:outline-none ${isActive ? "bg-bg-tertiary" : ""}`}
+									>
+										<div className="typo-body text-text-primary truncate">
+											{title}
+										</div>
+										<div className="typo-body-xs text-text-secondary line-clamp-1 font-mono">
+											{secondary}
+										</div>
+									</button>
+								</li>
+							);
+						})}
+					</ul>
+				)}
+			</HSComp.PopoverContent>
+		</HSComp.Popover>
+	);
+}
+
+const LABEL_OVERRIDES: Partial<Record<ItemMeta["type"], string>> = {
+	groups: "groups",
+};
+
+function InputView({
+	placeholder,
+	value,
+	onChange,
+}: {
+	placeholder: string;
+	value?: string;
+	onChange?: (value: string) => void;
+}) {
+	const [localValue, setLocalValue] = React.useState(value ?? "");
+	const timeoutRef = React.useRef<ReturnType<typeof setTimeout> | undefined>(
+		undefined,
+	);
+
+	React.useEffect(() => {
+		setLocalValue(value ?? "");
+	}, [value]);
+
+	const handleChange = (newValue: string) => {
+		setLocalValue(newValue);
+		if (timeoutRef.current) clearTimeout(timeoutRef.current);
+		timeoutRef.current = setTimeout(() => {
+			if (onChange && newValue !== value) onChange(newValue);
+		}, 500);
+	};
+
+	return (
+		<HSComp.Input
+			className="h-7 py-1 px-2 bg-bg-primary border-none hover:bg-bg-quaternary focus:bg-bg-primary group-hover/tree-item-label:bg-bg-tertiary focus:ring-1 focus:ring-border-link"
+			placeholder={placeholder}
+			value={localValue}
+			onChange={(e) => handleChange(e.target.value)}
+			onClick={(e) => e.stopPropagation()}
+			onMouseDown={(e) => e.stopPropagation()}
+		/>
+	);
+}
+
+// Auto-sizing input — same measurement pattern as CodeSystemPicker.
+// font-mono text-xs is applied to both the input AND the measuring span,
+// which is what makes the measurement accurate.
+function AutoSizeInputView({
+	placeholder,
+	value,
+	onChange,
+}: {
+	placeholder: string;
+	value?: string;
+	onChange?: (value: string) => void;
+}) {
+	const [localValue, setLocalValue] = React.useState(value ?? "");
+	const timeoutRef = React.useRef<ReturnType<typeof setTimeout> | undefined>(
+		undefined,
+	);
+	const inputRef = React.useRef<HTMLInputElement | null>(null);
+	const measureRef = React.useRef<HTMLSpanElement | null>(null);
+	const [widthPx, setWidthPx] = React.useState(120);
+
+	React.useEffect(() => {
+		setLocalValue(value ?? "");
+	}, [value]);
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: deps drive re-measurement of the span when text changes
+	React.useLayoutEffect(() => {
+		const input = inputRef.current;
+		const span = measureRef.current;
+		if (!input || !span) return;
+		const cs = getComputedStyle(input);
+		span.style.font = cs.font;
+		span.style.fontFamily = cs.fontFamily;
+		span.style.fontSize = cs.fontSize;
+		span.style.fontWeight = cs.fontWeight;
+		span.style.letterSpacing = cs.letterSpacing;
+		const padX =
+			Number.parseFloat(cs.paddingLeft) + Number.parseFloat(cs.paddingRight);
+		const borderX =
+			Number.parseFloat(cs.borderLeftWidth) +
+			Number.parseFloat(cs.borderRightWidth);
+		const caret = 2;
+		const w = span.offsetWidth + padX + borderX + caret;
+		setWidthPx(Math.max(120, Math.ceil(w)));
+	}, [localValue, placeholder]);
+
+	const handleChange = (newValue: string) => {
+		setLocalValue(newValue);
+		if (timeoutRef.current) clearTimeout(timeoutRef.current);
+		timeoutRef.current = setTimeout(() => {
+			if (onChange && newValue !== value) onChange(newValue);
+		}, 500);
+	};
+
+	return (
+		<div className="shrink-0" style={{ width: `${widthPx}px` }}>
+			<HSComp.Input
+				ref={inputRef}
+				className="h-7 py-1 px-2 bg-bg-primary border-none hover:bg-bg-quaternary focus:bg-bg-primary group-hover/tree-item-label:bg-bg-tertiary focus:ring-1 focus:ring-border-link font-mono text-xs"
+				placeholder={placeholder}
+				value={localValue}
+				onChange={(e) => handleChange(e.target.value)}
+				onClick={(e) => e.stopPropagation()}
+				onMouseDown={(e) => e.stopPropagation()}
+			/>
+			<span
+				ref={measureRef}
+				aria-hidden="true"
+				className="input-measure font-mono text-xs"
+			>
+				{localValue || placeholder}
+			</span>
+		</div>
+	);
+}
+
+// Auto-sizing Select — same idea as AutoSizeInputView but for HSComp.Select.
+// Measures the selected/placeholder text through a hidden span, then sets
+// width = textWidth + padding + chevron (24px) + caret allowance.
+function AutoSizeSelect({
+	value,
+	onChange,
+	options,
+	placeholder,
+}: {
+	value: string;
+	onChange: (next: string) => void;
+	options: readonly string[];
+	placeholder: string;
+}) {
+	const wrapperRef = React.useRef<HTMLDivElement | null>(null);
+	const measureRef = React.useRef<HTMLSpanElement | null>(null);
+	const [widthPx, setWidthPx] = React.useState(120);
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: deps drive re-measurement of the span when value/placeholder change
+	React.useLayoutEffect(() => {
+		const wrapper = wrapperRef.current;
+		const span = measureRef.current;
+		if (!wrapper || !span) return;
+		const trigger = wrapper.querySelector(
+			'[data-slot="select-trigger"], button[role="combobox"]',
+		) as HTMLElement | null;
+		if (!trigger) return;
+		const cs = getComputedStyle(trigger);
+		span.style.font = cs.font;
+		span.style.fontFamily = cs.fontFamily;
+		span.style.fontSize = cs.fontSize;
+		span.style.fontWeight = cs.fontWeight;
+		span.style.letterSpacing = cs.letterSpacing;
+		const padX =
+			Number.parseFloat(cs.paddingLeft) + Number.parseFloat(cs.paddingRight);
+		const borderX =
+			Number.parseFloat(cs.borderLeftWidth) +
+			Number.parseFloat(cs.borderRightWidth);
+		const chevron = 24; // chevron icon + gap inside trigger
+		const w = span.offsetWidth + padX + borderX + chevron;
+		setWidthPx(Math.max(120, Math.ceil(w)));
+	}, [value, placeholder]);
+
+	return (
+		<div
+			ref={wrapperRef}
+			className="shrink-0"
+			style={{ width: `${widthPx}px` }}
+		>
+			<HSComp.Select value={value} onValueChange={onChange}>
+				<HSComp.SelectTrigger className="h-7 py-1 px-2 bg-bg-primary border-none hover:bg-bg-quaternary focus:bg-bg-primary focus:ring-1 focus:ring-border-link group-hover/tree-item-label:bg-bg-tertiary">
+					<HSComp.SelectValue placeholder={placeholder} />
+				</HSComp.SelectTrigger>
+				<HSComp.SelectContent>
+					{options.map((o) => (
+						<HSComp.SelectItem key={o} value={o}>
+							{o}
+						</HSComp.SelectItem>
+					))}
+				</HSComp.SelectContent>
+			</HSComp.Select>
+			<span ref={measureRef} aria-hidden="true" className="input-measure">
+				{value || placeholder}
+			</span>
+		</div>
+	);
+}
+
+function labelView(item: ItemInstance<TreeViewItem<ItemMeta>>) {
+	const metaType = item.getItemData()?.meta?.type;
+	const isFolder = item.isFolder();
+	const isTextOnlyLabel = metaType === "properties" || metaType === "groups";
+
+	const additionalClass = isTextOnlyLabel
+		? "text-text-info-primary px-1!"
+		: "inline-flex items-center justify-center min-w-7 min-h-7 text-text-info-primary bg-bg-info-primary";
+
+	const label = (metaType && LABEL_OVERRIDES[metaType]) ?? metaType;
+
+	const onLabelClickFn = (e: React.MouseEvent) => {
+		if (!isFolder) return;
+		e.stopPropagation();
+		if (item.isExpanded()) item.collapse();
+		else item.expand();
+	};
+
+	return (
+		<button
+			type="button"
+			tabIndex={-1}
+			className={`uppercase px-1.5 py-0.5 ${isFolder ? "cursor-pointer" : ""} rounded-md ${additionalClass}`}
+			onClick={onLabelClickFn}
+		>
+			{label}
+		</button>
+	);
+}
+
+const groupRowId = (i: number) => `_group_${i}`;
+const elementsSectionId = (gi: number) => `_group_${gi}_elements`;
+const elementRowId = (gi: number, ei: number) => `_group_${gi}_element_${ei}`;
+const elementAddId = (gi: number) => `_group_${gi}_element_add`;
+const unmappedRowId = (gi: number) => `_group_${gi}_unmapped`;
+
+const UNMAPPED_MODES_R4 = ["provided", "fixed", "other-map"] as const;
+const UNMAPPED_MODES_R5 = [
+	"provided",
+	"fixed",
+	"other-map",
+	"use-source-code",
+] as const;
+
+const getUnmappedOtherMap = (
+	um: import("./types").ConceptMapUnmapped | undefined,
+): string | undefined => um?.otherMap ?? um?.url;
+
+const getTargetRel = (t: ConceptMapTarget | undefined, r4: boolean): string =>
+	r4 ? (t?.equivalence ?? "") : (t?.relationship ?? "");
+
+// Read whichever R4/R5 field is populated — picker shows whatever is there.
+const getRootSource = (cm: ConceptMap): string | undefined =>
+	cm.sourceScopeCanonical ??
+	cm.sourceScopeUri ??
+	cm.sourceCanonical ??
+	cm.sourceUri;
+
+const getRootTarget = (cm: ConceptMap): string | undefined =>
+	cm.targetScopeCanonical ??
+	cm.targetScopeUri ??
+	cm.targetCanonical ??
+	cm.targetUri;
+
+// Write to the version-appropriate canonical field, clear the others so the
+// resource has exactly one source-of-truth scope field.
+const writeRootSource = (cm: ConceptMap, value?: string, isR4 = false) => {
+	const cleared = {
+		...cm,
+		sourceUri: undefined,
+		sourceCanonical: undefined,
+		sourceScopeUri: undefined,
+		sourceScopeCanonical: undefined,
+	};
+	if (!value) return cleared;
+	return isR4
+		? { ...cleared, sourceCanonical: value }
+		: { ...cleared, sourceScopeCanonical: value };
+};
+
+const writeRootTarget = (cm: ConceptMap, value?: string, isR4 = false) => {
+	const cleared = {
+		...cm,
+		targetUri: undefined,
+		targetCanonical: undefined,
+		targetScopeUri: undefined,
+		targetScopeCanonical: undefined,
+	};
+	if (!value) return cleared;
+	return isR4
+		? { ...cleared, targetCanonical: value }
+		: { ...cleared, targetScopeCanonical: value };
+};
+
+export function PropertiesTree() {
+	const { conceptMap, updateConceptMap } = useConceptMapContext();
+	const fhirVersion = useFhirServerVersion();
+	const isR4 = isR4Like(fhirVersion);
+	const relationshipOptions = isR4 ? EQUIVALENCES_R4 : RELATIONSHIPS_R5;
+
+	const updateField = <K extends keyof ConceptMap>(
+		key: K,
+		value: ConceptMap[K] | undefined,
+	) =>
+		updateConceptMap((cm) => ({
+			...cm,
+			[key]: value === "" ? undefined : value,
+		}));
+
+	const mutateGroups = (
+		fn: (arr: ConceptMapGroup[]) => ConceptMapGroup[] | undefined,
+	) =>
+		updateConceptMap((cm) => {
+			const next = fn((cm.group ?? []).slice());
+			return { ...cm, group: next && next.length > 0 ? next : undefined };
+		});
+
+	const updateGroupAt = (i: number, patch: Partial<ConceptMapGroup>) =>
+		mutateGroups((arr) => {
+			const next = arr.slice();
+			next[i] = { ...next[i], ...patch };
+			return next;
+		});
+
+	const addGroup = () => {
+		mutateGroups((arr) => [...arr, {}]);
+		setExpandedItems((prev) => Array.from(new Set([...prev, "_groups"])));
+	};
+
+	const removeGroupAt = (i: number) =>
+		mutateGroups((arr) => arr.filter((_, idx) => idx !== i));
+
+	const mutateElementAt = (
+		gi: number,
+		ei: number,
+		fn: (el: ConceptMapElement) => ConceptMapElement,
+	) =>
+		mutateGroups((arr) => {
+			const next = arr.slice();
+			const g = next[gi] ?? {};
+			const elements = (g.element ?? []).slice();
+			elements[ei] = fn(elements[ei] ?? {});
+			next[gi] = { ...g, element: elements };
+			return next;
+		});
+
+	const updateElementCode = (gi: number, ei: number, code: string) =>
+		mutateElementAt(gi, ei, (el) => ({ ...el, code: code || undefined }));
+
+	const updateTargetCode = (gi: number, ei: number, code: string) =>
+		mutateElementAt(gi, ei, (el) => {
+			const targets = (el.target ?? []).slice();
+			targets[0] = { ...(targets[0] ?? {}), code: code || undefined };
+			return { ...el, target: targets };
+		});
+
+	const updateTargetRel = (
+		gi: number,
+		ei: number,
+		value: string,
+		isR4: boolean,
+	) =>
+		mutateElementAt(gi, ei, (el) => {
+			const targets = (el.target ?? []).slice();
+			const prev = targets[0] ?? {};
+			targets[0] = isR4
+				? {
+						...prev,
+						equivalence: value || undefined,
+						relationship: undefined,
+					}
+				: {
+						...prev,
+						relationship: value || undefined,
+						equivalence: undefined,
+					};
+			return { ...el, target: targets };
+		});
+
+	const addElementAt = (gi: number) => {
+		mutateGroups((arr) => {
+			const next = arr.slice();
+			const g = next[gi] ?? {};
+			next[gi] = {
+				...g,
+				element: [...(g.element ?? []), { target: [{}] }],
+			};
+			return next;
+		});
+		setExpandedItems((prev) =>
+			Array.from(new Set([...prev, groupRowId(gi), elementsSectionId(gi)])),
+		);
+	};
+
+	const removeElementAt = (gi: number, ei: number) =>
+		mutateGroups((arr) => {
+			const next = arr.slice();
+			const g = next[gi] ?? {};
+			const elements = (g.element ?? []).filter((_, idx) => idx !== ei);
+			next[gi] = {
+				...g,
+				element: elements.length > 0 ? elements : undefined,
+			};
+			return next;
+		});
+
+	const updateUnmappedMode = (gi: number, mode: string) => {
+		mutateGroups((arr) => {
+			const next = arr.slice();
+			const g = next[gi] ?? {};
+			if (!mode) {
+				next[gi] = { ...g, unmapped: undefined };
+				return next;
+			}
+			const um = g.unmapped ?? {};
+			// Drop fields that don't belong to the new mode (cmd-8, cmd-10).
+			const cleaned: import("./types").ConceptMapUnmapped = { mode };
+			if (mode === "fixed") {
+				cleaned.code = um.code;
+				cleaned.display = um.display;
+			} else if (mode === "other-map") {
+				cleaned.otherMap = um.otherMap;
+				cleaned.url = um.url;
+			}
+			next[gi] = { ...g, unmapped: cleaned };
+			return next;
+		});
+		if (mode === "fixed" || mode === "other-map") {
+			setExpandedItems((prev) =>
+				Array.from(new Set([...prev, groupRowId(gi)])),
+			);
+		}
+	};
+
+	const updateUnmappedField = (
+		gi: number,
+		patch: Partial<import("./types").ConceptMapUnmapped>,
+	) =>
+		mutateGroups((arr) => {
+			const next = arr.slice();
+			const g = next[gi] ?? {};
+			next[gi] = {
+				...g,
+				unmapped: { ...(g.unmapped ?? {}), ...patch },
+			};
+			return next;
+		});
+
+	const updateUnmappedOtherMap = (gi: number, value: string | undefined) =>
+		mutateGroups((arr) => {
+			const next = arr.slice();
+			const g = next[gi] ?? {};
+			const um = g.unmapped ?? {};
+			next[gi] = {
+				...g,
+				unmapped: isR4
+					? { ...um, url: value, otherMap: undefined }
+					: { ...um, otherMap: value, url: undefined },
+			};
+			return next;
+		});
+
+	const groups = conceptMap.group ?? [];
+
+	const tree: Record<string, TreeViewItem<ItemMeta>> = React.useMemo(() => {
+		const out: Record<string, TreeViewItem<ItemMeta>> = {
+			root: { name: "root", children: ["_properties", "_groups"] },
+			_properties: {
+				name: "_properties",
+				meta: { type: "properties" },
+				children: [
+					"_url",
+					"_version",
+					"_status",
+					"_title",
+					"_description",
+					"_source",
+					"_target",
+				],
+			},
+			_url: { name: "_url", meta: { type: "url" } },
+			_version: { name: "_version", meta: { type: "version" } },
+			_status: { name: "_status", meta: { type: "status" } },
+			_title: { name: "_title", meta: { type: "title" } },
+			_description: { name: "_description", meta: { type: "description" } },
+			_source: { name: "_source", meta: { type: "source" } },
+			_target: { name: "_target", meta: { type: "target" } },
+		};
+
+		const groupChildren: string[] = [];
+		groups.forEach((g, i) => {
+			const rowId = groupRowId(i);
+			const elements = g.element ?? [];
+			const sectionChildren: string[] = [];
+			elements.forEach((_, j) => {
+				const eId = elementRowId(i, j);
+				out[eId] = {
+					name: eId,
+					meta: { type: "element-row", groupIndex: i, elementIndex: j },
+				};
+				sectionChildren.push(eId);
+			});
+			const eAddId = elementAddId(i);
+			out[eAddId] = {
+				name: eAddId,
+				meta: { type: "element-add", groupIndex: i },
+			};
+			sectionChildren.push(eAddId);
+
+			const sectionId = elementsSectionId(i);
+			out[sectionId] = {
+				name: sectionId,
+				meta: { type: "elements-section", groupIndex: i },
+				children: sectionChildren,
+			};
+
+			// Unmapped — single inline row, no children.
+			const umRowId = unmappedRowId(i);
+			out[umRowId] = {
+				name: umRowId,
+				meta: { type: "unmapped-row", groupIndex: i },
+			};
+
+			out[rowId] = {
+				name: rowId,
+				meta: { type: "group-row", groupIndex: i },
+				children: [sectionId, umRowId],
+			};
+			groupChildren.push(rowId);
+		});
+		groupChildren.push("_group_add");
+		out._group_add = { name: "_group_add", meta: { type: "group-add" } };
+		out._groups = {
+			name: "_groups",
+			meta: { type: "groups" },
+			children: groupChildren,
+		};
+
+		return out;
+	}, [groups]);
+
+	const [expandedItems, setExpandedItems] = React.useState<string[]>(() => {
+		const out = ["_properties", "_groups"];
+		const initialGroups = conceptMap.group ?? [];
+		let totalElements = 0;
+		for (const g of initialGroups) {
+			totalElements += g.element?.length ?? 0;
+		}
+		if (totalElements >= 1000) return out;
+		initialGroups.forEach((_, i) => {
+			out.push(groupRowId(i), elementsSectionId(i));
+		});
+		return out;
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	});
+
+	// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: large switch over tree node types
+	const customItemView = (item: ItemInstance<TreeViewItem<ItemMeta>>) => {
+		const meta = item.getItemData()?.meta;
+		const metaType = meta?.type;
+		switch (metaType) {
+			case "properties":
+			case "groups":
+				return <div>{labelView(item)}</div>;
+			case "url":
+				return (
+					<div className="flex w-full items-center gap-2">
+						<div className="w-[246px] shrink-0">{labelView(item)}</div>
+						<div className="w-[50%]">
+							<InputView
+								placeholder="Canonical identifier for this concept map, represented as a URI (globally unique)"
+								value={conceptMap.url}
+								onChange={(v) => updateField("url", v)}
+							/>
+						</div>
+					</div>
+				);
+			case "version":
+				return (
+					<div className="flex w-full items-center gap-2">
+						<div className="w-[246px] shrink-0">{labelView(item)}</div>
+						<div className="w-[300px]">
+							<InputView
+								placeholder="Business version of the concept map"
+								value={conceptMap.version}
+								onChange={(v) => updateField("version", v)}
+							/>
+						</div>
+					</div>
+				);
+			case "status":
+				return (
+					<div className="flex w-full items-center gap-2">
+						<div className="w-[246px] shrink-0">{labelView(item)}</div>
+						<div className="w-[112px]">
+							<HSComp.Select
+								value={conceptMap.status ?? ""}
+								onValueChange={(v) =>
+									updateField("status", (v || undefined) as ConceptMapStatus)
+								}
+							>
+								<HSComp.SelectTrigger className="h-7 py-1 px-2 bg-bg-primary border-none hover:bg-bg-quaternary focus:bg-bg-primary focus:ring-1 focus:ring-border-link group-hover/tree-item-label:bg-bg-tertiary">
+									<HSComp.SelectValue placeholder="status" />
+								</HSComp.SelectTrigger>
+								<HSComp.SelectContent>
+									{STATUSES.map((s) => (
+										<HSComp.SelectItem key={s} value={s}>
+											{s}
+										</HSComp.SelectItem>
+									))}
+								</HSComp.SelectContent>
+							</HSComp.Select>
+						</div>
+					</div>
+				);
+			case "title":
+				return (
+					<div className="flex w-full items-center gap-2">
+						<div className="w-[246px] shrink-0">{labelView(item)}</div>
+						<div className="w-[50%]">
+							<InputView
+								placeholder="Name for this concept map (human friendly)"
+								value={conceptMap.title}
+								onChange={(v) => updateField("title", v)}
+							/>
+						</div>
+					</div>
+				);
+			case "description":
+				return (
+					<div className="flex w-full items-center gap-2">
+						<div className="w-[246px] shrink-0">{labelView(item)}</div>
+						<div className="flex-1 min-w-0">
+							<InputView
+								placeholder="Natural language description of the concept map"
+								value={conceptMap.description}
+								onChange={(v) => updateField("description", v)}
+							/>
+						</div>
+					</div>
+				);
+			case "source":
+				return (
+					<div className="flex w-full items-center gap-2">
+						<div className="w-[246px] shrink-0">{labelView(item)}</div>
+						<CanonicalPicker
+							resourceType="ValueSet"
+							value={getRootSource(conceptMap)}
+							onChange={(next) =>
+								updateConceptMap((cm) => writeRootSource(cm, next, isR4))
+							}
+						/>
+					</div>
+				);
+			case "target":
+				return (
+					<div className="flex w-full items-center gap-2">
+						<div className="w-[246px] shrink-0">{labelView(item)}</div>
+						<CanonicalPicker
+							resourceType="ValueSet"
+							value={getRootTarget(conceptMap)}
+							onChange={(next) =>
+								updateConceptMap((cm) => writeRootTarget(cm, next, isR4))
+							}
+						/>
+					</div>
+				);
+			case "group-row": {
+				const i = meta?.groupIndex ?? -1;
+				const g = groups[i];
+				const isFolder = item.isFolder();
+				const toggle = (e: React.MouseEvent) => {
+					if (!isFolder) return;
+					e.stopPropagation();
+					if (item.isExpanded()) item.collapse();
+					else item.expand();
+				};
+				const maxDigits = String(Math.max(groups.length, 1)).length;
+				// R4 keeps version in a separate field (sourceVersion/targetVersion).
+				// R5+ removed those fields — version lives inside the canonical
+				// as `url|version`. So we split/merge depending on FHIR version.
+				const srcParts = isR4
+					? { system: g?.source, version: g?.sourceVersion }
+					: parseSystemPipeVersion(g?.source ?? "");
+				const tgtParts = isR4
+					? { system: g?.target, version: g?.targetVersion }
+					: parseSystemPipeVersion(g?.target ?? "");
+				const writeGroupSourceFields = (next: {
+					system?: string;
+					version?: string;
+				}): Partial<ConceptMapGroup> =>
+					isR4
+						? { source: next.system, sourceVersion: next.version }
+						: {
+								source:
+									next.system && next.version
+										? `${next.system}|${next.version}`
+										: next.system,
+								sourceVersion: undefined,
+							};
+				const writeGroupTargetFields = (next: {
+					system?: string;
+					version?: string;
+				}): Partial<ConceptMapGroup> =>
+					isR4
+						? { target: next.system, targetVersion: next.version }
+						: {
+								target:
+									next.system && next.version
+										? `${next.system}|${next.version}`
+										: next.system,
+								targetVersion: undefined,
+							};
+				return (
+					<div className="flex w-full items-center gap-2">
+						<button
+							type="button"
+							tabIndex={-1}
+							className={`shrink-0 inline-flex items-center justify-start min-h-7 uppercase px-[2px] py-0.5 rounded-md text-text-info-primary tabular-nums ${isFolder ? "cursor-pointer" : ""}`}
+							style={{ minWidth: `calc(${maxDigits}ch + 4px)` }}
+							onClick={toggle}
+						>
+							{i + 1}
+						</button>
+						<CodeSystemPicker
+							system={srcParts.system}
+							version={srcParts.version}
+							placeholder="Source"
+							onChange={(next) =>
+								updateGroupAt(i, writeGroupSourceFields(next))
+							}
+						/>
+						<ArrowRight size={14} className="shrink-0 text-text-secondary" />
+						<CodeSystemPicker
+							system={tgtParts.system}
+							version={tgtParts.version}
+							placeholder="Target"
+							onChange={(next) =>
+								updateGroupAt(i, writeGroupTargetFields(next))
+							}
+						/>
+						<div className="flex-1" />
+						<HSComp.Button
+							variant="link"
+							size="small"
+							className="shrink-0 group-hover/tree-item-label:opacity-100 opacity-0 transition-opacity"
+							onClick={() => removeGroupAt(i)}
+							asChild
+						>
+							<span>
+								<X size={14} />
+							</span>
+						</HSComp.Button>
+					</div>
+				);
+			}
+			case "group-add":
+				return (
+					<HSComp.Button
+						variant="link"
+						size="small"
+						className="px-0"
+						onClick={addGroup}
+						asChild
+					>
+						<span>
+							<Plus size={16} strokeWidth={3} />
+							<span className="text-xs typo-label">Group</span>
+						</span>
+					</HSComp.Button>
+				);
+			case "elements-section": {
+				const gi = meta?.groupIndex ?? -1;
+				const count = groups[gi]?.element?.length ?? 0;
+				const isFolder = item.isFolder();
+				const toggle = (e: React.MouseEvent) => {
+					if (!isFolder) return;
+					e.stopPropagation();
+					if (item.isExpanded()) item.collapse();
+					else item.expand();
+				};
+				return (
+					<div>
+						<button
+							type="button"
+							tabIndex={-1}
+							className={`inline-flex items-center justify-center min-w-7 min-h-7 uppercase px-1.5 py-0.5 ${isFolder ? "cursor-pointer" : ""} rounded-md text-text-info-primary bg-bg-info-primary`}
+							onClick={toggle}
+						>
+							elements ({count})
+						</button>
+					</div>
+				);
+			}
+			case "element-row": {
+				const gi = meta?.groupIndex ?? -1;
+				const ei = meta?.elementIndex ?? -1;
+				const el = groups[gi]?.element?.[ei];
+				const t = el?.target?.[0];
+				const relation = getTargetRel(t, isR4);
+				return (
+					<div className="flex w-full items-center gap-2 pl-0.5">
+						<span className="text-text-info-primary bg-bg-info-primary rounded-md p-1 shrink-0">
+							<Link2 size={12} />
+						</span>
+						<div className="w-[200px] shrink-0">
+							<InputView
+								placeholder="source code"
+								value={el?.code}
+								onChange={(v) => updateElementCode(gi, ei, v)}
+							/>
+						</div>
+						<div className="w-[220px] shrink-0">
+							<HSComp.Select
+								value={relation}
+								onValueChange={(v) => updateTargetRel(gi, ei, v, isR4)}
+							>
+								<HSComp.SelectTrigger className="h-7 py-1 px-2 bg-bg-primary border-none hover:bg-bg-quaternary focus:bg-bg-primary focus:ring-1 focus:ring-border-link group-hover/tree-item-label:bg-bg-tertiary">
+									<HSComp.SelectValue
+										placeholder={isR4 ? "equivalence" : "relationship"}
+									/>
+								</HSComp.SelectTrigger>
+								<HSComp.SelectContent>
+									{relationshipOptions.map((r) => (
+										<HSComp.SelectItem key={r} value={r}>
+											{r}
+										</HSComp.SelectItem>
+									))}
+								</HSComp.SelectContent>
+							</HSComp.Select>
+						</div>
+						<div className="w-[200px] shrink-0">
+							<InputView
+								placeholder="target code"
+								value={t?.code}
+								onChange={(v) => updateTargetCode(gi, ei, v)}
+							/>
+						</div>
+						<HSComp.Button
+							variant="link"
+							size="small"
+							className="shrink-0 group-hover/tree-item-label:opacity-100 opacity-0 transition-opacity"
+							onClick={() => removeElementAt(gi, ei)}
+							asChild
+						>
+							<span>
+								<X size={14} />
+							</span>
+						</HSComp.Button>
+					</div>
+				);
+			}
+			case "element-add": {
+				const gi = meta?.groupIndex ?? -1;
+				return (
+					<HSComp.Button
+						variant="link"
+						size="small"
+						className="px-0"
+						onClick={() => addElementAt(gi)}
+						asChild
+					>
+						<span>
+							<Plus size={16} strokeWidth={3} />
+							<span className="text-xs typo-label">Element</span>
+						</span>
+					</HSComp.Button>
+				);
+			}
+			case "unmapped-row": {
+				const gi = meta?.groupIndex ?? -1;
+				const um = groups[gi]?.unmapped;
+				const modes = isR4 ? UNMAPPED_MODES_R4 : UNMAPPED_MODES_R5;
+				return (
+					<div className="flex w-full items-center gap-2">
+						<span className="inline-flex items-center justify-center min-w-7 min-h-7 uppercase px-1.5 py-0.5 rounded-md text-text-info-primary bg-bg-info-primary shrink-0">
+							unmapped
+						</span>
+						<AutoSizeSelect
+							value={um?.mode ?? ""}
+							onChange={(v) => updateUnmappedMode(gi, v)}
+							options={modes}
+							placeholder="(no fallback)"
+						/>
+						{um?.mode === "fixed" && (
+							<>
+								<AutoSizeInputView
+									placeholder="code"
+									value={um?.code}
+									onChange={(v) =>
+										updateUnmappedField(gi, { code: v || undefined })
+									}
+								/>
+								<AutoSizeInputView
+									placeholder="display"
+									value={um?.display}
+									onChange={(v) =>
+										updateUnmappedField(gi, { display: v || undefined })
+									}
+								/>
+							</>
+						)}
+						{um?.mode === "other-map" && (
+							<CanonicalPicker
+								resourceType="ConceptMap"
+								value={getUnmappedOtherMap(um)}
+								onChange={(next) => updateUnmappedOtherMap(gi, next)}
+							/>
+						)}
+					</div>
+				);
+			}
+			default:
+				return <div>{labelView(item)}</div>;
+		}
+	};
+
+	return (
+		<div>
+			<TreeView
+				items={tree}
+				rootItemId="root"
+				customItemView={customItemView}
+				disableHover={true}
+				chevronClassName="self-center cursor-pointer"
+				expandedItems={expandedItems}
+				onExpandedItemsChange={setExpandedItems}
+				onItemLabelClick={(item) => {
+					if (item.isFolder()) {
+						if (item.isExpanded()) item.collapse();
+						else item.expand();
+					}
+				}}
+				itemLabelClassFn={(item: ItemInstance<TreeViewItem<ItemMeta>>) => {
+					const metaType = item.getItemData()?.meta?.type;
+					if (metaType === "properties" || metaType === "groups") {
+						return "relative my-1.5 rounded-md bg-bg-info-primary cursor-pointer before:content-[''] before:absolute before:inset-x-0 before:top-0 before:bottom-0 before:-z-10 before:bg-bg-primary before:-my-1.5 after:content-[''] after:absolute after:inset-x-0 after:top-0 after:bottom-0 after:-z-10 after:bg-bg-primary after:rounded-md after:-my-1.5";
+					}
+					return "pr-0";
+				}}
+			/>
+		</div>
+	);
+}

--- a/src/components/ConceptMap/properties-tree.tsx
+++ b/src/components/ConceptMap/properties-tree.tsx
@@ -8,6 +8,7 @@ import { useQuery } from "@tanstack/react-query";
 import { ArrowRight, Link2, Plus, X } from "lucide-react";
 import * as React from "react";
 import { useAidboxClient } from "../../AidboxClient";
+import { readUrlHistory } from "../../utils/url-history";
 import { useConceptMapContext } from "./context";
 import type {
 	ConceptMap,
@@ -40,6 +41,8 @@ type ItemMeta = {
 
 const STATUSES = ["draft", "active", "retired", "unknown"] as const;
 type ConceptMapStatus = (typeof STATUSES)[number];
+
+const URL_HISTORY_KEY = "conceptmap-builder:url-history";
 
 // R5+ ConceptMap.group.element.target.relationship value set
 const RELATIONSHIPS_R5 = [
@@ -95,16 +98,24 @@ function formatSystemPipeVersion(
 	return system ?? "";
 }
 
-function CodeSystemPicker({
+export function CodeSystemPicker({
 	system,
 	version,
 	onChange,
 	placeholder = "CodeSystem canonical URL",
+	pinnedSystems,
+	variant = "tree",
+	prefixLabel,
+	onEnter,
 }: {
 	system?: string;
 	version?: string;
 	onChange: (next: { system?: string; version?: string }) => void;
 	placeholder?: string;
+	pinnedSystems?: string[];
+	variant?: "tree" | "form";
+	prefixLabel?: string;
+	onEnter?: () => void;
 }) {
 	const client = useAidboxClient();
 	const formatted = formatSystemPipeVersion(system, version);
@@ -241,12 +252,33 @@ function CodeSystemPicker({
 		setActiveIndex(-1);
 	};
 
+	const pinnedHits = React.useMemo<
+		Array<CodeSystemHit & { url: string; _pinned?: true }>
+	>(() => {
+		const list = pinnedSystems ?? [];
+		const seen = new Set<string>();
+		const out: Array<CodeSystemHit & { url: string; _pinned?: true }> = [];
+		for (const u of list) {
+			if (!u) continue;
+			if (systemPart && !u.includes(systemPart)) continue;
+			if (seen.has(u)) continue;
+			seen.add(u);
+			out.push({ url: u, _pinned: true });
+		}
+		return out;
+	}, [pinnedSystems, systemPart]);
+
+	const apiSystemHits = React.useMemo(
+		() => (systemHits ?? []).filter((h) => !pinnedSystems?.includes(h.url)),
+		[systemHits, pinnedSystems],
+	);
+
 	const hitsList =
 		mode === "version"
 			? (versionHits ?? []).filter(
 					(h) => !versionPart || h.version.includes(versionPart),
 				)
-			: (systemHits ?? []);
+			: [...pinnedHits, ...apiSystemHits];
 
 	const onSelectActive = () => {
 		const h = hitsList[activeIndex];
@@ -268,64 +300,85 @@ function CodeSystemPicker({
 		itemRefs.current[activeIndex]?.scrollIntoView({ block: "nearest" });
 	}, [activeIndex]);
 
+	const sharedInputProps = {
+		ref: inputRef,
+		placeholder,
+		value: local,
+		onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
+			setLocal(e.target.value);
+			setOpen(true);
+		},
+		onClick: (e: React.MouseEvent) => {
+			e.stopPropagation();
+			setOpen(true);
+		},
+		onFocus: () => setOpen(true),
+		onBlur: (e: React.FocusEvent) => {
+			const next = e.relatedTarget as HTMLElement | null;
+			if (next?.closest("[data-cs-picker-popover='true']")) return;
+			commit(local);
+			setOpen(false);
+		},
+		onKeyDown: (e: React.KeyboardEvent) => {
+			if (e.key === "ArrowDown") {
+				e.preventDefault();
+				if (hitsList.length === 0) return;
+				setOpen(true);
+				setActiveIndex((i) => (i + 1) % hitsList.length);
+			} else if (e.key === "ArrowUp") {
+				e.preventDefault();
+				if (hitsList.length === 0) return;
+				setOpen(true);
+				setActiveIndex((i) => (i <= 0 ? hitsList.length - 1 : i - 1));
+			} else if (e.key === "Enter") {
+				e.preventDefault();
+				if (open && activeIndex >= 0 && hitsList[activeIndex]) {
+					onSelectActive();
+				} else {
+					commit(local);
+					setOpen(false);
+					onEnter?.();
+				}
+			} else if (e.key === "Escape") {
+				setOpen(false);
+				setActiveIndex(-1);
+			}
+		},
+		onMouseDown: (e: React.MouseEvent) => e.stopPropagation(),
+	};
+
 	return (
 		<HSComp.Popover open={open} onOpenChange={setOpen}>
 			<HSComp.PopoverAnchor asChild>
-				<div className="shrink-0" style={{ width: `${inputWidthPx}px` }}>
-					<HSComp.Input
-						ref={inputRef}
-						placeholder={placeholder}
-						value={local}
-						onChange={(e) => {
-							setLocal(e.target.value);
-							setOpen(true);
-						}}
-						onClick={(e) => {
-							e.stopPropagation();
-							setOpen(true);
-						}}
-						onFocus={() => setOpen(true)}
-						onBlur={(e) => {
-							const next = e.relatedTarget as HTMLElement | null;
-							if (next?.closest("[data-cs-picker-popover='true']")) return;
-							commit(local);
-							setOpen(false);
-						}}
-						onKeyDown={(e) => {
-							if (e.key === "ArrowDown") {
-								e.preventDefault();
-								if (hitsList.length === 0) return;
-								setOpen(true);
-								setActiveIndex((i) => (i + 1) % hitsList.length);
-							} else if (e.key === "ArrowUp") {
-								e.preventDefault();
-								if (hitsList.length === 0) return;
-								setOpen(true);
-								setActiveIndex((i) => (i <= 0 ? hitsList.length - 1 : i - 1));
-							} else if (e.key === "Enter") {
-								e.preventDefault();
-								if (open && activeIndex >= 0 && hitsList[activeIndex]) {
-									onSelectActive();
-								} else {
-									commit(local);
-									setOpen(false);
-								}
-							} else if (e.key === "Escape") {
-								setOpen(false);
-								setActiveIndex(-1);
+				{variant === "form" ? (
+					<div className="flex-1 min-w-0 basis-0">
+						<HSComp.Input
+							{...sharedInputProps}
+							className="bg-bg-primary"
+							prefixValue={
+								prefixLabel ? (
+									<span className="text-nowrap text-elements-assistive font-medium">
+										{prefixLabel}
+									</span>
+								) : undefined
 							}
-						}}
-						onMouseDown={(e) => e.stopPropagation()}
-						className="h-7 py-1 px-2 bg-bg-primary border-none hover:bg-bg-quaternary focus:bg-bg-primary group-hover/tree-item-label:bg-bg-tertiary focus:ring-1 focus:ring-border-link font-mono text-xs"
-					/>
-					<span
-						ref={measureRef}
-						aria-hidden="true"
-						className="input-measure font-mono text-xs"
-					>
-						{local || placeholder}
-					</span>
-				</div>
+						/>
+					</div>
+				) : (
+					<div className="shrink-0" style={{ width: `${inputWidthPx}px` }}>
+						<HSComp.Input
+							{...sharedInputProps}
+							className="h-7 py-1 px-2 bg-bg-primary border-none hover:bg-bg-quaternary focus:bg-bg-primary group-hover/tree-item-label:bg-bg-tertiary focus:ring-1 focus:ring-border-link font-mono text-xs"
+						/>
+						<span
+							ref={measureRef}
+							aria-hidden="true"
+							className="input-measure font-mono text-xs"
+						>
+							{local || placeholder}
+						</span>
+					</div>
+				)}
 			</HSComp.PopoverAnchor>
 			<HSComp.PopoverContent
 				data-cs-picker-popover="true"
@@ -380,6 +433,8 @@ function CodeSystemPicker({
 									</li>
 								);
 							}
+							const isPinned = (h as CodeSystemHit & { _pinned?: boolean })
+								._pinned;
 							const title = h.title || h.name || h.id || h.url;
 							const secondary = h.description || h.url;
 							return (
@@ -396,8 +451,13 @@ function CodeSystemPicker({
 										onMouseEnter={() => setActiveIndex(i)}
 										className={`w-full text-left px-3 py-1.5 focus:outline-none ${isActive ? "bg-bg-tertiary" : ""}`}
 									>
-										<div className="typo-body text-text-primary truncate">
-											{title}
+										<div className="typo-body text-text-primary truncate flex items-center gap-2">
+											<span className="truncate">{title}</span>
+											{isPinned && (
+												<span className="typo-body-xs text-text-info-primary bg-bg-info-primary rounded-md px-1.5 py-0.5 uppercase shrink-0">
+													group
+												</span>
+											)}
 										</div>
 										<div className="typo-body-xs text-text-secondary line-clamp-1 font-mono">
 											{secondary}
@@ -743,6 +803,205 @@ function CanonicalPicker({
 	);
 }
 
+type ConceptHit = { code: string; display?: string; system?: string };
+
+function ConceptCodePicker({
+	system,
+	code,
+	onChange,
+	placeholder = "code",
+}: {
+	system?: string;
+	code?: string;
+	onChange: (next: { code?: string; display?: string }) => void;
+	placeholder?: string;
+}) {
+	const client = useAidboxClient();
+	const [local, setLocal] = React.useState(code ?? "");
+	const [debounced, setDebounced] = React.useState(local);
+	const [open, setOpen] = React.useState(false);
+	const [activeIndex, setActiveIndex] = React.useState(-1);
+	const itemRefs = React.useRef<Array<HTMLButtonElement | null>>([]);
+	const inputRef = React.useRef<HTMLInputElement | null>(null);
+
+	React.useEffect(() => {
+		setLocal(code ?? "");
+	}, [code]);
+
+	React.useEffect(() => {
+		const t = setTimeout(() => setDebounced(local), 250);
+		return () => clearTimeout(t);
+	}, [local]);
+
+	// strip "|version" — $expand wants the system URL only
+	const systemUrl = system?.split("|", 1)[0];
+
+	const { data: hits } = useQuery({
+		queryKey: ["conceptmap-builder", "concept-picker", systemUrl, debounced],
+		enabled: !!systemUrl,
+		queryFn: async () => {
+			if (!systemUrl) return [];
+			const body = {
+				resourceType: "Parameters" as const,
+				parameter: [
+					{
+						name: "valueSet",
+						resource: {
+							resourceType: "ValueSet" as const,
+							status: "active" as const,
+							compose: { include: [{ system: systemUrl }] },
+						},
+					},
+					...(debounced.trim()
+						? [{ name: "filter", valueString: debounced.trim() }]
+						: []),
+					{ name: "count", valueInteger: 15 },
+				],
+			};
+			const res = await client.request<{
+				expansion?: { contains?: ConceptHit[] };
+			}>({
+				method: "POST",
+				url: "/fhir/ValueSet/$expand",
+				body: JSON.stringify(body),
+				headers: { "Content-Type": "application/fhir+json" },
+			});
+			if (res.isErr()) return [];
+			return res.value.resource.expansion?.contains ?? [];
+		},
+		staleTime: 30_000,
+	});
+
+	const commit = (raw: string) => {
+		setLocal(raw);
+		if (raw !== code) onChange({ code: raw || undefined });
+	};
+
+	const selectHit = (h: ConceptHit) => {
+		setLocal(h.code);
+		onChange({ code: h.code, display: h.display });
+		setOpen(false);
+		setActiveIndex(-1);
+	};
+
+	const hitsList = hits ?? [];
+	const hitsLength = hitsList.length;
+
+	React.useEffect(() => {
+		setActiveIndex(hitsLength > 0 ? 0 : -1);
+	}, [hitsLength]);
+
+	React.useEffect(() => {
+		if (activeIndex < 0) return;
+		itemRefs.current[activeIndex]?.scrollIntoView({ block: "nearest" });
+	}, [activeIndex]);
+
+	return (
+		<HSComp.Popover open={open} onOpenChange={setOpen}>
+			<HSComp.PopoverAnchor asChild>
+				<div className="w-full">
+					<HSComp.Input
+						ref={inputRef}
+						placeholder={placeholder}
+						value={local}
+						onChange={(e) => {
+							setLocal(e.target.value);
+							setOpen(true);
+						}}
+						onClick={(e) => {
+							e.stopPropagation();
+							setOpen(true);
+						}}
+						onFocus={() => setOpen(true)}
+						onBlur={(e) => {
+							const next = e.relatedTarget as HTMLElement | null;
+							if (next?.closest("[data-cm-concept-popover='true']")) return;
+							commit(local);
+							setOpen(false);
+						}}
+						onKeyDown={(e) => {
+							if (e.key === "ArrowDown") {
+								e.preventDefault();
+								if (hitsLength === 0) return;
+								setOpen(true);
+								setActiveIndex((i) => (i + 1) % hitsLength);
+							} else if (e.key === "ArrowUp") {
+								e.preventDefault();
+								if (hitsLength === 0) return;
+								setOpen(true);
+								setActiveIndex((i) => (i <= 0 ? hitsLength - 1 : i - 1));
+							} else if (e.key === "Enter") {
+								e.preventDefault();
+								if (open && activeIndex >= 0 && hitsList[activeIndex]) {
+									selectHit(hitsList[activeIndex]);
+								} else {
+									commit(local);
+									setOpen(false);
+								}
+							} else if (e.key === "Escape") {
+								setOpen(false);
+								setActiveIndex(-1);
+							}
+						}}
+						onMouseDown={(e) => e.stopPropagation()}
+						className="h-7 py-1 px-2 bg-bg-primary border-none hover:bg-bg-quaternary focus:bg-bg-primary group-hover/tree-item-label:bg-bg-tertiary focus:ring-1 focus:ring-border-link font-mono text-xs"
+					/>
+				</div>
+			</HSComp.PopoverAnchor>
+			<HSComp.PopoverContent
+				data-cm-concept-popover="true"
+				className="w-[var(--radix-popover-trigger-width)] min-w-[360px] p-0 max-h-80 overflow-auto"
+				align="start"
+				onOpenAutoFocus={(e) => e.preventDefault()}
+				onInteractOutside={(e) => {
+					if (e.target === inputRef.current) e.preventDefault();
+				}}
+			>
+				{!systemUrl ? (
+					<div className="px-3 py-2 text-text-secondary text-sm">
+						Set a CodeSystem URL on the group to enable code search
+					</div>
+				) : hitsLength === 0 ? (
+					<div className="px-3 py-2 text-text-secondary text-sm">
+						No matches
+					</div>
+				) : (
+					<ul className="py-1">
+						{hitsList.map((h, i) => {
+							const isActive = i === activeIndex;
+							return (
+								<li key={`${h.code}|${h.system ?? ""}`}>
+									<button
+										ref={(el) => {
+											itemRefs.current[i] = el;
+										}}
+										type="button"
+										onClick={(e) => {
+											e.stopPropagation();
+											selectHit(h);
+										}}
+										onMouseEnter={() => setActiveIndex(i)}
+										className={`w-full text-left px-3 py-1.5 focus:outline-none ${isActive ? "bg-bg-tertiary" : ""}`}
+									>
+										<div className="typo-body text-text-primary truncate font-mono">
+											{h.code}
+										</div>
+										{h.display && (
+											<div className="typo-body-xs text-text-secondary line-clamp-1">
+												{h.display}
+											</div>
+										)}
+									</button>
+								</li>
+							);
+						})}
+					</ul>
+				)}
+			</HSComp.PopoverContent>
+		</HSComp.Popover>
+	);
+}
+
 const LABEL_OVERRIDES: Partial<Record<ItemMeta["type"], string>> = {
 	groups: "groups",
 };
@@ -751,10 +1010,16 @@ function InputView({
 	placeholder,
 	value,
 	onChange,
+	name,
+	autoComplete,
+	list,
 }: {
 	placeholder: string;
 	value?: string;
 	onChange?: (value: string) => void;
+	name?: string;
+	autoComplete?: string;
+	list?: string;
 }) {
 	const [localValue, setLocalValue] = React.useState(value ?? "");
 	const timeoutRef = React.useRef<ReturnType<typeof setTimeout> | undefined>(
@@ -775,6 +1040,9 @@ function InputView({
 
 	return (
 		<HSComp.Input
+			name={name}
+			autoComplete={autoComplete}
+			list={list}
 			className="h-7 py-1 px-2 bg-bg-primary border-none hover:bg-bg-quaternary focus:bg-bg-primary group-hover/tree-item-label:bg-bg-tertiary focus:ring-1 focus:ring-border-link"
 			placeholder={placeholder}
 			value={localValue}
@@ -1027,6 +1295,9 @@ export function PropertiesTree() {
 	const fhirVersion = useFhirServerVersion();
 	const isR4 = isR4Like(fhirVersion);
 	const relationshipOptions = isR4 ? EQUIVALENCES_R4 : RELATIONSHIPS_R5;
+	const [urlHistory] = React.useState<string[]>(() =>
+		readUrlHistory(URL_HISTORY_KEY),
+	);
 
 	const updateField = <K extends keyof ConceptMap>(
 		key: K,
@@ -1053,8 +1324,18 @@ export function PropertiesTree() {
 		});
 
 	const addGroup = () => {
+		const newIndex = conceptMap.group?.length ?? 0;
 		mutateGroups((arr) => [...arr, {}]);
-		setExpandedItems((prev) => Array.from(new Set([...prev, "_groups"])));
+		setExpandedItems((prev) =>
+			Array.from(
+				new Set([
+					...prev,
+					"_groups",
+					groupRowId(newIndex),
+					elementsSectionId(newIndex),
+				]),
+			),
+		);
 	};
 
 	const removeGroupAt = (i: number) =>
@@ -1108,12 +1389,15 @@ export function PropertiesTree() {
 		});
 
 	const addElementAt = (gi: number) => {
+		const defaultTarget: ConceptMapTarget = isR4
+			? { equivalence: "equivalent" }
+			: { relationship: "equivalent" };
 		mutateGroups((arr) => {
 			const next = arr.slice();
 			const g = next[gi] ?? {};
 			next[gi] = {
 				...g,
-				element: [...(g.element ?? []), { target: [{}] }],
+				element: [...(g.element ?? []), { target: [defaultTarget] }],
 			};
 			return next;
 		});
@@ -1298,6 +1582,9 @@ export function PropertiesTree() {
 						<div className="w-[246px] shrink-0">{labelView(item)}</div>
 						<div className="w-[50%]">
 							<InputView
+								name="conceptmap-url"
+								autoComplete="on"
+								list="conceptmap-builder-url-history"
 								placeholder="Canonical identifier for this concept map, represented as a URI (globally unique)"
 								value={conceptMap.url}
 								onChange={(v) => updateField("url", v)}
@@ -1525,7 +1812,8 @@ export function PropertiesTree() {
 			case "element-row": {
 				const gi = meta?.groupIndex ?? -1;
 				const ei = meta?.elementIndex ?? -1;
-				const el = groups[gi]?.element?.[ei];
+				const g = groups[gi];
+				const el = g?.element?.[ei];
 				const t = el?.target?.[0];
 				const relation = getTargetRel(t, isR4);
 				return (
@@ -1534,10 +1822,11 @@ export function PropertiesTree() {
 							<Link2 size={12} />
 						</span>
 						<div className="w-[200px] shrink-0">
-							<InputView
+							<ConceptCodePicker
+								system={g?.source}
+								code={el?.code}
 								placeholder="source code"
-								value={el?.code}
-								onChange={(v) => updateElementCode(gi, ei, v)}
+								onChange={(next) => updateElementCode(gi, ei, next.code ?? "")}
 							/>
 						</div>
 						<div className="w-[220px] shrink-0">
@@ -1560,10 +1849,11 @@ export function PropertiesTree() {
 							</HSComp.Select>
 						</div>
 						<div className="w-[200px] shrink-0">
-							<InputView
+							<ConceptCodePicker
+								system={g?.target}
+								code={t?.code}
 								placeholder="target code"
-								value={t?.code}
-								onChange={(v) => updateTargetCode(gi, ei, v)}
+								onChange={(next) => updateTargetCode(gi, ei, next.code ?? "")}
 							/>
 						</div>
 						<HSComp.Button
@@ -1669,6 +1959,11 @@ export function PropertiesTree() {
 					return "pr-0";
 				}}
 			/>
+			<datalist id="conceptmap-builder-url-history">
+				{urlHistory.map((u) => (
+					<option key={u} value={u} />
+				))}
+			</datalist>
 		</div>
 	);
 }

--- a/src/components/ConceptMap/translate-panel.tsx
+++ b/src/components/ConceptMap/translate-panel.tsx
@@ -1,0 +1,260 @@
+import * as HSComp from "@health-samurai/react-components";
+import { useMutation } from "@tanstack/react-query";
+import { ArrowRightLeft, X } from "lucide-react";
+import * as React from "react";
+import { useAidboxClient } from "../../AidboxClient";
+import { cleanEmptyValues } from "../../utils/clean-empty-values";
+import { useConceptMapContext } from "./context";
+import type { ConceptMap } from "./types";
+import { isR4Like, useFhirServerVersion } from "./version";
+
+type ParametersParameter = {
+	name: string;
+	resource?: unknown;
+	valueBoolean?: boolean;
+	valueString?: string;
+	valueCode?: string;
+	valueUri?: string;
+	valueCanonical?: string;
+	valueCoding?: {
+		system?: string;
+		code?: string;
+		display?: string;
+		version?: string;
+	};
+	part?: ParametersParameter[];
+};
+
+type ParametersResource = {
+	resourceType: "Parameters";
+	parameter?: ParametersParameter[];
+};
+
+type Match = {
+	relationship?: string;
+	concept?: {
+		system?: string;
+		code?: string;
+		display?: string;
+		version?: string;
+	};
+	originMap?: string;
+};
+
+function buildTranslateParameters({
+	conceptMap,
+	code,
+	system,
+	isR4,
+}: {
+	conceptMap: ConceptMap;
+	code: string;
+	system?: string;
+	isR4: boolean;
+}): ParametersResource {
+	const parameter: ParametersParameter[] = [
+		{ name: "conceptMap", resource: cleanEmptyValues(conceptMap) },
+		{ name: isR4 ? "code" : "sourceCode", valueCode: code },
+	];
+	if (system) {
+		parameter.push({ name: "system", valueUri: system });
+	}
+	return { resourceType: "Parameters", parameter };
+}
+
+function parseTranslateResult(result: ParametersResource | undefined) {
+	if (!result) return { success: undefined, message: undefined, matches: [] };
+	const params = result.parameter ?? [];
+	const success = params.find((p) => p.name === "result")?.valueBoolean;
+	const message = params.find((p) => p.name === "message")?.valueString;
+	const matches: Match[] = params
+		.filter((p) => p.name === "match")
+		.map((p) => {
+			const parts = p.part ?? [];
+			const relationship =
+				parts.find((x) => x.name === "relationship")?.valueCode ??
+				parts.find((x) => x.name === "equivalence")?.valueCode;
+			const concept = parts.find((x) => x.name === "concept")?.valueCoding;
+			const originMap =
+				parts.find((x) => x.name === "originMap")?.valueCanonical ??
+				parts.find((x) => x.name === "source")?.valueUri;
+			return { relationship, concept, originMap };
+		});
+	return { success, message, matches };
+}
+
+// Pick a reasonable default system for the user — first group with source.
+function defaultSystemFromMap(conceptMap: ConceptMap): string | undefined {
+	const g = conceptMap.group?.find((x) => x.source);
+	const src = g?.source;
+	if (!src) return undefined;
+	// strip "|version" if it's a canonical with version
+	return src.split("|", 1)[0];
+}
+
+export function TranslatePanel({ onClose }: { onClose: () => void }) {
+	const client = useAidboxClient();
+	const { conceptMap } = useConceptMapContext();
+	const fhirVersion = useFhirServerVersion();
+	const isR4 = isR4Like(fhirVersion);
+
+	const [code, setCode] = React.useState("");
+	const [system, setSystem] = React.useState("");
+
+	const systemPlaceholder =
+		defaultSystemFromMap(conceptMap) ?? "system (optional)";
+
+	const mutation = useMutation({
+		mutationFn: async (input: { code: string; system: string }) => {
+			const params = buildTranslateParameters({
+				conceptMap,
+				code: input.code,
+				system: input.system || defaultSystemFromMap(conceptMap),
+				isR4,
+			});
+			const res = await client.request<ParametersResource>({
+				method: "POST",
+				url: "/fhir/ConceptMap/$translate",
+				body: JSON.stringify(params),
+				headers: { "Content-Type": "application/json" },
+			});
+			if (res.isErr()) throw res.value.resource;
+			return res.value.resource;
+		},
+	});
+
+	const { success, message, matches } = parseTranslateResult(mutation.data);
+	const oo = mutation.error as
+		| {
+				resourceType?: string;
+				issue?: Array<{ diagnostics?: string; severity?: string }>;
+		  }
+		| undefined;
+
+	const handleRun = () => {
+		if (!code) return;
+		mutation.mutate({ code, system });
+	};
+
+	return (
+		<div className="flex-none border-t bg-bg-secondary flex flex-col max-h-[50%]">
+			<div className="flex items-center justify-between h-10 px-4 border-b flex-none">
+				<div className="flex items-center gap-2">
+					<ArrowRightLeft size={14} className="text-text-info-primary" />
+					<span className="typo-label uppercase text-text-info-primary">
+						Translate
+					</span>
+				</div>
+				<HSComp.Button
+					variant="ghost"
+					size="small"
+					className="px-0!"
+					onClick={onClose}
+					asChild
+				>
+					<span>
+						<X size={14} />
+					</span>
+				</HSComp.Button>
+			</div>
+			<div className="flex-1 min-h-0 overflow-auto p-4 space-y-3">
+				<div className="flex flex-wrap items-center gap-2">
+					<HSComp.Input
+						className="h-7 py-1 px-2 font-mono text-xs max-w-[200px]"
+						placeholder="source code (required)"
+						value={code}
+						onChange={(e) => setCode(e.target.value)}
+						onKeyDown={(e) => {
+							if (e.key === "Enter") handleRun();
+						}}
+					/>
+					<HSComp.Input
+						className="h-7 py-1 px-2 font-mono text-xs flex-1 min-w-[200px]"
+						placeholder={systemPlaceholder}
+						value={system}
+						onChange={(e) => setSystem(e.target.value)}
+						onKeyDown={(e) => {
+							if (e.key === "Enter") handleRun();
+						}}
+					/>
+					<HSComp.Button
+						variant="primary"
+						size="small"
+						onClick={handleRun}
+						disabled={!code || mutation.isPending}
+					>
+						{mutation.isPending ? "Translating…" : "Translate"}
+					</HSComp.Button>
+				</div>
+
+				{oo?.issue && (
+					<div className="rounded-md border border-border-error-primary bg-bg-error-primary/10 p-3 text-text-error-primary text-xs">
+						{oo.issue.map((i, idx) => (
+							<div key={`${idx}-${i.diagnostics ?? ""}`}>
+								<span className="font-mono">[{i.severity ?? "error"}]</span>{" "}
+								{i.diagnostics ?? "Unknown error"}
+							</div>
+						))}
+					</div>
+				)}
+
+				{mutation.data && (
+					<div className="space-y-2">
+						<div className="flex items-center gap-2 typo-label">
+							<span
+								className={`inline-flex items-center justify-center px-2 py-0.5 rounded-md text-xs uppercase ${
+									success
+										? "text-text-success-primary bg-bg-success-primary"
+										: "text-text-warning-primary bg-bg-warning-primary"
+								}`}
+							>
+								{success ? "found" : "no match"}
+							</span>
+							<span className="text-text-secondary">
+								{matches.length} match{matches.length === 1 ? "" : "es"}
+							</span>
+							{message && (
+								<span className="text-text-secondary text-xs">— {message}</span>
+							)}
+						</div>
+						{matches.map((m, idx) => (
+							<div
+								key={`${idx}-${m.concept?.code ?? ""}`}
+								className="border border-border-primary rounded-md p-3 space-y-1"
+							>
+								<div className="flex items-baseline gap-2">
+									<span className="font-mono text-sm">
+										{m.concept?.code ?? "—"}
+									</span>
+									{m.concept?.display && (
+										<span className="text-text-secondary text-sm">
+											{m.concept.display}
+										</span>
+									)}
+								</div>
+								{m.concept?.system && (
+									<div className="font-mono text-xs text-text-secondary">
+										system: {m.concept.system}
+										{m.concept.version ? `|${m.concept.version}` : ""}
+									</div>
+								)}
+								{m.relationship && (
+									<div className="text-xs">
+										<span className="text-text-secondary">relationship: </span>
+										<span className="font-mono">{m.relationship}</span>
+									</div>
+								)}
+								{m.originMap && (
+									<div className="text-xs">
+										<span className="text-text-secondary">via: </span>
+										<span className="font-mono">{m.originMap}</span>
+									</div>
+								)}
+							</div>
+						))}
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/src/components/ConceptMap/translate-panel.tsx
+++ b/src/components/ConceptMap/translate-panel.tsx
@@ -1,10 +1,11 @@
 import * as HSComp from "@health-samurai/react-components";
 import { useMutation } from "@tanstack/react-query";
-import { ArrowRightLeft, X } from "lucide-react";
+import { X } from "lucide-react";
 import * as React from "react";
 import { useAidboxClient } from "../../AidboxClient";
 import { cleanEmptyValues } from "../../utils/clean-empty-values";
 import { useConceptMapContext } from "./context";
+import { CodeSystemPicker } from "./properties-tree";
 import type { ConceptMap } from "./types";
 import { isR4Like, useFhirServerVersion } from "./version";
 
@@ -52,8 +53,16 @@ function buildTranslateParameters({
 	system?: string;
 	isR4: boolean;
 }): ParametersResource {
+	// Strip server-tracked fields (id, meta) from the inline conceptMap.
+	// Aidbox $translate duplicates matches when inline.id matches a saved
+	// resource — server treats it as both an inline draft AND a DB reference.
+	// Sending it as an anonymous inline avoids the bug; the test still
+	// reflects unsaved form changes (which was the whole point).
+	const { id, meta, ...inlineCm } = cleanEmptyValues(conceptMap) as ConceptMap;
+	void id;
+	void meta;
 	const parameter: ParametersParameter[] = [
-		{ name: "conceptMap", resource: cleanEmptyValues(conceptMap) },
+		{ name: "conceptMap", resource: inlineCm },
 		{ name: isR4 ? "code" : "sourceCode", valueCode: code },
 	];
 	if (system) {
@@ -83,13 +92,30 @@ function parseTranslateResult(result: ParametersResource | undefined) {
 	return { success, message, matches };
 }
 
-// Pick a reasonable default system for the user — first group with source.
-function defaultSystemFromMap(conceptMap: ConceptMap): string | undefined {
-	const g = conceptMap.group?.find((x) => x.source);
-	const src = g?.source;
-	if (!src) return undefined;
-	// strip "|version" if it's a canonical with version
-	return src.split("|", 1)[0];
+// Unique source systems pulled from the ConceptMap (version stripped from
+// canonicals). Drives both the system input shape (hidden / dropdown / text)
+// and the code suggestions filter.
+function getSourceSystems(conceptMap: ConceptMap): string[] {
+	const set = new Set<string>();
+	for (const g of conceptMap.group ?? []) {
+		if (!g.source) continue;
+		const url = g.source.split("|", 1)[0];
+		if (url) set.add(url);
+	}
+	return [...set];
+}
+
+// Unique element.code values, optionally filtered by selected source system.
+function getElementCodes(conceptMap: ConceptMap, system: string): string[] {
+	const set = new Set<string>();
+	for (const g of conceptMap.group ?? []) {
+		const gs = g.source?.split("|", 1)[0];
+		if (system && gs && gs !== system) continue;
+		for (const el of g.element ?? []) {
+			if (el.code) set.add(el.code);
+		}
+	}
+	return [...set];
 }
 
 export function TranslatePanel({ onClose }: { onClose: () => void }) {
@@ -98,18 +124,26 @@ export function TranslatePanel({ onClose }: { onClose: () => void }) {
 	const fhirVersion = useFhirServerVersion();
 	const isR4 = isR4Like(fhirVersion);
 
-	const [code, setCode] = React.useState("");
-	const [system, setSystem] = React.useState("");
+	const sourceOptions = React.useMemo(
+		() => getSourceSystems(conceptMap),
+		[conceptMap],
+	);
+	const datalistId = React.useId();
 
-	const systemPlaceholder =
-		defaultSystemFromMap(conceptMap) ?? "system (optional)";
+	const [code, setCode] = React.useState("");
+	const [system, setSystem] = React.useState(() => sourceOptions[0] ?? "");
+
+	const codeOptions = React.useMemo(
+		() => getElementCodes(conceptMap, system),
+		[conceptMap, system],
+	);
 
 	const mutation = useMutation({
 		mutationFn: async (input: { code: string; system: string }) => {
 			const params = buildTranslateParameters({
 				conceptMap,
 				code: input.code,
-				system: input.system || defaultSystemFromMap(conceptMap),
+				system: input.system || undefined,
 				isR4,
 			});
 			const res = await client.request<ParametersResource>({
@@ -123,7 +157,7 @@ export function TranslatePanel({ onClose }: { onClose: () => void }) {
 		},
 	});
 
-	const { success, message, matches } = parseTranslateResult(mutation.data);
+	const { matches } = parseTranslateResult(mutation.data);
 	const oo = mutation.error as
 		| {
 				resourceType?: string;
@@ -137,14 +171,9 @@ export function TranslatePanel({ onClose }: { onClose: () => void }) {
 	};
 
 	return (
-		<div className="flex-none border-t bg-bg-secondary flex flex-col max-h-[50%]">
+		<div className="bg-bg-secondary flex flex-col h-full">
 			<div className="flex items-center justify-between h-10 px-4 border-b flex-none">
-				<div className="flex items-center gap-2">
-					<ArrowRightLeft size={14} className="text-text-info-primary" />
-					<span className="typo-label uppercase text-text-info-primary">
-						Translate
-					</span>
-				</div>
+				<span className="typo-label text-text-secondary">Translation</span>
 				<HSComp.Button
 					variant="ghost"
 					size="small"
@@ -157,38 +186,52 @@ export function TranslatePanel({ onClose }: { onClose: () => void }) {
 					</span>
 				</HSComp.Button>
 			</div>
-			<div className="flex-1 min-h-0 overflow-auto p-4 space-y-3">
-				<div className="flex flex-wrap items-center gap-2">
-					<HSComp.Input
-						className="h-7 py-1 px-2 font-mono text-xs max-w-[200px]"
-						placeholder="source code (required)"
-						value={code}
-						onChange={(e) => setCode(e.target.value)}
-						onKeyDown={(e) => {
-							if (e.key === "Enter") handleRun();
-						}}
+			<div className="px-4 py-3 border-b bg-bg-tertiary flex-none">
+				<div className="flex gap-2">
+					<CodeSystemPicker
+						system={system}
+						onChange={(next) => setSystem(next.system ?? "")}
+						pinnedSystems={sourceOptions}
+						variant="form"
+						prefixLabel="system"
+						placeholder="search CodeSystem…"
+						onEnter={handleRun}
 					/>
-					<HSComp.Input
-						className="h-7 py-1 px-2 font-mono text-xs flex-1 min-w-[200px]"
-						placeholder={systemPlaceholder}
-						value={system}
-						onChange={(e) => setSystem(e.target.value)}
-						onKeyDown={(e) => {
-							if (e.key === "Enter") handleRun();
-						}}
-					/>
+					<div className="flex-1 min-w-0 basis-0">
+						<HSComp.Input
+							type="text"
+							className="bg-bg-primary"
+							list={datalistId}
+							prefixValue={
+								<span className="text-nowrap text-elements-assistive font-medium">
+									code
+								</span>
+							}
+							placeholder="e.g., info"
+							value={code}
+							onChange={(e) => setCode(e.target.value)}
+							onKeyPress={(e) => {
+								if (e.key === "Enter") handleRun();
+							}}
+						/>
+					</div>
+					<datalist id={datalistId}>
+						{codeOptions.map((c) => (
+							<option key={c} value={c} />
+						))}
+					</datalist>
 					<HSComp.Button
-						variant="primary"
-						size="small"
+						variant="secondary"
 						onClick={handleRun}
 						disabled={!code || mutation.isPending}
 					>
-						{mutation.isPending ? "Translating…" : "Translate"}
+						Translate
 					</HSComp.Button>
 				</div>
-
+			</div>
+			<div className="flex-1 min-h-0 overflow-auto bg-bg-primary">
 				{oo?.issue && (
-					<div className="rounded-md border border-border-error-primary bg-bg-error-primary/10 p-3 text-text-error-primary text-xs">
+					<div className="m-4 rounded-md border border-border-error-primary bg-bg-error-primary/10 p-3 text-text-error-primary text-xs">
 						{oo.issue.map((i, idx) => (
 							<div key={`${idx}-${i.diagnostics ?? ""}`}>
 								<span className="font-mono">[{i.severity ?? "error"}]</span>{" "}
@@ -197,62 +240,46 @@ export function TranslatePanel({ onClose }: { onClose: () => void }) {
 						))}
 					</div>
 				)}
-
-				{mutation.data && (
-					<div className="space-y-2">
-						<div className="flex items-center gap-2 typo-label">
-							<span
-								className={`inline-flex items-center justify-center px-2 py-0.5 rounded-md text-xs uppercase ${
-									success
-										? "text-text-success-primary bg-bg-success-primary"
-										: "text-text-warning-primary bg-bg-warning-primary"
-								}`}
-							>
-								{success ? "found" : "no match"}
-							</span>
-							<span className="text-text-secondary">
-								{matches.length} match{matches.length === 1 ? "" : "es"}
-							</span>
-							{message && (
-								<span className="text-text-secondary text-xs">— {message}</span>
-							)}
-						</div>
-						{matches.map((m, idx) => (
-							<div
-								key={`${idx}-${m.concept?.code ?? ""}`}
-								className="border border-border-primary rounded-md p-3 space-y-1"
-							>
-								<div className="flex items-baseline gap-2">
-									<span className="font-mono text-sm">
-										{m.concept?.code ?? "—"}
-									</span>
-									{m.concept?.display && (
-										<span className="text-text-secondary text-sm">
-											{m.concept.display}
-										</span>
-									)}
-								</div>
-								{m.concept?.system && (
-									<div className="font-mono text-xs text-text-secondary">
-										system: {m.concept.system}
-										{m.concept.version ? `|${m.concept.version}` : ""}
-									</div>
-								)}
-								{m.relationship && (
-									<div className="text-xs">
-										<span className="text-text-secondary">relationship: </span>
-										<span className="font-mono">{m.relationship}</span>
-									</div>
-								)}
-								{m.originMap && (
-									<div className="text-xs">
-										<span className="text-text-secondary">via: </span>
-										<span className="font-mono">{m.originMap}</span>
-									</div>
-								)}
-							</div>
-						))}
-					</div>
+				{mutation.data && matches.length > 0 && (
+					<HSComp.Table zebra stickyHeader className="typo-code">
+						<HSComp.TableHeader className="z-0">
+							<HSComp.TableRow>
+								<HSComp.TableHead>Relationship</HSComp.TableHead>
+								<HSComp.TableHead>Code</HSComp.TableHead>
+								<HSComp.TableHead>Display</HSComp.TableHead>
+								<HSComp.TableHead>System</HSComp.TableHead>
+								<HSComp.TableHead>Source</HSComp.TableHead>
+								<HSComp.TableHead className="w-full p-0" />
+							</HSComp.TableRow>
+						</HSComp.TableHeader>
+						<HSComp.TableBody>
+							{matches.map((m, idx) => (
+								<HSComp.TableRow
+									// biome-ignore lint/suspicious/noArrayIndexKey: match order is stable
+									key={idx}
+									zebra
+									index={idx}
+								>
+									<HSComp.TableCell>{m.relationship ?? "—"}</HSComp.TableCell>
+									<HSComp.TableCell>{m.concept?.code ?? "—"}</HSComp.TableCell>
+									<HSComp.TableCell>
+										{m.concept?.display ?? "—"}
+									</HSComp.TableCell>
+									<HSComp.TableCell className="text-text-secondary">
+										{m.concept?.system ?? "—"}
+										{m.concept?.version ? `|${m.concept.version}` : ""}
+									</HSComp.TableCell>
+									<HSComp.TableCell className="text-text-secondary">
+										{m.originMap ?? "—"}
+									</HSComp.TableCell>
+									<HSComp.TableCell className="p-0" />
+								</HSComp.TableRow>
+							))}
+						</HSComp.TableBody>
+					</HSComp.Table>
+				)}
+				{mutation.data && matches.length === 0 && !oo?.issue && (
+					<div className="p-4 text-text-secondary text-xs">No match</div>
 				)}
 			</div>
 		</div>

--- a/src/components/ConceptMap/types.ts
+++ b/src/components/ConceptMap/types.ts
@@ -1,0 +1,57 @@
+import type { Resource } from "@aidbox-ui/fhir-types/hl7-fhir-r5-core";
+
+export type ConceptMapTarget = {
+	code?: string;
+	display?: string;
+	relationship?: string; // R5+
+	equivalence?: string; // R4
+	comment?: string;
+};
+
+export type ConceptMapElement = {
+	code?: string;
+	display?: string;
+	noMap?: boolean;
+	target?: ConceptMapTarget[];
+};
+
+export type ConceptMapUnmapped = {
+	mode?: string;
+	code?: string;
+	display?: string;
+	url?: string; // R4
+	otherMap?: string; // R5+
+	valueSet?: string; // R5+
+	relationship?: string; // R5+
+	comment?: string; // R6+
+};
+
+export type ConceptMapGroup = {
+	source?: string;
+	sourceVersion?: string;
+	target?: string;
+	targetVersion?: string;
+	element?: ConceptMapElement[];
+	unmapped?: ConceptMapUnmapped;
+};
+
+export type ConceptMap = Resource & {
+	resourceType: "ConceptMap";
+	url?: string;
+	version?: string;
+	name?: string;
+	title?: string;
+	status?: "draft" | "active" | "retired" | "unknown";
+	description?: string;
+	// R4 source[x] / target[x] (scope of the whole map)
+	sourceUri?: string;
+	sourceCanonical?: string;
+	targetUri?: string;
+	targetCanonical?: string;
+	// R5 sourceScope[x] / targetScope[x]
+	sourceScopeUri?: string;
+	sourceScopeCanonical?: string;
+	targetScopeUri?: string;
+	targetScopeCanonical?: string;
+	group?: ConceptMapGroup[];
+};

--- a/src/components/ConceptMap/version.ts
+++ b/src/components/ConceptMap/version.ts
@@ -1,0 +1,24 @@
+import { useQuery } from "@tanstack/react-query";
+import { useAidboxClient } from "../../AidboxClient";
+
+export function useFhirServerVersion(): string | undefined {
+	const client = useAidboxClient();
+	const { data } = useQuery({
+		queryKey: ["fhir-metadata-version"],
+		queryFn: async () => {
+			const res = await client.request<{ fhirVersion?: string }>({
+				method: "GET",
+				url: "/fhir/metadata?_elements=fhirVersion",
+			});
+			if (res.isErr()) return undefined;
+			return res.value.resource.fhirVersion;
+		},
+		staleTime: Number.POSITIVE_INFINITY,
+	});
+	return data;
+}
+
+// "4.0.x" / "4.3.x" → R4-style. "5.x" / "6.x" → R5-style.
+export const isR4Like = (fhirVersion?: string): boolean =>
+	!!fhirVersion &&
+	(fhirVersion.startsWith("4.0") || fhirVersion.startsWith("4.3"));

--- a/src/components/ResourceEditor/page.tsx
+++ b/src/components/ResourceEditor/page.tsx
@@ -27,6 +27,8 @@ import { AccessPolicyBuilderContent } from "../AccessPolicy/builder-content";
 import { AccessPolicyProvider } from "../AccessPolicy/page";
 import { CodeSystemBuilderContent } from "../CodeSystem/builder-content";
 import { CodeSystemProvider } from "../CodeSystem/page";
+import { ConceptMapBuilderContent } from "../ConceptMap/builder-content";
+import { ConceptMapProvider } from "../ConceptMap/page";
 import { EmptyState } from "../empty-state";
 import { SearchParameterBuilderContent } from "../SearchParameter/builder-content";
 import { IndexesTab as SearchParameterIndexesTab } from "../SearchParameter/indexes-tab";
@@ -376,6 +378,7 @@ export const ResourceEditorPage = ({
 	const isLibrary = resourceType === "Library";
 	const isValueSet = resourceType === "ValueSet";
 	const isCodeSystem = resourceType === "CodeSystem";
+	const isConceptMap = resourceType === "ConceptMap";
 	const isSQLQuery =
 		isLibrary &&
 		Boolean(
@@ -442,6 +445,22 @@ export const ResourceEditorPage = ({
 			content: (
 				<HSComp.TabsContent value="builder" className="grow min-h-0">
 					<CodeSystemBuilderContent />
+				</HSComp.TabsContent>
+			),
+		});
+	}
+
+	if (isConceptMap) {
+		tabs.push({
+			value: "builder",
+			trigger: (
+				<HSComp.TabsTrigger value="builder">
+					ConceptMap Builder
+				</HSComp.TabsTrigger>
+			),
+			content: (
+				<HSComp.TabsContent value="builder" className="grow min-h-0">
+					<ConceptMapBuilderContent />
 				</HSComp.TabsContent>
 			),
 		});
@@ -752,6 +771,14 @@ export const ResourceEditorPage = ({
 			<CodeSystemProvider initialResource={initialResource}>
 				{content}
 			</CodeSystemProvider>
+		);
+	}
+
+	if (isConceptMap) {
+		return (
+			<ConceptMapProvider initialResource={initialResource}>
+				{content}
+			</ConceptMapProvider>
 		);
 	}
 

--- a/src/components/ResourceEditor/types.ts
+++ b/src/components/ResourceEditor/types.ts
@@ -40,6 +40,7 @@ export const RESOURCE_TYPES_WITH_BUILDER = new Set([
 	"SearchParameter",
 	"ValueSet",
 	"CodeSystem",
+	"ConceptMap",
 ]);
 
 /**

--- a/src/index.css
+++ b/src/index.css
@@ -38,6 +38,17 @@ tr:hover .pin-button {
 	opacity: 0.5 !important;
 }
 
+/* Hidden span used for cross-browser text width measurement
+   (used by CodeSystemPicker for auto-sizing the input field) */
+.input-measure {
+	position: absolute;
+	visibility: hidden;
+	pointer-events: none;
+	white-space: pre;
+	top: -9999px;
+	left: -9999px;
+}
+
 /* Fix CodeMirror tooltip containers inheriting padding from baseTheme in react-components.
    The baseTheme uses "&" selector which applies padding to all elements with theme class prefix,
    including tooltip containers appended to body. These containers are not editors but inherit


### PR DESCRIPTION
## Summary

- New builder tab for `ConceptMap` (`/u/resource/ConceptMap/edit/<id>` or `/create`).
- Properties tree: url / version / status / title / description + root sourceScope / targetScope (ValueSet picker).
- Groups: numeric header + source → target CodeSystem pickers, inline element rows with source code / relationship / target code, `+ Element`, `+ Group`, conditional `unmapped` row.
- `$translate` side-panel (Translation toggle in header): inline `conceptMap` resource, version-aware params (`code`/`sourceCode`), parses both `equivalence` (R4) and `relationship` (R5) match shapes, results in HSComp.Table.
- Server `fhirVersion` (via `GET /fhir/metadata`) drives field shape and enum lists across the form.

## Highlights

- Source/target code inputs are `ConceptCodePicker` via `POST /fhir/ValueSet/\$expand` with inline VS (works for any CodeSystem).
- system input in translate panel uses `CodeSystemPicker variant="form"` with `group.source` pinned ("GROUP" badge).
- Defaults: new target → `relationship/equivalence = "equivalent"`, status = `draft`, version = `1.0.0`, group source/target written per FHIR version (R5 → `source = "url|version"`; R4 → separate `sourceVersion`).
- Aidbox `\$translate` workaround: strip `id`/`meta` from inline conceptMap (saved `id` triggers duplicate matches).
- URL datalist (history persisted in localStorage), Redirect from `/create` → `/edit/{id}` after first save.

## Test plan

- [ ] Open existing `ConceptMap` (R4 + R5 file) → builder loads, Properties + Groups + Elements rendered correctly per version.
- [ ] Create new ConceptMap → defaults preset, save POSTs and URL redirects to `/edit/<id>`.
- [ ] Edit `group.source`/`target` via CodeSystemPicker, verify pipe-version write on R5 server and `sourceVersion`/`targetVersion` write on R4 server.
- [ ] Add element → source/target code search via `\$expand`, relationship Select uses correct enum per FHIR version, change of `relationship`/`equivalence` writes to the correct field.
- [ ] Unmapped: switch `mode` (provided / fixed / other-map / use-source-code) → fields toggle accordingly, `code`/`display`/`otherMap` written per FHIR version.
- [ ] Open Translation panel → enter `system` and `code`, hit Translate → table shows matches; "GROUP" pinned suggestions appear in system picker; "No match" fallback works.
- [ ] Save existing record → toast appears, URL stays on `/edit/<id>`.