### PR TITLE
ValueSet: paginate expansion server-side via $expand count + offset

### DIFF
--- a/src/components/ValueSet/builder-content.tsx
+++ b/src/components/ValueSet/builder-content.tsx
@@ -13,6 +13,16 @@ import { PropertiesTree } from "./properties-tree";
 import { ResultPanel } from "./result-panel";
 import type { ValueSet } from "./types";
 
+const DEFAULT_PAGE_SIZE = 30;
+const PAGE_SIZE_STORAGE_KEY = "valueset-builder:result-page-size";
+
+type ExpandVariables = {
+	offset: number;
+	count: number;
+	reset: boolean;
+	seq: number;
+};
+
 function toOperationOutcome(err: unknown): HSComp.OperationOutcome {
 	if (
 		typeof err === "object" &&
@@ -104,17 +114,36 @@ export const ValueSetBuilderContent = () => {
 		},
 	});
 
+	const [page, setPage] = React.useState(1);
+	const [pageSize, setPageSize] = useLocalStorage<number>({
+		key: PAGE_SIZE_STORAGE_KEY,
+		defaultValue: DEFAULT_PAGE_SIZE,
+		getInitialValueInEffect: false,
+	});
+
 	const expandStartRef = React.useRef<number>(0);
+	const expandedValueSetRef = React.useRef<ValueSet | null>(null);
+	const expandSeqRef = React.useRef(0);
 	const expandMutation = useMutation({
-		mutationFn: async () => {
+		mutationFn: async ({ offset, count, reset }: ExpandVariables) => {
 			setExpandError(null);
-			setExpansion(null);
-			setExpandDurationMs(null);
+			if (reset) {
+				setExpansion(null);
+				setExpandDurationMs(null);
+				expandedValueSetRef.current = cleanEmptyValues(valueSet);
+			}
 			setIsExpanding(true);
 			expandStartRef.current = performance.now();
 			const body = {
 				resourceType: "Parameters" as const,
-				parameter: [{ name: "valueSet", resource: cleanEmptyValues(valueSet) }],
+				parameter: [
+					{
+						name: "valueSet",
+						resource: expandedValueSetRef.current ?? cleanEmptyValues(valueSet),
+					},
+					{ name: "count", valueInteger: count },
+					{ name: "offset", valueInteger: offset },
+				],
 			};
 			const result = await client.request<ValueSet>({
 				method: "POST",
@@ -125,12 +154,14 @@ export const ValueSetBuilderContent = () => {
 			if (result.isErr()) throw result.value.resource;
 			return result.value.resource;
 		},
-		onSuccess: (resource) => {
+		onSuccess: (resource, { seq }) => {
+			if (seq !== expandSeqRef.current) return;
 			setIsExpanding(false);
 			setExpandDurationMs(performance.now() - expandStartRef.current);
 			setExpansion(resource.expansion ?? null);
 		},
-		onError: (err) => {
+		onError: (err, { seq }) => {
+			if (seq !== expandSeqRef.current) return;
 			setIsExpanding(false);
 			setExpandDurationMs(performance.now() - expandStartRef.current);
 			setExpandError(toOperationOutcome(err));
@@ -166,11 +197,41 @@ export const ValueSetBuilderContent = () => {
 		return () => document.removeEventListener("keydown", onEscape);
 	}, [isMaximized]);
 
+	const requestExpand = React.useCallback(
+		(vars: Omit<ExpandVariables, "seq">) => {
+			expandSeqRef.current += 1;
+			expandMutation.mutate({ ...vars, seq: expandSeqRef.current });
+		},
+		[expandMutation],
+	);
+
 	const triggerExpand = React.useCallback(() => {
 		if (expandMutation.isPending) return;
 		handleExpandResult();
-		expandMutation.mutate();
-	}, [expandMutation, handleExpandResult]);
+		setPage(1);
+		requestExpand({ offset: 0, count: pageSize, reset: true });
+	}, [expandMutation.isPending, handleExpandResult, requestExpand, pageSize]);
+
+	const handlePageChange = React.useCallback(
+		(nextPage: number) => {
+			setPage(nextPage);
+			requestExpand({
+				offset: (nextPage - 1) * pageSize,
+				count: pageSize,
+				reset: false,
+			});
+		},
+		[requestExpand, pageSize],
+	);
+
+	const handlePageSizeChange = React.useCallback(
+		(nextSize: number) => {
+			setPageSize(nextSize);
+			setPage(1);
+			requestExpand({ offset: 0, count: nextSize, reset: false });
+		},
+		[requestExpand, setPageSize],
+	);
 
 	const editorContent = (
 		<div className="flex flex-col h-full">
@@ -241,6 +302,10 @@ export const ValueSetBuilderContent = () => {
 								isMaximized={isMaximized}
 								onToggleMaximize={handleToggleMaximize}
 								onToggleCollapse={handleToggleCollapse}
+								page={page}
+								pageSize={pageSize}
+								onPageChange={handlePageChange}
+								onPageSizeChange={handlePageSizeChange}
 							/>
 						</div>
 					</div>

--- a/src/components/ValueSet/graph/expand-result-panel.tsx
+++ b/src/components/ValueSet/graph/expand-result-panel.tsx
@@ -1,22 +1,11 @@
 import * as HSComp from "@health-samurai/react-components";
 import { Maximize2, Minimize2, PanelBottomClose, Timer, X } from "lucide-react";
-import * as React from "react";
-import { useLocalStorage } from "../../../hooks";
 import { DataTableFooter } from "../../data-table/footer";
 import { EmptyState } from "../../empty-state";
 import { useGraphRunContext } from "./run-context";
 
-const DEFAULT_PAGE_SIZE = 30;
-const PAGE_SIZE_STORAGE_KEY = "valueset-graph:result-page-size";
-
-function ExpansionTable({
-	page,
-	pageSize,
-}: {
-	page: number;
-	pageSize: number;
-}) {
-	const { result } = useGraphRunContext();
+function ExpansionTable({ offset }: { offset: number }) {
+	const { result, runningNodeId } = useGraphRunContext();
 	if (!result || result.kind !== "expand") return null;
 	if (result.contains.length === 0) {
 		return (
@@ -26,10 +15,12 @@ function ExpansionTable({
 			/>
 		);
 	}
-	const start = (page - 1) * pageSize;
-	const visibleRows = result.contains.slice(start, start + pageSize);
 	return (
-		<HSComp.Table zebra stickyHeader className="typo-code">
+		<HSComp.Table
+			zebra
+			stickyHeader
+			className={`typo-code ${runningNodeId ? "opacity-60 pointer-events-none" : ""}`}
+		>
 			<HSComp.TableHeader className="z-0">
 				<HSComp.TableRow>
 					<HSComp.TableHead>Code</HSComp.TableHead>
@@ -39,9 +30,9 @@ function ExpansionTable({
 				</HSComp.TableRow>
 			</HSComp.TableHeader>
 			<HSComp.TableBody>
-				{visibleRows.map((row, i) => (
+				{result.contains.map((row, i) => (
 					// biome-ignore lint/suspicious/noArrayIndexKey: row order is stable
-					<HSComp.TableRow key={start + i} zebra index={start + i}>
+					<HSComp.TableRow key={offset + i} zebra index={offset + i}>
 						<HSComp.TableCell>{row.code ?? "—"}</HSComp.TableCell>
 						<HSComp.TableCell>{row.display ?? "—"}</HSComp.TableCell>
 						<HSComp.TableCell className="text-text-secondary">
@@ -106,7 +97,7 @@ function ContentTable({ page, pageSize }: { page: number; pageSize: number }) {
 function ResultBody({ page, pageSize }: { page: number; pageSize: number }) {
 	const { runningNodeId, error, result } = useGraphRunContext();
 
-	if (runningNodeId) {
+	if (runningNodeId && !result) {
 		return (
 			<div className="flex items-center justify-center h-full w-full text-text-secondary">
 				Loading…
@@ -134,7 +125,7 @@ function ResultBody({ page, pageSize }: { page: number; pageSize: number }) {
 	}
 
 	if (result.kind === "expand") {
-		return <ExpansionTable page={page} pageSize={pageSize} />;
+		return <ExpansionTable offset={(page - 1) * pageSize} />;
 	}
 	return <ContentTable page={page} pageSize={pageSize} />;
 }
@@ -144,7 +135,7 @@ function getHeaderLabel(
 	total: number,
 ): string {
 	if (!result) return "Result";
-	if (result.kind === "expand") return `Expansion (${result.total ?? total})`;
+	if (result.kind === "expand") return `Expansion (${total})`;
 	return `Concepts (${total})`;
 }
 
@@ -152,7 +143,7 @@ function getTotal(
 	result: ReturnType<typeof useGraphRunContext>["result"],
 ): number {
 	if (!result) return 0;
-	if (result.kind === "expand") return result.contains.length;
+	if (result.kind === "expand") return result.total ?? result.contains.length;
 	return result.rows.length;
 }
 
@@ -161,29 +152,22 @@ export function ExpandResultPanel({
 	onToggleMaximize,
 	onToggleCollapse,
 	onClose,
+	page,
+	pageSize,
+	onPageChange,
+	onPageSizeChange,
 }: {
 	isMaximized: boolean;
 	onToggleMaximize: () => void;
 	onToggleCollapse: () => void;
 	onClose: () => void;
+	page: number;
+	pageSize: number;
+	onPageChange: (page: number) => void;
+	onPageSizeChange: (size: number) => void;
 }) {
 	const { result } = useGraphRunContext();
-	const [page, setPage] = React.useState(1);
-	const [pageSize, setPageSize] = useLocalStorage<number>({
-		key: PAGE_SIZE_STORAGE_KEY,
-		getInitialValueInEffect: false,
-		defaultValue: DEFAULT_PAGE_SIZE,
-	});
 	const total = getTotal(result);
-	const totalPages = Math.max(1, Math.ceil(total / pageSize));
-
-	React.useEffect(() => {
-		setPage(1);
-	}, []);
-
-	React.useEffect(() => {
-		if (page > totalPages) setPage(totalPages);
-	}, [page, totalPages]);
 
 	return (
 		<div className="flex flex-col h-full overflow-hidden">
@@ -249,11 +233,8 @@ export function ExpandResultPanel({
 						currentPage={page}
 						pageSize={pageSize}
 						selectedCount={0}
-						onPageChange={setPage}
-						onPageSizeChange={(size) => {
-							setPageSize(size);
-							setPage(1);
-						}}
+						onPageChange={onPageChange}
+						onPageSizeChange={onPageSizeChange}
 					/>
 				)}
 			</div>

--- a/src/components/ValueSet/graph/graph-tab.tsx
+++ b/src/components/ValueSet/graph/graph-tab.tsx
@@ -55,6 +55,17 @@ const DEFAULT_RESULT_HEIGHT = 320;
 const MIN_RESULT_HEIGHT = 120;
 const MAX_RESULT_HEIGHT = 800;
 
+const DEFAULT_PAGE_SIZE = 30;
+const PAGE_SIZE_STORAGE_KEY = "valueset-graph:result-page-size";
+
+type RunVariables = {
+	target: RunTarget;
+	offset: number;
+	count: number;
+	reset: boolean;
+	seq: number;
+};
+
 const DEFAULT_DETAILS_WIDTH = 440;
 const MIN_DETAILS_WIDTH = 280;
 const MAX_DETAILS_WIDTH = 800;
@@ -261,24 +272,41 @@ export function ValueSetGraphTab() {
 		setEdges(graph.edges);
 	}, [graph.nodes, graph.edges, setNodes, setEdges]);
 
+	const [page, setPage] = React.useState(1);
+	const [pageSize, setPageSize] = useLocalStorage<number>({
+		key: PAGE_SIZE_STORAGE_KEY,
+		defaultValue: DEFAULT_PAGE_SIZE,
+		getInitialValueInEffect: false,
+	});
+
 	const runStartRef = React.useRef<number>(0);
+	const lastTargetRef = React.useRef<RunTarget | null>(null);
+	const expandedValueSetRef = React.useRef<ValueSet | null>(null);
+	const runSeqRef = React.useRef(0);
 
 	const runMutation = useMutation({
-		mutationFn: async (target: RunTarget): Promise<GraphRunResult> => {
+		mutationFn: async ({
+			target,
+			offset,
+			count,
+			reset,
+		}: RunVariables): Promise<GraphRunResult> => {
 			setRunningNodeId(target.nodeId);
 			setResultNodeId(target.nodeId);
 			setError(null);
-			setResult(null);
+			if (reset) setResult(null);
 			runStartRef.current = performance.now();
 			if (target.kind === "expand") {
 				if (target.isRoot) {
+					if (reset || !expandedValueSetRef.current) {
+						expandedValueSetRef.current = cleanEmptyValues(valueSetRef.current);
+					}
 					const body = {
 						resourceType: "Parameters" as const,
 						parameter: [
-							{
-								name: "valueSet",
-								resource: cleanEmptyValues(valueSetRef.current),
-							},
+							{ name: "valueSet", resource: expandedValueSetRef.current },
+							{ name: "count", valueInteger: count },
+							{ name: "offset", valueInteger: offset },
 						],
 					};
 					const r = await client.request<ValueSet>({
@@ -309,6 +337,7 @@ export function ValueSetGraphTab() {
 				}
 				const params: Array<[string, string]> = [["url", target.url]];
 				if (target.version) params.push(["valueSetVersion", target.version]);
+				params.push(["count", String(count)], ["offset", String(offset)]);
 				const r = await client.request<ValueSet>({
 					method: "GET",
 					url: "/fhir/ValueSet/$expand",
@@ -329,24 +358,62 @@ export function ValueSetGraphTab() {
 				durationMs: performance.now() - runStartRef.current,
 			};
 		},
-		onSuccess: (res) => {
+		onSuccess: (res, { seq }) => {
+			if (seq !== runSeqRef.current) return;
 			setRunningNodeId(null);
 			setResult(res);
 		},
-		onError: (err) => {
+		onError: (err, { seq }) => {
+			if (seq !== runSeqRef.current) return;
 			setRunningNodeId(null);
 			setError(toOperationOutcome(err));
 		},
 	});
+
+	const requestRun = React.useCallback(
+		(vars: Omit<RunVariables, "seq">) => {
+			runSeqRef.current += 1;
+			runMutation.mutate({ ...vars, seq: runSeqRef.current });
+		},
+		[runMutation],
+	);
 
 	const run = React.useCallback(
 		(target: RunTarget) => {
 			if (runMutation.isPending) return;
 			setIsResultCollapsed(false);
 			setIsMaximized(false);
-			runMutation.mutate(target);
+			setPage(1);
+			lastTargetRef.current = target;
+			requestRun({ target, offset: 0, count: pageSize, reset: true });
 		},
-		[runMutation],
+		[runMutation.isPending, requestRun, pageSize],
+	);
+
+	const handlePageChange = React.useCallback(
+		(nextPage: number) => {
+			setPage(nextPage);
+			const target = lastTargetRef.current;
+			if (!target || target.kind !== "expand") return;
+			requestRun({
+				target,
+				offset: (nextPage - 1) * pageSize,
+				count: pageSize,
+				reset: false,
+			});
+		},
+		[requestRun, pageSize],
+	);
+
+	const handlePageSizeChange = React.useCallback(
+		(nextSize: number) => {
+			setPageSize(nextSize);
+			setPage(1);
+			const target = lastTargetRef.current;
+			if (!target || target.kind !== "expand") return;
+			requestRun({ target, offset: 0, count: nextSize, reset: false });
+		},
+		[requestRun, setPageSize],
 	);
 
 	const runContextValue = React.useMemo<GraphRunContextValue>(
@@ -424,6 +491,9 @@ export function ValueSetGraphTab() {
 		setError(null);
 		setIsResultCollapsed(false);
 		setIsMaximized(false);
+		setPage(1);
+		lastTargetRef.current = null;
+		expandedValueSetRef.current = null;
 	}, []);
 
 	React.useEffect(() => {
@@ -611,6 +681,10 @@ export function ValueSetGraphTab() {
 							onToggleMaximize={handleToggleMaximize}
 							onToggleCollapse={handleToggleCollapse}
 							onClose={handleClose}
+							page={page}
+							pageSize={pageSize}
+							onPageChange={handlePageChange}
+							onPageSizeChange={handlePageSizeChange}
 						/>
 					</div>
 				)}

--- a/src/components/ValueSet/result-panel.tsx
+++ b/src/components/ValueSet/result-panel.tsx
@@ -1,18 +1,13 @@
 import * as HSComp from "@health-samurai/react-components";
 import { Maximize2, Minimize2, PanelBottomClose, Timer } from "lucide-react";
-import * as React from "react";
-import { useLocalStorage } from "../../hooks";
 import { DataTableFooter } from "../data-table/footer";
 import { EmptyState } from "../empty-state";
 import { useValueSetContext } from "./context";
 
-const DEFAULT_PAGE_SIZE = 30;
-const PAGE_SIZE_STORAGE_KEY = "valueset-builder:result-page-size";
-
-function ResultBody({ page, pageSize }: { page: number; pageSize: number }) {
+function ResultBody({ offset }: { offset: number }) {
 	const { expansion, expandError, isExpanding } = useValueSetContext();
 
-	if (isExpanding) {
+	if (isExpanding && !expansion) {
 		return (
 			<div className="flex items-center justify-center h-full text-text-secondary">
 				Expanding…
@@ -39,8 +34,8 @@ function ResultBody({ page, pageSize }: { page: number; pageSize: number }) {
 		);
 	}
 
-	const contains = expansion.contains ?? [];
-	if (contains.length === 0) {
+	const visibleRows = expansion.contains ?? [];
+	if (visibleRows.length === 0) {
 		return (
 			<EmptyState
 				title="Empty expansion"
@@ -49,11 +44,12 @@ function ResultBody({ page, pageSize }: { page: number; pageSize: number }) {
 		);
 	}
 
-	const start = (page - 1) * pageSize;
-	const visibleRows = contains.slice(start, start + pageSize);
-
 	return (
-		<HSComp.Table zebra stickyHeader className="typo-code">
+		<HSComp.Table
+			zebra
+			stickyHeader
+			className={`typo-code ${isExpanding ? "opacity-60 pointer-events-none" : ""}`}
+		>
 			<HSComp.TableHeader className="z-0">
 				<HSComp.TableRow>
 					<HSComp.TableHead>Code</HSComp.TableHead>
@@ -65,7 +61,7 @@ function ResultBody({ page, pageSize }: { page: number; pageSize: number }) {
 			<HSComp.TableBody>
 				{visibleRows.map((row, i) => (
 					// biome-ignore lint/suspicious/noArrayIndexKey: row order is stable
-					<HSComp.TableRow key={start + i} zebra index={start + i}>
+					<HSComp.TableRow key={offset + i} zebra index={offset + i}>
 						<HSComp.TableCell>{row.code ?? "—"}</HSComp.TableCell>
 						<HSComp.TableCell>{row.display ?? "—"}</HSComp.TableCell>
 						<HSComp.TableCell className="text-text-secondary">
@@ -83,34 +79,27 @@ export function ResultPanel({
 	isMaximized,
 	onToggleMaximize,
 	onToggleCollapse,
+	page,
+	pageSize,
+	onPageChange,
+	onPageSizeChange,
 }: {
 	isMaximized: boolean;
 	onToggleMaximize: () => void;
 	onToggleCollapse: () => void;
+	page: number;
+	pageSize: number;
+	onPageChange: (page: number) => void;
+	onPageSizeChange: (size: number) => void;
 }) {
 	const { expansion, expandDurationMs } = useValueSetContext();
-	const [page, setPage] = React.useState(1);
-	const [pageSize, setPageSize] = useLocalStorage<number>({
-		key: PAGE_SIZE_STORAGE_KEY,
-		getInitialValueInEffect: false,
-		defaultValue: DEFAULT_PAGE_SIZE,
-	});
-	const total = expansion?.contains?.length ?? 0;
-	const totalPages = Math.max(1, Math.ceil(total / pageSize));
-
-	React.useEffect(() => {
-		setPage(1);
-	}, []);
-
-	React.useEffect(() => {
-		if (page > totalPages) setPage(totalPages);
-	}, [page, totalPages]);
+	const total = expansion?.total ?? expansion?.contains?.length ?? 0;
 
 	return (
 		<div className="flex flex-col h-full overflow-hidden">
 			<div className="flex gap-1 items-center justify-between bg-bg-secondary pl-4 pr-2 border-b h-10 shrink-0">
 				<span className="typo-label text-text-secondary">
-					Expansion ({expansion?.total ?? total})
+					Expansion ({total})
 				</span>
 				<div className="flex items-center gap-2">
 					{expandDurationMs != null && (
@@ -154,7 +143,7 @@ export function ResultPanel({
 			</div>
 			<div className="flex-1 min-h-0 flex flex-col">
 				<div className="flex-1 min-h-0">
-					<ResultBody page={page} pageSize={pageSize} />
+					<ResultBody offset={(page - 1) * pageSize} />
 				</div>
 				{total > 0 && (
 					<DataTableFooter
@@ -162,11 +151,8 @@ export function ResultPanel({
 						currentPage={page}
 						pageSize={pageSize}
 						selectedCount={0}
-						onPageChange={setPage}
-						onPageSizeChange={(size) => {
-							setPageSize(size);
-							setPage(1);
-						}}
+						onPageChange={onPageChange}
+						onPageSizeChange={onPageSizeChange}
 					/>
 				)}
 			</div>


### PR DESCRIPTION
## Problem

The builder's EXPAND ran `$expand` without `count`/`offset` and paginated the full `expansion.contains` client-side. Aidbox silently caps an unbounded expansion at **1024** codes, so for anything larger the header claimed the real total (e.g. `Expansion (1116)` for v3-ActCode) while pages past code 1024 simply didn't exist. The whole expansion was also held in browser memory.

## Change

Every page is now its own `$expand` call with `count` + `offset`; the table renders exactly the page the server returned, and the footer/header totals come from `expansion.total`.

**Builder result panel** (`builder-content.tsx`, `result-panel.tsx`)
- `page`/`pageSize` state lifted to `ValueSetBuilderContent`; the mutation takes `{offset, count, reset, seq}`.
- EXPAND snapshots `cleanEmptyValues(valueSet)` into a ref — page loads keep querying the snapshot even if the draft is edited meanwhile.
- Monotonic `seq` guard drops out-of-order responses when pages are clicked quickly.
- While paginating, the previous page stays visible dimmed (`opacity-60`); the full-size "Expanding…" placeholder only shows for the initial run.

**Graph tab** (`graph-tab.tsx`, `expand-result-panel.tsx`)
- Same pattern for node runs: root EXPAND → POST with inline snapshot + `count`/`offset`; dependency EXPAND → GET with `url`/`valueSetVersion` + `count`/`offset`.
- CONTENT (CodeSystem inline concepts) is unchanged: fetched in full, still sliced client-side — there's no server-side pagination for it.

Changing page size resets to page 1: verified against Aidbox that result order is stable for a fixed `count` but differs across `count` values, so mixing page sizes within one expansion would shuffle rows.

## Verified

- `$expand` contract checked with curl against a local box (POST inline + GET by url, multi-include compose): `total` is always returned, pages for a fixed `count` are deterministic, disjoint, and gap-free.
- `pnpm typecheck` and `biome check` are clean.