### PR TITLE
Clipboard: HTTP-safe fallback for copy actions

### DIFF
--- a/src/components/ResourceBrowser/page.tsx
+++ b/src/components/ResourceBrowser/page.tsx
@@ -14,6 +14,7 @@ import {
 import * as ApiUtils from "../../api/utils";
 import * as Humanize from "../../humanize";
 import * as Utils from "../../utils";
+import { copyToClipboard } from "../../utils/clipboard";
 import { useWebMCPResourceInstances } from "../../webmcp/resource-instances";
 import type { ResourceInstancesActions } from "../../webmcp/resource-instances-context";
 import {
@@ -97,7 +98,7 @@ export const ResourcesTabSarchInput = () => {
 	};
 
 	const handleCopy = () => {
-		navigator.clipboard.writeText(queryValue);
+		copyToClipboard(queryValue);
 	};
 
 	return (

--- a/src/components/ViewDefinition/editor-panel-content.tsx
+++ b/src/components/ViewDefinition/editor-panel-content.tsx
@@ -23,6 +23,7 @@ import React from "react";
 import { type AidboxClientR5, useAidboxClient } from "../../AidboxClient";
 import * as Utils from "../../api/utils";
 import { useLocalStorage } from "../../hooks";
+import { copyToClipboard } from "../../utils/clipboard";
 import { addUrlToHistory } from "../../utils/url-history";
 import { useWebMCPViewDefinition } from "../../webmcp/view-definition";
 import type { ViewDefinitionBuilderActions } from "../../webmcp/view-definition-context";
@@ -493,7 +494,7 @@ export const useViewDefinitionActions = (
 						aria-label="Copy view name"
 						icon={<Lucide.CopyIcon className="w-4 h-4" />}
 						onClick={() => {
-							navigator.clipboard.writeText(viewName);
+							copyToClipboard(viewName);
 							HSComp.toast.success("Copied to clipboard", {
 								position: "bottom-right",
 								style: { margin: "1rem" },

--- a/src/components/claude-chat/element-context-badge.tsx
+++ b/src/components/claude-chat/element-context-badge.tsx
@@ -1,5 +1,6 @@
 import { Badge } from "@health-samurai/react-components";
 import { Copy, X } from "lucide-react";
+import { copyToClipboard } from "../../utils/clipboard";
 import { useChatDispatch, useChatState } from "./chat-context";
 import { formatElementContexts } from "./types";
 
@@ -36,9 +37,7 @@ export function ElementContextBadge() {
 			<button
 				type="button"
 				className="text-text-secondary hover:text-text-primary shrink-0"
-				onClick={() =>
-					navigator.clipboard.writeText(formatElementContexts(elementContexts))
-				}
+				onClick={() => copyToClipboard(formatElementContexts(elementContexts))}
 			>
 				<Copy className="size-3.5" />
 			</button>

--- a/src/components/claude-chat/element-picker.tsx
+++ b/src/components/claude-chat/element-picker.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef } from "react";
+import { copyToClipboard } from "../../utils/clipboard";
 import { useChatDispatch, useChatState } from "./chat-context";
 import type { ElementContext } from "./types";
 
@@ -277,7 +278,7 @@ export function ElementPicker() {
 			try {
 				const context = extractElementContext(el);
 				dispatch({ type: "add_element_context", context });
-				navigator.clipboard.writeText(JSON.stringify(context, null, 2));
+				copyToClipboard(JSON.stringify(context, null, 2));
 			} catch (err) {
 				console.error("[element-picker] extraction failed:", err);
 			}

--- a/src/components/db-console/result-content.tsx
+++ b/src/components/db-console/result-content.tsx
@@ -28,6 +28,7 @@ import {
 } from "lucide-react";
 import type React from "react";
 import { useCallback, useMemo, useRef, useState } from "react";
+import { copyToClipboard } from "../../utils/clipboard";
 import type { QueryResultItem } from "../../webmcp/db-console-context";
 import { LIMIT_PRESETS, TIMEOUT_PRESETS } from "./utils";
 
@@ -525,7 +526,7 @@ export function ExportDropdown({
 				downloadFile(combined, "export.csv", "text/csv;charset=utf-8;");
 			} else {
 				const separator = format === "markdown" ? "\n\n" : "\n";
-				navigator.clipboard.writeText(parts.join(separator));
+				copyToClipboard(parts.join(separator));
 			}
 		},
 		[],
@@ -556,18 +557,14 @@ export function ExportDropdown({
 								<DropdownMenuContent side="left">
 									<DropdownMenuItem
 										onClick={() =>
-											navigator.clipboard.writeText(
-												resultsToMarkdown(columns, rows),
-											)
+											copyToClipboard(resultsToMarkdown(columns, rows))
 										}
 									>
 										Copy as Markdown
 									</DropdownMenuItem>
 									<DropdownMenuItem
 										onClick={() =>
-											navigator.clipboard.writeText(
-												JSON.stringify(rows, null, 2),
-											)
+											copyToClipboard(JSON.stringify(rows, null, 2))
 										}
 									>
 										Copy as JSON

--- a/src/routes/notebooks.$id.tsx
+++ b/src/routes/notebooks.$id.tsx
@@ -32,6 +32,7 @@ import { ResultContent } from "../components/db-console/result-content";
 import { transformToQueryResultItems } from "../components/db-console/tables-view";
 import { NotebookResourcePicker } from "../components/notebook-resource-picker";
 import { HTTP_STATUS_CODES } from "../shared/const";
+import { copyToClipboard } from "../utils/clipboard";
 import { prettyEdn } from "../utils/edn";
 import type { QueryResultItem } from "../webmcp/db-console-context";
 
@@ -1469,7 +1470,7 @@ function ShareButton({ notebook }: { notebook: Notebook }) {
 			};
 			const url = json.result?.notebook?.["import-url"];
 			if (!url) throw new Error(json.error?.message ?? "No import-url");
-			await navigator.clipboard.writeText(url);
+			await copyToClipboard(url);
 			return url;
 		},
 		onSuccess: () => {

--- a/src/utils/clipboard.ts
+++ b/src/utils/clipboard.ts
@@ -1,0 +1,68 @@
+// navigator.clipboard exists only in secure contexts (HTTPS / localhost).
+// On plain HTTP it is undefined, which is why writeText throws
+// "Cannot read properties of undefined (reading 'writeText')".
+//
+// The fallback path is tricky because:
+//   1. document.execCommand("copy") copies the current window selection,
+//      not whatever element you focused — and Radix DropdownMenu's
+//      FocusScope can yank focus away from a hidden textarea.
+//   2. CodeMirror (used in the db-console SQL editor) installs its own
+//      "copy" listener that rewrites clipboardData with its own selection.
+//
+// To beat both we (a) drive selection via the Range/Selection API on a
+// detached span — no focus dance required — and (b) intercept the copy
+// event in the capture phase with stopImmediatePropagation so CodeMirror's
+// listener never runs.
+export async function copyToClipboard(text: string): Promise<boolean> {
+	if (navigator.clipboard?.writeText) {
+		try {
+			await navigator.clipboard.writeText(text);
+			return true;
+		} catch {
+			// fall through to execCommand fallback
+		}
+	}
+
+	let listenerFired = false;
+	const onCopy = (event: ClipboardEvent) => {
+		event.preventDefault();
+		event.stopImmediatePropagation();
+		event.clipboardData?.setData("text/plain", text);
+		listenerFired = true;
+	};
+	document.addEventListener("copy", onCopy, { capture: true, once: true });
+
+	const span = document.createElement("span");
+	span.textContent = text;
+	span.style.whiteSpace = "pre";
+	span.style.position = "absolute";
+	span.style.left = "-9999px";
+	span.style.top = "0";
+	document.body.appendChild(span);
+
+	const selection = window.getSelection();
+	const previousRange =
+		selection && selection.rangeCount > 0 ? selection.getRangeAt(0) : null;
+
+	const range = document.createRange();
+	range.selectNodeContents(span);
+	selection?.removeAllRanges();
+	selection?.addRange(range);
+
+	let ok = false;
+	try {
+		ok = document.execCommand("copy");
+	} catch {
+		ok = false;
+	}
+
+	document.body.removeChild(span);
+	selection?.removeAllRanges();
+	if (previousRange && selection) selection.addRange(previousRange);
+	// `once: true` removes the listener automatically when it fires; this
+	// removeEventListener is a no-op cleanup in case execCommand never
+	// dispatched a copy event (e.g. permission denied).
+	document.removeEventListener("copy", onCopy, { capture: true });
+
+	return ok && listenerFired;
+}


### PR DESCRIPTION
## Summary
- On non-secure origins (plain HTTP) `navigator.clipboard` is `undefined`, so every Copy action in the UI threw `Cannot read properties of undefined (reading 'writeText')` — reproducible in DB Console → Result → *Copy as JSON / Markdown*.
- Add `src/utils/clipboard.ts` with a `copyToClipboard(text)` helper that prefers `navigator.clipboard.writeText` and falls back to a `Range`/`Selection`-based path. The fallback installs a capture-phase `copy` listener with `stopImmediatePropagation` so CodeMirror's own copy handler can't overwrite `clipboardData` (otherwise it was copying whatever line was focused in the SQL editor). Selection via `Range` also avoids Radix DropdownMenu's FocusScope yanking focus back to the trigger.
- Replace all direct `navigator.clipboard.writeText` callers: db-console result export (3 sites), ResourceBrowser query bar, claude-chat element picker & badge, ViewDefinition materialized-view toast, notebooks share URL.

## Test plan
- [ ] DB Console over HTTP: run a query, *Copy as JSON* → pasted text equals the JSON, not the focused SQL line.
- [ ] DB Console over HTTP: *Copy as Markdown* and "Copy all as …" with multiple results.
- [ ] DB Console over HTTPS: same actions still use the native `navigator.clipboard` path.
- [ ] ResourceBrowser: copy current query URL.
- [ ] ViewDefinition: materialize a view, copy the view name from the toast.
- [ ] Claude chat element picker + badge: copy element context.
- [ ] Notebooks: share notebook URL.