### PR TITLE
Misc UI fixes: resizable data tables, Safari combobox, REST Console polish

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
 		"@replit/codemirror-vim": "^6.3.0",
 		"@tanstack/react-query": "^5.90.21",
 		"@tanstack/react-router": "^1.166.7",
+		"@tanstack/react-table": "^8.21.3",
 		"@tanstack/react-virtual": "^3.13.25",
 		"@xyflow/react": "^12.10.2",
 		"fuse.js": "^7.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@tanstack/react-router':
         specifier: ^1.166.7
         version: 1.167.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@tanstack/react-table':
+        specifier: ^8.21.3
+        version: 8.21.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tanstack/react-virtual':
         specifier: ^3.13.25
         version: 3.13.25(react-dom@19.2.4(react@19.2.4))(react@19.2.4)

--- a/src/components/AsyncOperations/page.tsx
+++ b/src/components/AsyncOperations/page.tsx
@@ -6,20 +6,17 @@ import {
 	SelectItem,
 	SelectTrigger,
 	SelectValue,
-	Table,
-	TableBody,
-	TableCell,
-	TableHead,
-	TableHeader,
-	TableRow,
 } from "@health-samurai/react-components";
 import { Link } from "@tanstack/react-router";
-import { ArrowDown, ArrowUp, ArrowUpDown, RefreshCw } from "lucide-react";
+import { RefreshCw } from "lucide-react";
 import { useEffect, useState } from "react";
+import { DataTable } from "../data-table/data-table";
+import type { ColumnDef, SortState } from "../data-table/types";
 import { useAsyncOperationsList } from "./api";
 import { StatusBadge } from "./status-badge";
 import {
 	type AsyncOperationStatus,
+	type AsyncOperationSummary,
 	DEFAULT_LIST_QUERY,
 	type ListQuery,
 	type SortField,
@@ -27,36 +24,14 @@ import {
 } from "./types";
 import { formatDateTime } from "./utils";
 
-function SortHeader({
-	label,
-	field,
-	query,
-	onSort,
-}: {
-	label: string;
-	field: SortField;
-	query: ListQuery;
-	onSort: (field: SortField) => void;
-}) {
-	const active = query.sortField === field;
-	const Icon = !active
-		? ArrowUpDown
-		: query.sortOrder === "asc"
-			? ArrowUp
-			: ArrowDown;
-	return (
-		<TableHead className="whitespace-nowrap">
-			<button
-				type="button"
-				className={`inline-flex items-center gap-1 cursor-pointer hover:text-text-primary ${active ? "text-text-primary font-medium" : "text-text-secondary"}`}
-				onClick={() => onSort(field)}
-			>
-				{label}
-				<Icon className="size-3" />
-			</button>
-		</TableHead>
-	);
-}
+const COLUMN_TO_SORT_FIELD: Record<string, SortField> = {
+	created: "created-at",
+	lastUpdated: "last-updated",
+};
+const SORT_FIELD_TO_COLUMN: Record<SortField, string> = {
+	"created-at": "created",
+	"last-updated": "lastUpdated",
+};
 
 export function AsyncOperationsPage() {
 	const [query, setQuery] = useState<ListQuery>(DEFAULT_LIST_QUERY);
@@ -79,13 +54,95 @@ export function AsyncOperationsPage() {
 	const operations = data?.operations ?? [];
 	const total = data?.total ?? 0;
 
-	const toggleSort = (field: SortField) => {
+	const tableSort: SortState = {
+		column: SORT_FIELD_TO_COLUMN[query.sortField],
+		direction: query.sortOrder,
+	};
+
+	const handleSortToggle = (columnId: string) => {
+		const field = COLUMN_TO_SORT_FIELD[columnId];
+		if (!field) return;
 		setQuery((prev) =>
 			prev.sortField === field
 				? { ...prev, sortOrder: prev.sortOrder === "asc" ? "desc" : "asc" }
 				: { ...prev, sortField: field, sortOrder: "desc" },
 		);
 	};
+
+	const columns: ColumnDef<AsyncOperationSummary>[] = [
+		{
+			id: "operation",
+			header: "Operation",
+			maxSize: 400,
+			cell: (op) => {
+				const id = op["operation-id"];
+				return (
+					<Link
+						to="/async-operations/$operationId"
+						params={{ operationId: id }}
+						className="text-text-link hover:underline font-medium"
+						title={id}
+					>
+						{id}
+					</Link>
+				);
+			},
+		},
+		{
+			id: "task",
+			header: "Task",
+			maxSize: 300,
+			cell: (op) => op["task-name"] ?? "—",
+		},
+		{
+			id: "status",
+			header: "Status",
+			maxSize: 180,
+			cell: (op) => <StatusBadge status={op.status} />,
+		},
+		{
+			id: "tasks",
+			header: "Tasks",
+			maxSize: 180,
+			cell: (op) => (
+				<span
+					className="text-text-secondary tabular-nums"
+					title={`active=${op.active} succeeded=${op.succeeded} failed=${op.failed}`}
+				>
+					{op.succeeded}/{op.total}
+					{op.failed > 0 ? (
+						<span className="text-text-error-primary ml-1">
+							({op.failed} failed)
+						</span>
+					) : null}
+				</span>
+			),
+		},
+		{
+			id: "created",
+			header: "Created",
+			sortable: true,
+			defaultSize: 200,
+			maxSize: 320,
+			cell: (op) => (
+				<span className="text-text-secondary whitespace-nowrap">
+					{formatDateTime(op["created-at"])}
+				</span>
+			),
+		},
+		{
+			id: "lastUpdated",
+			header: "Last updated",
+			sortable: true,
+			defaultSize: 200,
+			maxSize: 320,
+			cell: (op) => (
+				<span className="text-text-secondary whitespace-nowrap">
+					{formatDateTime(op["last-updated"])}
+				</span>
+			),
+		},
+	];
 
 	return (
 		<div className="flex flex-col h-full">
@@ -135,81 +192,21 @@ export function AsyncOperationsPage() {
 			</div>
 
 			<div className="flex-1 overflow-auto">
-				{isLoading ? (
-					<div className="flex items-center justify-center h-full text-text-secondary">
-						Loading...
-					</div>
-				) : operations.length === 0 ? (
-					<div className="flex items-center justify-center h-full text-text-secondary">
-						No async operations found
-					</div>
-				) : (
-					<Table stickyHeader>
-						<TableHeader>
-							<TableRow>
-								<TableHead>Operation</TableHead>
-								<TableHead>Task</TableHead>
-								<TableHead>Status</TableHead>
-								<TableHead className="text-right">Tasks</TableHead>
-								<SortHeader
-									label="Created"
-									field="created-at"
-									query={query}
-									onSort={toggleSort}
-								/>
-								<SortHeader
-									label="Last updated"
-									field="last-updated"
-									query={query}
-									onSort={toggleSort}
-								/>
-							</TableRow>
-						</TableHeader>
-						<TableBody>
-							{operations.map((op) => {
-								const id = op["operation-id"];
-								return (
-									<TableRow key={id}>
-										<TableCell className="max-w-0 truncate">
-											<Link
-												to="/async-operations/$operationId"
-												params={{ operationId: id }}
-												className="text-text-link hover:underline font-medium"
-												title={id}
-											>
-												{id}
-											</Link>
-										</TableCell>
-										<TableCell className="whitespace-nowrap">
-											{op["task-name"] ?? "—"}
-										</TableCell>
-										<TableCell>
-											<StatusBadge status={op.status} />
-										</TableCell>
-										<TableCell className="text-right text-text-secondary tabular-nums">
-											<span
-												title={`active=${op.active} succeeded=${op.succeeded} failed=${op.failed}`}
-											>
-												{op.succeeded}/{op.total}
-												{op.failed > 0 ? (
-													<span className="text-text-error-primary ml-1">
-														({op.failed} failed)
-													</span>
-												) : null}
-											</span>
-										</TableCell>
-										<TableCell className="whitespace-nowrap text-text-secondary">
-											{formatDateTime(op["created-at"])}
-										</TableCell>
-										<TableCell className="whitespace-nowrap text-text-secondary">
-											{formatDateTime(op["last-updated"])}
-										</TableCell>
-									</TableRow>
-								);
-							})}
-						</TableBody>
-					</Table>
-				)}
+				<DataTable<AsyncOperationSummary>
+					data={operations}
+					columns={columns}
+					rowKey={(op) => op["operation-id"]}
+					loading={isLoading}
+					sort={tableSort}
+					onSortToggle={handleSortToggle}
+					resizable
+					tableId="async-operations"
+					emptyState={
+						<div className="flex items-center justify-center h-full text-text-secondary">
+							No async operations found
+						</div>
+					}
+				/>
 			</div>
 		</div>
 	);

--- a/src/components/ResourceBrowser/browser.tsx
+++ b/src/components/ResourceBrowser/browser.tsx
@@ -181,7 +181,7 @@ const ItemCard = React.memo(function ItemCard({
 				className="block"
 			>
 				<div className="flex flex-col pl-3 pr-10 py-3 min-w-0">
-					<div className="typo-body text-text-primary truncate">
+					<div className="typo-body text-text-primary truncate font-medium!">
 						{highlight(item.name, item.nameMatches)}
 					</div>
 					{item.description && (

--- a/src/components/ResourceBrowser/constants.tsx
+++ b/src/components/ResourceBrowser/constants.tsx
@@ -1,2 +1,2 @@
 export const PageID = "resource-browser";
-export const DEFAULT_SEARCH_QUERY = "_count=30&_page=1&_ilike=";
+export const DEFAULT_SEARCH_QUERY = "_page=1&_ilike=";

--- a/src/components/ResourceBrowser/page.tsx
+++ b/src/components/ResourceBrowser/page.tsx
@@ -249,6 +249,18 @@ const parseSearchParam = (
 	return val ? Number.parseInt(val, 10) || fallback : fallback;
 };
 
+const parseOptionalIntParam = (query: string, key: string): number | null => {
+	const params = new URLSearchParams(query);
+	const val = params.get(key);
+	if (!val) return null;
+	const n = Number.parseInt(val, 10);
+	return Number.isFinite(n) && n > 0 ? n : null;
+};
+
+const ROW_HEIGHT_PX = 28;
+const HEADER_HEIGHT_PX = 32;
+const MIN_FIT_PAGE_SIZE = 5;
+
 const parseSortParam = (query: string): Types.SortState => {
 	const params = new URLSearchParams(query);
 	const sort = params.get("_sort");
@@ -286,7 +298,11 @@ const ResourcesTabContent = ({
 		: Constants.DEFAULT_SEARCH_QUERY;
 
 	const currentPage = parseSearchParam(decodedSearchQuery, "_page", 1);
-	const pageSize = parseSearchParam(decodedSearchQuery, "_count", 30);
+	const explicitPageSize = parseOptionalIntParam(decodedSearchQuery, "_count");
+	const [autoPageSize, setAutoPageSize] = React.useState(30);
+	const pageSize = explicitPageSize ?? autoPageSize;
+	const scrollAreaRef = React.useRef<HTMLDivElement>(null);
+
 	const sort = parseSortParam(decodedSearchQuery);
 
 	const { data: indexData } = ReactQuery.useQuery({
@@ -326,17 +342,23 @@ const ResourcesTabContent = ({
 		queryFn: () => fetchDefaultSchema(client, resourceType),
 	});
 
+	const effectiveSearchQuery = React.useMemo(() => {
+		const params = new URLSearchParams(decodedSearchQuery);
+		if (!params.has("_count")) params.set("_count", String(pageSize));
+		return params.toString();
+	}, [decodedSearchQuery, pageSize]);
+
 	const { data, isLoading, error } = ReactQuery.useQuery({
 		queryKey: [
 			Constants.PageID,
 			"resource-list",
 			resourceType,
-			decodedSearchQuery,
+			effectiveSearchQuery,
 		],
 		queryFn: async () => {
 			const result = await client.searchType({
 				type: resourcesPageContext.resourceType,
-				query: Utils.formatSearchQuery(decodedSearchQuery),
+				query: Utils.formatSearchQuery(effectiveSearchQuery),
 			});
 			if (result.isErr())
 				throw new Error("error obtaining resource list", {
@@ -358,6 +380,27 @@ const ResourcesTabContent = ({
 	React.useEffect(() => {
 		setSelectedIds(new Set());
 	}, [decodedSearchQuery]);
+
+	React.useLayoutEffect(() => {
+		if (explicitPageSize !== null) return;
+		const el = scrollAreaRef.current;
+		if (!el) return;
+		const compute = () => {
+			const firstRow = el.querySelector<HTMLElement>("tbody tr");
+			const header = el.querySelector<HTMLElement>("thead");
+			const rowH = firstRow?.getBoundingClientRect().height || ROW_HEIGHT_PX;
+			const headerH =
+				header?.getBoundingClientRect().height || HEADER_HEIGHT_PX;
+			if (rowH <= 0) return;
+			const usable = el.clientHeight - headerH;
+			const fit = Math.max(MIN_FIT_PAGE_SIZE, Math.floor(usable / rowH));
+			setAutoPageSize((prev) => (prev === fit ? prev : fit));
+		};
+		compute();
+		const ro = new ResizeObserver(compute);
+		ro.observe(el);
+		return () => ro.disconnect();
+	}, [explicitPageSize]);
 
 	const deleteMutation = ReactQuery.useMutation({
 		mutationFn: async () => {
@@ -635,7 +678,7 @@ const ResourcesTabContent = ({
 		>
 			<div className="flex flex-col h-full">
 				<ResourcesTabHeader handleSearch={handleSearch} />
-				<div className="flex-1 overflow-auto">
+				<div ref={scrollAreaRef} className="flex-1 overflow-auto">
 					<DataTable<Resource>
 						data={data?.resources ?? []}
 						columns={columns}

--- a/src/components/ResourceBrowser/page.tsx
+++ b/src/components/ResourceBrowser/page.tsx
@@ -507,6 +507,7 @@ const ResourcesTabContent = ({
 			id: "id",
 			header: "Id",
 			width: "w-0",
+			maxSize: 400,
 			cell: (resource) => (
 				<div className="group/id flex items-center gap-1">
 					<Router.Link
@@ -538,13 +539,17 @@ const ResourcesTabContent = ({
 			id: "lastUpdated",
 			header: "LastUpdated",
 			width: dynamicKeys.length > 0 ? "w-0" : undefined,
+			defaultSize: 260,
+			maxSize: 600,
 			sortable: true,
 			headerTooltip:
-				indexData === false ? (
-					<span className="bg-bg-warning-primary_inverse text-neutral-900 px-2 py-1 rounded">
-						Sort might be slow — no index for &apos;_lastUpdated&apos;
-					</span>
-				) : undefined,
+				indexData === false
+					? "Sort might be slow — no index for '_lastUpdated'"
+					: undefined,
+			headerTooltipClassName:
+				indexData === false
+					? "bg-bg-warning-primary_inverse text-neutral-900"
+					: undefined,
 			cell: (resource) =>
 				Humanize.humanizeValue("lastUpdated", resource.meta?.lastUpdated, {}),
 		},
@@ -553,6 +558,7 @@ const ResourcesTabContent = ({
 			header: k,
 			width: i < dynamicKeys.length - 1 ? "w-0" : undefined,
 			className: "max-w-[300px]",
+			maxSize: 300,
 			cell: (resource) => {
 				const v = (resource as unknown as Record<string, unknown>)[k];
 				const hasValue = v != null;
@@ -640,6 +646,8 @@ const ResourcesTabContent = ({
 						onSelectionChange={setSelectedIds}
 						sort={tableSort}
 						onSortToggle={handleSortToggle}
+						resizable
+						tableId={`resource-browser-instances:${resourcesPageContext.resourceType}`}
 						emptyState={
 							<EmptyState
 								title="No resources found"

--- a/src/components/ResourceEditor/page.tsx
+++ b/src/components/ResourceEditor/page.tsx
@@ -73,6 +73,7 @@ export const ResourceEditorPageWithLoader = (
 		data: resourceData,
 		isLoading,
 		error,
+		dataUpdatedAt,
 	} = useQuery({
 		enabled: id !== undefined,
 		queryKey: [pageId, resourceType, id],
@@ -113,16 +114,14 @@ export const ResourceEditorPageWithLoader = (
 			/>
 		);
 
-	const meta = (resourceData as unknown as Record<string, unknown>).meta as
-		| Record<string, unknown>
-		| undefined;
-
 	return (
 		<ResourceEditorPage
 			// Remount on id/type change so `useState(initialResource)` re-initializes —
 			// otherwise navigating to a sibling resource keeps the previous one's
-			// state. VersionId guards against in-place updates of the same id.
-			key={`${resourceType}/${id ?? ""}@${String(meta?.versionId ?? "")}`}
+			// state. dataUpdatedAt guards against in-place updates of the same id
+			// (e.g. Save invalidates the query and refetches): Aidbox doesn't expose
+			// meta.versionId, so we key off the query's last successful fetch time.
+			key={`${resourceType}/${id ?? ""}@${dataUpdatedAt}`}
 			initialResource={resourceData}
 			{...props}
 		/>

--- a/src/components/ViewDefinition/editor-form-tab-content.tsx
+++ b/src/components/ViewDefinition/editor-form-tab-content.tsx
@@ -2523,44 +2523,46 @@ export const FormTabContent = ({
 					<option key={u} value={u} />
 				))}
 			</datalist>
-			<TreeView
-				itemLabelClassFn={(item: ItemInstance<TreeViewItem<ItemMeta>>) => {
-					const metaType = item.getItemData()?.meta?.type;
+			<div className="pb-48">
+				<TreeView
+					itemLabelClassFn={(item: ItemInstance<TreeViewItem<ItemMeta>>) => {
+						const metaType = item.getItemData()?.meta?.type;
 
-					if (
-						metaType === "constant" ||
-						metaType === "select" ||
-						metaType === "where" ||
-						metaType === "properties"
-					) {
-						return "relative my-1.5 rounded-md bg-bg-info-primary cursor-pointer before:content-[''] before:absolute before:inset-x-0 before:top-0 before:bottom-0 before:-z-10 before:bg-bg-primary before:-my-1.5 after:content-[''] after:absolute after:inset-x-0 after:top-0 after:bottom-0 after:-z-10 after:bg-bg-primary after:rounded-md after:-my-1.5";
-					} else {
 						if (
-							metaType === "column-item" ||
-							metaType === "constant-value" ||
-							metaType === "where-value"
+							metaType === "constant" ||
+							metaType === "select" ||
+							metaType === "where" ||
+							metaType === "properties"
 						) {
-							return "pl-0! pr-0! ml-2.5 border-y border-t-transparent";
+							return "relative my-1.5 rounded-md bg-bg-info-primary cursor-pointer before:content-[''] before:absolute before:inset-x-0 before:top-0 before:bottom-0 before:-z-10 before:bg-bg-primary before:-my-1.5 after:content-[''] after:absolute after:inset-x-0 after:top-0 after:bottom-0 after:-z-10 after:bg-bg-primary after:rounded-md after:-my-1.5";
 						} else {
-							return "pr-0";
+							if (
+								metaType === "column-item" ||
+								metaType === "constant-value" ||
+								metaType === "where-value"
+							) {
+								return "pl-0! pr-0! ml-2.5 border-y border-t-transparent";
+							} else {
+								return "pr-0";
+							}
 						}
-					}
-				}}
-				items={tree}
-				rootItemId="root"
-				customItemView={customItemView}
-				disableHover={true}
-				chevronClassName="self-center cursor-pointer"
-				onItemLabelClick={(item) => {
-					if (item.isFolder()) {
-						item.isExpanded() ? item.collapse() : item.expand();
-					}
-				}}
-				canReorder={true}
-				onDropFn={onDropTreeItem}
-				expandedItems={expandedItems}
-				onExpandedItemsChange={onExpandedItemsChange}
-			/>
+					}}
+					items={tree}
+					rootItemId="root"
+					customItemView={customItemView}
+					disableHover={true}
+					chevronClassName="self-center cursor-pointer"
+					onItemLabelClick={(item) => {
+						if (item.isFolder()) {
+							item.isExpanded() ? item.collapse() : item.expand();
+						}
+					}}
+					canReorder={true}
+					onDropFn={onDropTreeItem}
+					expandedItems={expandedItems}
+					onExpandedItemsChange={onExpandedItemsChange}
+				/>
+			</div>
 		</FhirPathLspProvider>
 	);
 };

--- a/src/components/data-table/data-table.tsx
+++ b/src/components/data-table/data-table.tsx
@@ -1,5 +1,20 @@
+"use no memo";
+
 import * as HSComp from "@health-samurai/react-components";
+import {
+	type ColumnSizingState,
+	getCoreRowModel,
+	type ColumnDef as TSColumnDef,
+	useReactTable,
+} from "@tanstack/react-table";
+import React from "react";
+import { useLocalStorage } from "../../hooks";
 import type { ColumnDef, DataTableProps, SortState } from "./types";
+
+const DEFAULT_MIN_SIZE = 60;
+const DEFAULT_MAX_SIZE = 1000;
+const DEFAULT_SIZE = 150;
+const STORAGE_PREFIX = "data-table-sizing:";
 
 function sortedColumn(
 	sort: SortState | undefined,
@@ -13,23 +28,36 @@ function ColumnHead<T>({
 	column,
 	sort,
 	onSortToggle,
+	style,
+	resizeHandle,
+	colId,
 }: {
 	column: ColumnDef<T>;
 	sort: SortState | undefined;
 	onSortToggle: ((column: string) => void) | undefined;
+	style?: React.CSSProperties;
+	resizeHandle?: React.ReactNode;
+	colId?: string;
 }) {
 	const head = (
 		<HSComp.TableHead
-			className={column.width}
+			className={resizeHandle ? "relative" : column.width}
+			style={style}
 			sortable={column.sortable}
 			sorted={sortedColumn(sort, column.id)}
+			data-col-id={colId}
 			onClick={
 				column.sortable && onSortToggle
 					? () => onSortToggle(column.id)
 					: undefined
 			}
 		>
-			{column.header}
+			{resizeHandle ? (
+				<span className="block truncate">{column.header}</span>
+			) : (
+				column.header
+			)}
+			{resizeHandle}
 		</HSComp.TableHead>
 	);
 
@@ -38,39 +66,60 @@ function ColumnHead<T>({
 	return (
 		<HSComp.Tooltip>
 			<HSComp.TooltipTrigger asChild>{head}</HSComp.TooltipTrigger>
-			<HSComp.TooltipContent side="bottom" align="start">
+			<HSComp.TooltipContent
+				side="bottom"
+				align="start"
+				className={column.headerTooltipClassName}
+			>
 				{column.headerTooltip}
 			</HSComp.TooltipContent>
 		</HSComp.Tooltip>
 	);
 }
 
-export function DataTable<T>({
-	data,
-	columns,
-	rowKey,
-	loading,
-	emptyState,
-	selectable,
-	selectedIds,
-	onSelectionChange,
-	sort,
-	onSortToggle,
-}: DataTableProps<T>) {
-	if (loading) {
-		return (
-			<div className="flex items-center justify-center h-full text-text-secondary">
-				<div className="text-center">
-					<div className="text-lg mb-2">Loading...</div>
-				</div>
-			</div>
-		);
-	}
+function ResizeHandle({
+	onMouseDown,
+	onTouchStart,
+	isResizing,
+	columnId,
+}: {
+	onMouseDown: React.MouseEventHandler;
+	onTouchStart: React.TouchEventHandler;
+	isResizing: boolean;
+	columnId: string;
+}) {
+	return (
+		<button
+			type="button"
+			aria-label={`Resize ${columnId}`}
+			onMouseDown={onMouseDown}
+			onTouchStart={onTouchStart}
+			onClick={(e) => e.stopPropagation()}
+			className={`group/resize absolute top-0 h-full w-3 cursor-col-resize select-none touch-none z-10 flex items-center justify-center ${
+				isResizing ? "z-20" : ""
+			}`}
+			style={{ right: -6, userSelect: "none", touchAction: "none" }}
+		>
+			<span
+				className={`block w-0.5 h-1/2 transition-colors ${
+					isResizing
+						? "bg-border-link"
+						: "bg-transparent group-hover/header:bg-border-secondary group-hover/resize:bg-border-link!"
+				}`}
+			/>
+		</button>
+	);
+}
 
-	if (!data || data.length === 0) {
-		return <>{emptyState}</>;
-	}
-
+function useSelectionHelpers<T>(
+	data: T[],
+	rowKey: (row: T, index: number) => string,
+	selectable: boolean | undefined,
+	selectedIds: Set<string> | undefined,
+	onSelectionChange:
+		| React.Dispatch<React.SetStateAction<Set<string>>>
+		| undefined,
+) {
 	const allIds = data.map(rowKey);
 	const allSelected =
 		selectable &&
@@ -102,67 +151,355 @@ export function DataTable<T>({
 		});
 	};
 
+	return { allSelected, someSelected, toggleAll, toggleOne };
+}
+
+export function DataTable<T>(props: DataTableProps<T>) {
+	if (props.loading) {
+		return (
+			<div className="flex items-center justify-center h-full text-text-secondary">
+				<div className="text-center">
+					<div className="text-lg mb-2">Loading...</div>
+				</div>
+			</div>
+		);
+	}
+
+	if (!props.data || props.data.length === 0) {
+		return <>{props.emptyState}</>;
+	}
+
+	if (props.resizable) {
+		return <ResizableDataTable {...props} />;
+	}
+	return <SimpleDataTable {...props} />;
+}
+
+function SimpleDataTable<T>({
+	data,
+	columns,
+	rowKey,
+	selectable,
+	selectedIds,
+	onSelectionChange,
+	sort,
+	onSortToggle,
+	zebra = true,
+	noRowHover,
+}: DataTableProps<T>) {
+	const { allSelected, someSelected, toggleAll, toggleOne } =
+		useSelectionHelpers(
+			data,
+			rowKey,
+			selectable,
+			selectedIds,
+			onSelectionChange,
+		);
+
 	return (
-		<HSComp.Table zebra stickyHeader className="typo-code">
-			<HSComp.TableHeader>
-				<HSComp.TableRow>
-					{selectable && (
-						<HSComp.TableHead className="w-[52px] min-w-[52px]">
-							<HSComp.Checkbox
-								size="small"
-								className="border-border-primary"
-								checked={
-									allSelected ? true : someSelected ? "indeterminate" : false
-								}
-								onCheckedChange={toggleAll}
-								aria-label="Select all"
+		<div className="contents [&>div[data-slot=table-container]]:overflow-visible [&>div[data-slot=table-container]]:h-auto">
+			<HSComp.Table zebra={zebra} stickyHeader className="typo-code">
+				<HSComp.TableHeader>
+					<HSComp.TableRow>
+						{selectable && (
+							<HSComp.TableHead className="w-[52px] min-w-[52px]">
+								<HSComp.Checkbox
+									size="small"
+									className="border-border-primary"
+									checked={
+										allSelected ? true : someSelected ? "indeterminate" : false
+									}
+									onCheckedChange={toggleAll}
+									aria-label="Select all"
+								/>
+							</HSComp.TableHead>
+						)}
+						{columns.map((column) => (
+							<ColumnHead
+								key={column.id}
+								column={column}
+								sort={sort}
+								onSortToggle={onSortToggle}
 							/>
-						</HSComp.TableHead>
-					)}
-					{columns.map((column) => (
-						<ColumnHead
-							key={column.id}
-							column={column}
-							sort={sort}
-							onSortToggle={onSortToggle}
-						/>
-					))}
-				</HSComp.TableRow>
-			</HSComp.TableHeader>
-			<HSComp.TableBody>
-				{data.map((row, index) => {
-					const id = rowKey(row);
-					const isSelected = selectedIds?.has(id) ?? false;
-					return (
-						<HSComp.TableRow
-							key={id || index}
-							zebra
-							index={index}
-							selected={isSelected}
-						>
-							{selectable && (
-								<HSComp.TableCell>
-									<HSComp.Checkbox
-										size="small"
-										className="border-border-primary"
-										checked={isSelected}
-										onCheckedChange={() => toggleOne(id)}
-										aria-label={`Select ${id}`}
-									/>
-								</HSComp.TableCell>
-							)}
-							{columns.map((column) => (
-								<HSComp.TableCell
+						))}
+					</HSComp.TableRow>
+				</HSComp.TableHeader>
+				<HSComp.TableBody
+					className={noRowHover ? "[&_tr]:hover:bg-transparent" : undefined}
+				>
+					{data.map((row, index) => {
+						const id = rowKey(row, index);
+						const isSelected = selectedIds?.has(id) ?? false;
+						return (
+							<HSComp.TableRow
+								key={id || index}
+								zebra={zebra}
+								index={index}
+								selected={isSelected}
+							>
+								{selectable && (
+									<HSComp.TableCell>
+										<HSComp.Checkbox
+											size="small"
+											className="border-border-primary"
+											checked={isSelected}
+											onCheckedChange={() => toggleOne(id)}
+											aria-label={`Select ${id}`}
+										/>
+									</HSComp.TableCell>
+								)}
+								{columns.map((column) => (
+									<HSComp.TableCell
+										key={column.id}
+										className={column.className ?? column.width}
+									>
+										{column.cell(row)}
+									</HSComp.TableCell>
+								))}
+							</HSComp.TableRow>
+						);
+					})}
+				</HSComp.TableBody>
+			</HSComp.Table>
+		</div>
+	);
+}
+
+function ResizableDataTable<T>({
+	data,
+	columns,
+	rowKey,
+	selectable,
+	selectedIds,
+	onSelectionChange,
+	sort,
+	onSortToggle,
+	tableId,
+	zebra = true,
+	noRowHover,
+}: DataTableProps<T>) {
+	const { allSelected, someSelected, toggleAll, toggleOne } =
+		useSelectionHelpers(
+			data,
+			rowKey,
+			selectable,
+			selectedIds,
+			onSelectionChange,
+		);
+
+	const containerRef = React.useRef<HTMLDivElement>(null);
+
+	const [persistedSizing, setPersistedSizing] =
+		useLocalStorage<ColumnSizingState>({
+			key: `${STORAGE_PREFIX}${tableId ?? "_unkeyed"}`,
+			defaultValue: {},
+		});
+
+	const columnsById = React.useMemo(() => {
+		const map = new Map<string, ColumnDef<T>>();
+		for (const c of columns) map.set(c.id, c);
+		return map;
+	}, [columns]);
+
+	const tsColumns = React.useMemo<TSColumnDef<T>[]>(
+		() =>
+			columns.map((c) => ({
+				id: c.id,
+				size: c.defaultSize ?? DEFAULT_SIZE,
+				minSize: c.minSize ?? DEFAULT_MIN_SIZE,
+				maxSize: c.maxSize ?? DEFAULT_MAX_SIZE,
+				enableResizing: true,
+			})),
+		[columns],
+	);
+
+	const table = useReactTable({
+		data,
+		columns: tsColumns,
+		getCoreRowModel: getCoreRowModel(),
+		columnResizeMode: "onChange",
+		enableColumnResizing: true,
+		state: { columnSizing: persistedSizing },
+		onColumnSizingChange: (updater) => {
+			setPersistedSizing((prev) =>
+				typeof updater === "function" ? updater(prev) : updater,
+			);
+		},
+	});
+
+	const needsMeasure = React.useMemo(
+		() =>
+			columns.filter(
+				(c) => c.defaultSize == null && !(c.id in persistedSizing),
+			),
+		[columns, persistedSizing],
+	);
+	const isMeasuring = needsMeasure.length > 0;
+
+	React.useLayoutEffect(() => {
+		if (!isMeasuring) return;
+		const container = containerRef.current;
+		if (!container) return;
+		const ths = container.querySelectorAll<HTMLTableCellElement>(
+			"thead [data-col-id]",
+		);
+		const map = new Map<string, HTMLTableCellElement>();
+		ths.forEach((th) => {
+			const id = th.dataset.colId;
+			if (id) map.set(id, th);
+		});
+		const updates: ColumnSizingState = {};
+		for (const c of needsMeasure) {
+			const th = map.get(c.id);
+			if (!th) continue;
+			const natural = th.getBoundingClientRect().width;
+			updates[c.id] = Math.min(
+				Math.max(natural, c.minSize ?? DEFAULT_MIN_SIZE),
+				c.maxSize ?? DEFAULT_MAX_SIZE,
+			);
+		}
+		if (Object.keys(updates).length > 0) {
+			setPersistedSizing((prev) => ({ ...prev, ...updates }));
+		}
+	}, [isMeasuring, needsMeasure, setPersistedSizing]);
+
+	const headerGroup = table.getHeaderGroups()[0];
+	if (!headerGroup) return null;
+
+	const resizingHeader = headerGroup.headers.find((h) =>
+		h.column.getIsResizing(),
+	);
+	const guideLeft =
+		!isMeasuring && resizingHeader
+			? (selectable ? 52 : 0) +
+				resizingHeader.getStart() +
+				resizingHeader.getSize()
+			: null;
+
+	const tableStyle: React.CSSProperties = isMeasuring
+		? { tableLayout: "auto", width: "100%" }
+		: {
+				tableLayout: "fixed",
+				width: "100%",
+				minWidth: table.getCenterTotalSize() + (selectable ? 52 : 0),
+			};
+
+	return (
+		<div
+			ref={containerRef}
+			className="relative [&_div[data-slot=table-container]]:overflow-visible [&_div[data-slot=table-container]]:h-auto"
+		>
+			{guideLeft !== null && (
+				<div
+					className="pointer-events-none absolute top-0 bottom-0 w-0.5 bg-border-link z-30"
+					style={{ left: guideLeft - 1 }}
+				/>
+			)}
+			<HSComp.Table
+				zebra={zebra}
+				stickyHeader
+				className="typo-code"
+				style={tableStyle}
+			>
+				<HSComp.TableHeader>
+					<HSComp.TableRow className="group/header">
+						{selectable && (
+							<HSComp.TableHead
+								className="w-[52px] min-w-[52px]"
+								style={{ width: 52 }}
+							>
+								<HSComp.Checkbox
+									size="small"
+									className="border-border-primary"
+									checked={
+										allSelected ? true : someSelected ? "indeterminate" : false
+									}
+									onCheckedChange={toggleAll}
+									aria-label="Select all"
+								/>
+							</HSComp.TableHead>
+						)}
+						{headerGroup.headers.map((header) => {
+							const column = columnsById.get(header.column.id);
+							if (!column) return null;
+							const isLast =
+								header.column.getIndex() === headerGroup.headers.length - 1;
+							const headStyle: React.CSSProperties | undefined = isMeasuring
+								? { maxWidth: column.maxSize ?? DEFAULT_MAX_SIZE }
+								: isLast
+									? undefined
+									: { width: header.getSize() };
+							return (
+								<ColumnHead
 									key={column.id}
-									className={column.className ?? column.width}
-								>
-									{column.cell(row)}
-								</HSComp.TableCell>
-							))}
-						</HSComp.TableRow>
-					);
-				})}
-			</HSComp.TableBody>
-		</HSComp.Table>
+									column={column}
+									sort={sort}
+									onSortToggle={onSortToggle}
+									style={headStyle}
+									colId={column.id}
+									resizeHandle={
+										isMeasuring || isLast ? null : (
+											<ResizeHandle
+												columnId={column.id}
+												onMouseDown={header.getResizeHandler()}
+												onTouchStart={header.getResizeHandler()}
+												isResizing={header.column.getIsResizing()}
+											/>
+										)
+									}
+								/>
+							);
+						})}
+					</HSComp.TableRow>
+				</HSComp.TableHeader>
+				<HSComp.TableBody
+					className={noRowHover ? "[&_tr]:hover:bg-transparent" : undefined}
+				>
+					{data.map((row, index) => {
+						const id = rowKey(row, index);
+						const isSelected = selectedIds?.has(id) ?? false;
+						return (
+							<HSComp.TableRow
+								key={id || index}
+								zebra={zebra}
+								index={index}
+								selected={isSelected}
+							>
+								{selectable && (
+									<HSComp.TableCell style={{ width: 52 }}>
+										<HSComp.Checkbox
+											size="small"
+											className="border-border-primary"
+											checked={isSelected}
+											onCheckedChange={() => toggleOne(id)}
+											aria-label={`Select ${id}`}
+										/>
+									</HSComp.TableCell>
+								)}
+								{headerGroup.headers.map((header, idx) => {
+									const column = columnsById.get(header.column.id);
+									if (!column) return null;
+									const isLast = idx === headerGroup.headers.length - 1;
+									const cellStyle: React.CSSProperties | undefined = isMeasuring
+										? { maxWidth: column.maxSize ?? DEFAULT_MAX_SIZE }
+										: isLast
+											? undefined
+											: { width: header.getSize() };
+									return (
+										<HSComp.TableCell
+											key={column.id}
+											className={`${column.className ?? ""} truncate`}
+											style={cellStyle}
+										>
+											{column.cell(row)}
+										</HSComp.TableCell>
+									);
+								})}
+							</HSComp.TableRow>
+						);
+					})}
+				</HSComp.TableBody>
+			</HSComp.Table>
+		</div>
 	);
 }

--- a/src/components/data-table/types.ts
+++ b/src/components/data-table/types.ts
@@ -11,10 +11,14 @@ export type ColumnDef<T> = {
 	id: string;
 	header: React.ReactNode;
 	headerTooltip?: React.ReactNode;
+	headerTooltipClassName?: string;
 	cell: (row: T) => React.ReactNode;
 	width?: string;
 	className?: string;
 	sortable?: boolean;
+	defaultSize?: number;
+	minSize?: number;
+	maxSize?: number;
 };
 
 export type BulkAction = {
@@ -34,7 +38,7 @@ export type BulkAction = {
 export type DataTableProps<T> = {
 	data: T[];
 	columns: ColumnDef<T>[];
-	rowKey: (row: T) => string;
+	rowKey: (row: T, index: number) => string;
 	loading?: boolean;
 	emptyState?: React.ReactNode;
 	selectable?: boolean;
@@ -42,6 +46,10 @@ export type DataTableProps<T> = {
 	onSelectionChange?: React.Dispatch<React.SetStateAction<Set<string>>>;
 	sort?: SortState;
 	onSortToggle?: (column: string) => void;
+	resizable?: boolean;
+	tableId?: string;
+	zebra?: boolean;
+	noRowHover?: boolean;
 };
 
 export type DataTableFooterProps = {

--- a/src/components/db-console/result-content.tsx
+++ b/src/components/db-console/result-content.tsx
@@ -4,12 +4,6 @@ import {
 	DropdownMenuContent,
 	DropdownMenuItem,
 	DropdownMenuTrigger,
-	Table,
-	TableBody,
-	TableCell,
-	TableHead,
-	TableHeader,
-	TableRow,
 	Tabs,
 	TabsBrowserList,
 	TabsContent,
@@ -30,6 +24,8 @@ import type React from "react";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { copyToClipboard } from "../../utils/clipboard";
 import type { QueryResultItem } from "../../webmcp/db-console-context";
+import { DataTable } from "../data-table/data-table";
+import type { ColumnDef } from "../data-table/types";
 import { LIMIT_PRESETS, TIMEOUT_PRESETS } from "./utils";
 
 // ── JSON highlighting ──
@@ -271,35 +267,21 @@ function QueryResult({
 				</div>
 			) : (
 				<div className="flex-1 overflow-auto min-h-0">
-					<Table stickyHeader className="typo-code w-auto min-w-full">
-						<TableHeader>
-							<TableRow>
-								{columns.map((key, colIdx) => (
-									<TableHead
-										key={key}
-										className={`px-6 hover:bg-transparent whitespace-nowrap ${colIdx === 0 ? "pl-5.5" : ""} ${colIdx === columns.length - 1 ? "w-full" : ""}`}
-									>
-										{key}
-									</TableHead>
-								))}
-							</TableRow>
-						</TableHeader>
-						<TableBody className="[&_tr]:hover:bg-transparent">
-							{rows.map((row, rowIdx) => (
-								// biome-ignore lint/suspicious/noArrayIndexKey: result rows lack stable unique identifiers
-								<TableRow key={rowIdx}>
-									{columns.map((key, colIdx) => (
-										<TableCell
-											key={key}
-											className={`px-6 align-top ${colIdx === 0 ? "pl-5.5" : ""}`}
-										>
-											<CellValue value={row[key]} />
-										</TableCell>
-									))}
-								</TableRow>
-							))}
-						</TableBody>
-					</Table>
+					<DataTable<Record<string, unknown>>
+						data={rows}
+						columns={columns.map<ColumnDef<Record<string, unknown>>>((key) => ({
+							id: key,
+							header: key,
+							maxSize: 2000,
+							className: "align-top",
+							cell: (row) => <CellValue value={row[key]} />,
+						}))}
+						rowKey={(_row, idx) => String(idx)}
+						resizable
+						zebra={false}
+						noRowHover
+						tableId="db-console-result"
+					/>
 				</div>
 			)}
 		</div>

--- a/src/routes/rest.tsx
+++ b/src/routes/rest.tsx
@@ -1286,7 +1286,7 @@ function ResponsePane({
 					</TabsList>
 				</div>
 				<div className="flex items-center gap-1">
-					{response && activeResponseTab !== "explain" && (
+					{response && !isLoading && activeResponseTab !== "explain" && (
 						<ResponseInfo response={response} />
 					)}
 					{fullScreenState === "normal" && (

--- a/src/routes/rest.tsx
+++ b/src/routes/rest.tsx
@@ -652,31 +652,35 @@ function RequestView({
 							onFormat={handleFormatBody}
 						/>
 					</div>
-					<CodeEditor
-						id={`request-editor-${selectedTab.id}-${currentActiveSubTab}`}
-						key={`request-editor-${selectedTab.id}`}
-						currentValue={getEditorValue()}
-						mode={bodyMode}
-						onChange={handleBodyEditorChange}
-						additionalExtensions={[preventNewlineOnModEnter]}
-						getStructureDefinitions={getStructureDefinitions}
-						expandValueSet={expandValueSet}
-						resourceTypeHint={resourceTypeHint}
-						issueLineNumbers={responseIssueLines}
-						vimMode={vimMode}
-					/>
+					<div className="h-full">
+						<CodeEditor
+							id={`request-editor-${selectedTab.id}-${currentActiveSubTab}`}
+							key={`request-editor-${selectedTab.id}`}
+							currentValue={getEditorValue()}
+							mode={bodyMode}
+							onChange={handleBodyEditorChange}
+							additionalExtensions={[preventNewlineOnModEnter]}
+							getStructureDefinitions={getStructureDefinitions}
+							expandValueSet={expandValueSet}
+							resourceTypeHint={resourceTypeHint}
+							issueLineNumbers={responseIssueLines}
+							vimMode={vimMode}
+						/>
+					</div>
 				</TabsContent>
 				<TabsContent value="raw">
-					<RawEditor
-						requestLineVersion={requestLineVersion}
-						selectedTab={selectedTab}
-						onRawChange={onRawChange}
-						getStructureDefinitions={getStructureDefinitions}
-						expandValueSet={expandValueSet}
-						resourceTypeHint={resourceTypeHint}
-						getUrlSuggestions={getUrlSuggestions}
-						issueLineNumbers={responseIssueLines}
-					/>
+					<div className="h-full">
+						<RawEditor
+							requestLineVersion={requestLineVersion}
+							selectedTab={selectedTab}
+							onRawChange={onRawChange}
+							getStructureDefinitions={getStructureDefinitions}
+							expandValueSet={expandValueSet}
+							resourceTypeHint={resourceTypeHint}
+							getUrlSuggestions={getUrlSuggestions}
+							issueLineNumbers={responseIssueLines}
+						/>
+					</div>
 				</TabsContent>
 			</Tabs>
 		</div>


### PR DESCRIPTION
## Summary

Bug fixes and UX polish accumulated across several feature areas; one bump of `@health-samurai/react-components` (committed on `development` of the submodule).

### ResourceEditor
- Remount on react-query `dataUpdatedAt` so saves refresh the Builder tab even though Aidbox doesn't expose `meta.versionId`.

### ViewDefinition Builder
- Bottom padding under the tree view so the last item isn't pinned to the scroll edge.

### Resource Browser
- Column resize on the Instances table (TanStack-backed, widths persisted per resource type in `localStorage`).
- Auto-fit `_count` to viewport height (drops the hardcoded `_count=30` from the default search URL); user choices in the page-size dropdown still override.
- Medium font weight for resource-type names in `ItemCard2`.

### Shared `DataTable`
- New opt-in `resizable` mode on the local `DataTable` (column sizing on `@tanstack/react-table`, `localStorage` persistence, fit-content via measurement, last column auto-grows, sticky-header workaround).
- New props: `resizable`, `tableId`, `zebra`, `noRowHover`. `ColumnDef` gains `defaultSize`/`minSize`/`maxSize`, `headerTooltipClassName`. `rowKey` now also receives the row index.

### DB Console
- Result table switched to the resizable `DataTable` (no zebra, no row hover, `maxSize` 2000px); `CellValue` JSON highlighting preserved.

### Async Operations
- List switched to the resizable `DataTable`; sort, refresh, status/task filters preserved.

### REST Console
- Now relies on the new built-in 400px right padding on `.cm-content` (committed in `react-components`) so the floating menubar no longer hides the right side of the code.
- Hide stale response status while a new request is loading.

### Submodule (`@health-samurai/react-components`)
- Safari `Combobox` viewport unclip (Resource Browser → ViewDefinition resource select was empty in Safari).
- `CodeEditor`: built-in `.cm-content` right padding + opaque gutter with fade shadow.

## Test plan

- [ ] Edit a `ViewDefinition`, save in the Edit tab, switch to Builder — shows fresh resource.
- [ ] Open Resource Browser → `Patient` (or any type), drag column borders, reload — widths persist.
- [ ] Zoom out / resize browser on a tall monitor — `_count` adapts and the page fills.
- [ ] DB Console — run a SQL query that returns wide JSON, drag column borders; sticky header on scroll.
- [ ] Async Operations — column resize on the list.
- [ ] REST Console — type a long line in Body / Raw, scroll horizontally — text doesn't hide under the menubar; while a request is in flight the status code disappears.
- [ ] Safari only: Resource Browser → `ViewDefinition` → Builder → "Resources" select now opens with visible options.