### PR TITLE
SQLView: support across Analytics UI and notebooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
 		"tailwindcss": "^4.2.1",
 		"tw-animate-css": "^1.4.0",
 		"typescript": "^5.9.3",
-		"vite": "^7.3.2",
-		"ws": "^8.19.0",
+		"vite": "^7.3.5",
+		"ws": "^8.21.0",
 		"zod": "^4.3.6"
 	},
 	"pnpm": {
@@ -56,6 +56,7 @@
 			"yaml": "^2.8.3",
 			"diff": "^8.0.3",
 			"postcss@<8.5.10": ">=8.5.10",
+			"esbuild@<0.28.1": ">=0.28.1",
 			"@codemirror/view": "^6.42.0",
 			"@codemirror/autocomplete": "6.20.2",
 			"@health-samurai/aidbox-client": "file:./aidbox-ts-sdk/packages/aidbox-client"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   yaml: ^2.8.3
   diff: ^8.0.3
   postcss@<8.5.10: '>=8.5.10'
+  esbuild@<0.28.1: '>=0.28.1'
   '@codemirror/view': ^6.42.0
   '@codemirror/autocomplete': 6.20.2
   '@health-samurai/aidbox-client': file:./aidbox-ts-sdk/packages/aidbox-client
@@ -95,10 +96,10 @@ importers:
         version: 2.1.3
       '@tailwindcss/vite':
         specifier: ^4.2.1
-        version: 4.2.1(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.2.1(vite@7.3.5(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
       '@tanstack/router-plugin':
         specifier: ^1.166.7
-        version: 1.166.12(@tanstack/react-router@1.167.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 1.166.12(@tanstack/react-router@1.167.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.5(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
       '@types/css':
         specifier: ^0.0.38
         version: 0.0.38
@@ -119,7 +120,7 @@ importers:
         version: 8.18.1
       '@vitejs/plugin-react':
         specifier: ^4.7.0
-        version: 4.7.0(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.7.0(vite@7.3.5(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
       '@zed-industries/claude-agent-acp':
         specifier: ^0.20.2
         version: 0.20.2
@@ -136,11 +137,11 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
-        specifier: ^7.3.2
-        version: 7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
+        specifier: ^7.3.5
+        version: 7.3.5(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
       ws:
-        specifier: ^8.19.0
-        version: 8.19.0
+        specifier: ^8.21.0
+        version: 8.21.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -394,158 +395,158 @@ packages:
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
 
-  '@esbuild/aix-ppc64@0.27.4':
-    resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.27.4':
-    resolution: {integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==}
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.27.4':
-    resolution: {integrity: sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==}
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.27.4':
-    resolution: {integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==}
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.27.4':
-    resolution: {integrity: sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==}
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.27.4':
-    resolution: {integrity: sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==}
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.27.4':
-    resolution: {integrity: sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==}
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.27.4':
-    resolution: {integrity: sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==}
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.27.4':
-    resolution: {integrity: sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==}
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.27.4':
-    resolution: {integrity: sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==}
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.4':
-    resolution: {integrity: sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==}
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.27.4':
-    resolution: {integrity: sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==}
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.4':
-    resolution: {integrity: sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==}
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.27.4':
-    resolution: {integrity: sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==}
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.4':
-    resolution: {integrity: sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==}
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.27.4':
-    resolution: {integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==}
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.4':
-    resolution: {integrity: sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==}
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.27.4':
-    resolution: {integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==}
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.4':
-    resolution: {integrity: sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==}
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.27.4':
-    resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.4':
-    resolution: {integrity: sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==}
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.27.4':
-    resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.27.4':
-    resolution: {integrity: sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==}
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.27.4':
-    resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.4':
-    resolution: {integrity: sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==}
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.27.4':
-    resolution: {integrity: sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==}
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -2298,8 +2299,8 @@ packages:
   es-toolkit@1.45.1:
     resolution: {integrity: sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==}
 
-  esbuild@0.27.4:
-    resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -3108,8 +3109,8 @@ packages:
   victory-vendor@37.3.6:
     resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
-  vite@7.3.2:
-    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
+  vite@7.3.5:
+    resolution: {integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -3175,8 +3176,8 @@ packages:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
 
-  ws@8.19.0:
-    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -3571,82 +3572,82 @@ snapshots:
 
   '@date-fns/tz@1.4.1': {}
 
-  '@esbuild/aix-ppc64@0.27.4':
+  '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm64@0.27.4':
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm@0.27.4':
+  '@esbuild/android-arm@0.28.1':
     optional: true
 
-  '@esbuild/android-x64@0.27.4':
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.4':
+  '@esbuild/darwin-arm64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-x64@0.27.4':
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.4':
+  '@esbuild/freebsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.4':
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.4':
+  '@esbuild/linux-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm@0.27.4':
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.4':
+  '@esbuild/linux-ia32@0.28.1':
     optional: true
 
-  '@esbuild/linux-loong64@0.27.4':
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.4':
+  '@esbuild/linux-mips64el@0.28.1':
     optional: true
 
-  '@esbuild/linux-ppc64@0.27.4':
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.4':
+  '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
-  '@esbuild/linux-s390x@0.27.4':
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
-  '@esbuild/linux-x64@0.27.4':
+  '@esbuild/linux-x64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.27.4':
+  '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.4':
+  '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.27.4':
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.4':
+  '@esbuild/openbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.27.4':
+  '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.4':
+  '@esbuild/sunos-x64@0.28.1':
     optional: true
 
-  '@esbuild/win32-arm64@0.27.4':
+  '@esbuild/win32-arm64@0.28.1':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.4':
+  '@esbuild/win32-ia32@0.28.1':
     optional: true
 
-  '@esbuild/win32-x64@0.27.4':
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@floating-ui/core@1.7.5':
@@ -4934,12 +4935,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.2.1
       '@tailwindcss/oxide-win32-x64-msvc': 4.2.1
 
-  '@tailwindcss/vite@4.2.1(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@tailwindcss/vite@4.2.1(vite@7.3.5(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@tailwindcss/node': 4.2.1
       '@tailwindcss/oxide': 4.2.1
       tailwindcss: 4.2.1
-      vite: 7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.5(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@tanstack/history@1.161.6': {}
 
@@ -5003,7 +5004,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.166.12(@tanstack/react-router@1.167.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@tanstack/router-plugin@1.166.12(@tanstack/react-router@1.167.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.5(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
@@ -5020,7 +5021,7 @@ snapshots:
       zod: 3.25.76
     optionalDependencies:
       '@tanstack/react-router': 1.167.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      vite: 7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.5(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -5158,7 +5159,7 @@ snapshots:
 
   '@ungap/structured-clone@1.3.1': {}
 
-  '@vitejs/plugin-react@4.7.0(vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitejs/plugin-react@4.7.0(vite@7.3.5(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -5166,7 +5167,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.5(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -5446,34 +5447,34 @@ snapshots:
 
   es-toolkit@1.45.1: {}
 
-  esbuild@0.27.4:
+  esbuild@0.28.1:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.4
-      '@esbuild/android-arm': 0.27.4
-      '@esbuild/android-arm64': 0.27.4
-      '@esbuild/android-x64': 0.27.4
-      '@esbuild/darwin-arm64': 0.27.4
-      '@esbuild/darwin-x64': 0.27.4
-      '@esbuild/freebsd-arm64': 0.27.4
-      '@esbuild/freebsd-x64': 0.27.4
-      '@esbuild/linux-arm': 0.27.4
-      '@esbuild/linux-arm64': 0.27.4
-      '@esbuild/linux-ia32': 0.27.4
-      '@esbuild/linux-loong64': 0.27.4
-      '@esbuild/linux-mips64el': 0.27.4
-      '@esbuild/linux-ppc64': 0.27.4
-      '@esbuild/linux-riscv64': 0.27.4
-      '@esbuild/linux-s390x': 0.27.4
-      '@esbuild/linux-x64': 0.27.4
-      '@esbuild/netbsd-arm64': 0.27.4
-      '@esbuild/netbsd-x64': 0.27.4
-      '@esbuild/openbsd-arm64': 0.27.4
-      '@esbuild/openbsd-x64': 0.27.4
-      '@esbuild/openharmony-arm64': 0.27.4
-      '@esbuild/sunos-x64': 0.27.4
-      '@esbuild/win32-arm64': 0.27.4
-      '@esbuild/win32-ia32': 0.27.4
-      '@esbuild/win32-x64': 0.27.4
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escalade@3.2.0: {}
 
@@ -6435,7 +6436,7 @@ snapshots:
 
   tsx@4.21.0:
     dependencies:
-      esbuild: 0.27.4
+      esbuild: 0.28.1
       get-tsconfig: 4.13.6
     optionalDependencies:
       fsevents: 2.3.3
@@ -6547,9 +6548,9 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite@7.3.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3):
+  vite@7.3.5(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
-      esbuild: 0.27.4
+      esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
       postcss: 8.5.13
@@ -6588,7 +6589,7 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
 
-  ws@8.19.0: {}
+  ws@8.21.0: {}
 
   xml-naming@0.1.0: {}
 

--- a/src/components/ResourceEditor/page.tsx
+++ b/src/components/ResourceEditor/page.tsx
@@ -36,7 +36,7 @@ import { StatsTab as SearchParameterStatsTab } from "../SearchParameter/stats-ta
 import { SQLQueryBuilderContent } from "../SQLQueryBuilder/builder-content";
 import { LineageTab } from "../SQLQueryBuilder/lineage/lineage-tab";
 import { SQLQueryProvider } from "../SQLQueryBuilder/page";
-import { SQL_QUERY_PROFILE } from "../SQLQueryBuilder/types";
+import { SQL_QUERY_PROFILE, SQL_VIEW_PROFILE } from "../SQLQueryBuilder/types";
 import { ValueSetBuilderContent } from "../ValueSet/builder-content";
 import { ValueSetGraphTab } from "../ValueSet/graph/graph-tab";
 import { ValueSetProvider } from "../ValueSet/page";
@@ -127,6 +127,26 @@ export const ResourceEditorPageWithLoader = (
 		/>
 	);
 };
+
+function libraryHasProfile(resource: Resource, profile: string): boolean {
+	return Boolean(
+		(resource as { meta?: { profile?: string[] } }).meta?.profile?.includes(
+			profile,
+		),
+	);
+}
+
+function detectSqlLibrary(resource: Resource, isLibrary: boolean) {
+	const isSQLView = isLibrary && libraryHasProfile(resource, SQL_VIEW_PROFILE);
+	const isSQLQuery =
+		isLibrary && libraryHasProfile(resource, SQL_QUERY_PROFILE);
+	return {
+		isSQLView,
+		isSQLQuery,
+		isSqlLibrary: isSQLView || isSQLQuery,
+		builderLabel: isSQLView ? "SQLView" : "SQLQuery",
+	};
+}
 
 export const ResourceEditorPage = ({
 	id,
@@ -378,13 +398,10 @@ export const ResourceEditorPage = ({
 	const isValueSet = resourceType === "ValueSet";
 	const isCodeSystem = resourceType === "CodeSystem";
 	const isConceptMap = resourceType === "ConceptMap";
-	const isSQLQuery =
-		isLibrary &&
-		Boolean(
-			(
-				initialResource as { meta?: { profile?: string[] } }
-			).meta?.profile?.includes(SQL_QUERY_PROFILE),
-		);
+	const { isSqlLibrary, builderLabel } = detectSqlLibrary(
+		initialResource,
+		isLibrary,
+	);
 
 	const tabs: {
 		value: string;
@@ -482,7 +499,7 @@ export const ResourceEditorPage = ({
 			value: "sqlquery",
 			trigger: (
 				<HSComp.TabsTrigger value="sqlquery">
-					SQLQuery Builder
+					{builderLabel} Builder
 				</HSComp.TabsTrigger>
 			),
 			content: (
@@ -493,7 +510,7 @@ export const ResourceEditorPage = ({
 		});
 	}
 
-	if (isSQLQuery) {
+	if (isSqlLibrary) {
 		tabs.push({
 			value: "lineage",
 			trigger: <HSComp.TabsTrigger value="lineage">Lineage</HSComp.TabsTrigger>,

--- a/src/components/SQLQueryBuilder/builder-content.tsx
+++ b/src/components/SQLQueryBuilder/builder-content.tsx
@@ -11,10 +11,8 @@ import { EditorHeaderMenu } from "./header-menu";
 import { PropertiesTree } from "./properties-tree";
 import { useResolvedParameterTree } from "./resolve-tree";
 import { ResultPanel } from "./result-panel";
-import { buildRunPayload, ensureSQLQueryShape } from "./run-payload";
-import type { SQLLibrary } from "./types";
-
-const URL_HISTORY_KEY = "sqlquery-library-url-history";
+import { buildRunPayload, ensureSqlLibraryShape } from "./run-payload";
+import { type SQLLibrary, sqlLibraryKindMeta } from "./types";
 
 function toOperationOutcome(err: unknown): HSComp.OperationOutcome {
 	if (
@@ -138,6 +136,8 @@ export function SQLQueryBuilderContent() {
 		onCreated,
 	} = useSQLQueryContext();
 
+	const kindMeta = sqlLibraryKindMeta(library);
+
 	const { tree: resolvedTree } = useResolvedParameterTree(library);
 	const inheritedTypes = React.useMemo(() => {
 		const m = new Map<string, string>();
@@ -150,7 +150,7 @@ export function SQLQueryBuilderContent() {
 	const saveMutation = useMutation({
 		mutationFn: async () => {
 			setRunError(null);
-			const shaped = ensureSQLQueryShape(library);
+			const shaped = ensureSqlLibraryShape(library);
 			const trimmed: SQLLibrary = {
 				...shaped,
 				relatedArtifact: (shaped.relatedArtifact ?? []).filter(
@@ -180,8 +180,8 @@ export function SQLQueryBuilderContent() {
 		},
 		onSuccess: ({ resource, created }) => {
 			setIsDirty(false);
-			addUrlToHistory(URL_HISTORY_KEY, library.url);
-			HSComp.toast.success("SQLQuery saved successfully", {
+			addUrlToHistory(kindMeta.urlHistoryKey, library.url);
+			HSComp.toast.success(`${kindMeta.label} saved successfully`, {
 				position: "bottom-right",
 				style: { margin: "1rem" },
 			});
@@ -196,7 +196,7 @@ export function SQLQueryBuilderContent() {
 		onError: (err) => {
 			const oo = toOperationOutcome(err);
 			Utils.toastError(
-				"Failed to save SQLQuery",
+				`Failed to save ${kindMeta.label}`,
 				oo.issue?.[0]?.diagnostics ?? undefined,
 			);
 		},

--- a/src/components/SQLQueryBuilder/lineage/detail-panel.tsx
+++ b/src/components/SQLQueryBuilder/lineage/detail-panel.tsx
@@ -1,7 +1,14 @@
 import * as HSComp from "@health-samurai/react-components";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
-import { Database, ExternalLink, FileCode2, Table, X } from "lucide-react";
+import {
+	Database,
+	ExternalLink,
+	FileCode2,
+	Layers,
+	Table,
+	X,
+} from "lucide-react";
 import type * as React from "react";
 import { useAidboxClient } from "../../../AidboxClient";
 import {
@@ -456,12 +463,15 @@ export function LineageDetailPanel({
 	}
 
 	// sql-query
+	const isView = data.libraryKind === "sql-view";
 	return (
 		<div className="h-full overflow-auto p-4 pb-20 flex flex-col gap-4 bg-bg-primary">
 			<PanelHeader
-				icon={<FileCode2 size={14} />}
-				label="Query"
-				color="text-text-warning-primary"
+				icon={isView ? <Layers size={14} /> : <FileCode2 size={14} />}
+				label={isView ? "SQLView" : "SQLQuery"}
+				color={
+					isView ? "text-text-success-primary" : "text-text-warning-primary"
+				}
 				onClose={onClose}
 			/>
 			<div className="flex flex-col gap-1">
@@ -469,7 +479,11 @@ export function LineageDetailPanel({
 					ID
 				</span>
 				<Link
-					to="/analytics/queries/edit/$id"
+					to={
+						isView
+							? "/analytics/sqlview/edit/$id"
+							: "/analytics/queries/edit/$id"
+					}
 					params={{ id: data.id }}
 					search={{
 						tab: "sqlquery" as const,
@@ -493,38 +507,39 @@ export function LineageDetailPanel({
 					</p>
 				</Section>
 			)}
-			{(() => {
-				const ownNames = new Set(data.parameters.map((p) => p.name));
-				const merged = [
-					...data.parameters.map((p) => ({ ...p, inherited: false })),
-					...data.inheritedParameters
-						.filter((p) => !ownNames.has(p.name))
-						.map((p) => ({ ...p, inherited: true })),
-				];
-				return (
-					<Section title={`Parameters (${merged.length})`}>
-						{merged.length === 0 ? (
-							<span className="text-xs text-text-tertiary italic">none</span>
-						) : (
-							<ul className="list-disc pl-4 flex flex-col gap-0.5">
-								{merged.map((p) => (
-									<li key={p.name} className="text-xs font-mono">
-										<span className="text-text-primary">{p.name}</span>
-										{p.type && (
-											<span className="text-text-tertiary"> ({p.type})</span>
-										)}
-										{p.inherited && (
-											<span className="ml-1 text-[10px] text-text-tertiary italic">
-												inherited
-											</span>
-										)}
-									</li>
-								))}
-							</ul>
-						)}
-					</Section>
-				);
-			})()}
+			{!isView &&
+				(() => {
+					const ownNames = new Set(data.parameters.map((p) => p.name));
+					const merged = [
+						...data.parameters.map((p) => ({ ...p, inherited: false })),
+						...data.inheritedParameters
+							.filter((p) => !ownNames.has(p.name))
+							.map((p) => ({ ...p, inherited: true })),
+					];
+					return (
+						<Section title={`Parameters (${merged.length})`}>
+							{merged.length === 0 ? (
+								<span className="text-xs text-text-tertiary italic">none</span>
+							) : (
+								<ul className="list-disc pl-4 flex flex-col gap-0.5">
+									{merged.map((p) => (
+										<li key={p.name} className="text-xs font-mono">
+											<span className="text-text-primary">{p.name}</span>
+											{p.type && (
+												<span className="text-text-tertiary"> ({p.type})</span>
+											)}
+											{p.inherited && (
+												<span className="ml-1 text-[10px] text-text-tertiary italic">
+													inherited
+												</span>
+											)}
+										</li>
+									))}
+								</ul>
+							)}
+						</Section>
+					);
+				})()}
 			{data.sql && (
 				<Section title="SQL">
 					<div

--- a/src/components/SQLQueryBuilder/lineage/node-search.tsx
+++ b/src/components/SQLQueryBuilder/lineage/node-search.tsx
@@ -11,8 +11,8 @@ function nodeLabel(data: LineageNodeData): string {
 
 function nodeKind(data: LineageNodeData): string {
 	if (data.kind === "resource-type") return "Resource";
-	if (data.kind === "view-definition") return "View";
-	return "Query";
+	if (data.kind === "view-definition") return "ViewDefinition";
+	return data.libraryKind === "sql-view" ? "SQLView" : "SQLQuery";
 }
 
 export function NodeSearch({ onSelect }: { onSelect: (id: string) => void }) {

--- a/src/components/SQLQueryBuilder/lineage/nodes.tsx
+++ b/src/components/SQLQueryBuilder/lineage/nodes.tsx
@@ -1,6 +1,6 @@
 import * as HSComp from "@health-samurai/react-components";
 import { Handle, Position } from "@xyflow/react";
-import { Database, FileCode2, PlayIcon, Table } from "lucide-react";
+import { Database, FileCode2, Layers, PlayIcon, Table } from "lucide-react";
 import * as React from "react";
 import {
 	BaseNode,
@@ -254,12 +254,19 @@ export function SQLQueryNode({ id, data, selected }: AnyNodeProps) {
 
 	const showInputs = (selected ?? false) && allParams.length > 0;
 
+	const isView = d.libraryKind === "sql-view";
 	const headerInner = (
 		<>
 			<div className="flex items-center gap-2">
-				<FileCode2 size={14} className="text-text-warning-primary shrink-0" />
-				<span className="font-mono text-xs text-text-warning-primary uppercase">
-					Query
+				{isView ? (
+					<Layers size={14} className="text-text-success-primary shrink-0" />
+				) : (
+					<FileCode2 size={14} className="text-text-warning-primary shrink-0" />
+				)}
+				<span
+					className={`font-mono text-xs uppercase ${isView ? "text-text-success-primary" : "text-text-warning-primary"}`}
+				>
+					{isView ? "SQLView" : "SQLQuery"}
 				</span>
 			</div>
 			<div className="font-mono text-sm font-medium text-text-primary truncate">
@@ -274,25 +281,29 @@ export function SQLQueryNode({ id, data, selected }: AnyNodeProps) {
 				selected={selected}
 				className={d.isRoot ? "border-border-link" : ""}
 			>
-				<BaseNodeHeader>{headerInner}</BaseNodeHeader>
-				<BaseNodeBody>
-					{allParams.length === 0 ? (
-						<div className="px-3 py-2 text-xs text-text-tertiary italic">
-							no parameters
-						</div>
-					) : (
-						allParams.map((p) => (
-							<BaseNodeRow key={p.name}>
-								<span className="font-mono text-xs text-text-primary truncate">
-									{p.name}
-								</span>
-								<span className="font-mono text-xs text-text-tertiary text-right truncate">
-									{p.type ?? ""}
-								</span>
-							</BaseNodeRow>
-						))
-					)}
-				</BaseNodeBody>
+				<BaseNodeHeader className={isView ? "border-b-0" : undefined}>
+					{headerInner}
+				</BaseNodeHeader>
+				{!isView && (
+					<BaseNodeBody>
+						{allParams.length === 0 ? (
+							<div className="px-3 py-2 text-xs text-text-tertiary italic">
+								no parameters
+							</div>
+						) : (
+							allParams.map((p) => (
+								<BaseNodeRow key={p.name}>
+									<span className="font-mono text-xs text-text-primary truncate">
+										{p.name}
+									</span>
+									<span className="font-mono text-xs text-text-tertiary text-right truncate">
+										{p.type ?? ""}
+									</span>
+								</BaseNodeRow>
+							))
+						)}
+					</BaseNodeBody>
+				)}
 				<QueryNodeFooter
 					nodeId={id}
 					queryId={d.id}

--- a/src/components/SQLQueryBuilder/lineage/resolve-graph.ts
+++ b/src/components/SQLQueryBuilder/lineage/resolve-graph.ts
@@ -2,7 +2,7 @@ import type { Bundle } from "@aidbox-ui/fhir-types/hl7-fhir-r5-core";
 import { useQuery } from "@tanstack/react-query";
 import type { Edge, Node } from "@xyflow/react";
 import { type AidboxClientR5, useAidboxClient } from "../../../AidboxClient";
-import type { SQLLibrary } from "../types";
+import { type SQLLibrary, sqlLibraryKind } from "../types";
 import type {
 	LineageNodeData,
 	ResourceTypeNodeData,
@@ -193,6 +193,7 @@ function rootLibraryNode(lib: SQLLibrary): ResolvedNode {
 		id,
 		data: {
 			kind: "sql-query",
+			libraryKind: sqlLibraryKind(lib),
 			id: lib.id ?? "",
 			canonical: lib.url ?? "",
 			name: lib.name ?? "",
@@ -215,6 +216,7 @@ function libraryNode(lib: RawLibrary, canonical: string): ResolvedNode {
 		id,
 		data: {
 			kind: "sql-query",
+			libraryKind: sqlLibraryKind(lib),
 			id: lib.id ?? "",
 			canonical,
 			name: lib.name ?? "",

--- a/src/components/SQLQueryBuilder/lineage/types.ts
+++ b/src/components/SQLQueryBuilder/lineage/types.ts
@@ -44,6 +44,7 @@ export type ParamSpec = { name: string; type?: string };
 
 export type SQLQueryNodeData = {
 	kind: "sql-query";
+	libraryKind: "sql-query" | "sql-view";
 	id: string;
 	canonical: string;
 	name: string;

--- a/src/components/SQLQueryBuilder/properties-tree.tsx
+++ b/src/components/SQLQueryBuilder/properties-tree.tsx
@@ -20,9 +20,8 @@ import {
 	LABEL_REGEX,
 	type SQLDependsOn,
 	type SQLParameter,
+	sqlLibraryKindMeta,
 } from "./types";
-
-const URL_HISTORY_KEY = "sqlquery-library-url-history";
 
 type ItemMeta = {
 	type:
@@ -338,6 +337,7 @@ function InheritedParameterRow({
 export function PropertiesTree() {
 	const { library, updateLibrary, paramValues, setParamValue, missingParams } =
 		useSQLQueryContext();
+	const kindMeta = sqlLibraryKindMeta(library);
 	const treeContainerRef = React.useRef<HTMLDivElement>(null);
 
 	React.useEffect(() => {
@@ -436,7 +436,9 @@ export function PropertiesTree() {
 		const out: Record<string, TreeViewItem<ItemMeta>> = {
 			root: {
 				name: "root",
-				children: ["_properties", "_depends_on", "_parameter", "_sql"],
+				children: kindMeta.supportsParameters
+					? ["_properties", "_depends_on", "_parameter", "_sql"]
+					: ["_properties", "_depends_on", "_sql"],
 			},
 			_properties: {
 				name: "_properties",
@@ -494,7 +496,7 @@ export function PropertiesTree() {
 			};
 		});
 		return out;
-	}, [dependsOn, parameters, inheritedOnly]);
+	}, [dependsOn, parameters, inheritedOnly, kindMeta.supportsParameters]);
 
 	const [expandedItems, setExpandedItems] = React.useState<string[]>([
 		"_properties",
@@ -658,9 +660,9 @@ export function PropertiesTree() {
 						<div className="w-[226px] shrink-0">{labelView(item)}</div>
 						<div className="w-[50%]">
 							<InputView
-								name="sqlquery-library-url"
+								name={`${kindMeta.kind}-library-url`}
 								autoComplete="on"
-								list="sqlquery-library-url-history"
+								list={kindMeta.urlHistoryKey}
 								placeholder="Canonical identifier for this library, represented as a URI (globally unique)"
 								value={library.url}
 								onChange={updateUrl}
@@ -719,6 +721,11 @@ export function PropertiesTree() {
 							<ResourcePicker
 								value={entry.resource}
 								onChange={(ref) => updateDependsOnResource(idx, ref)}
+								kinds={
+									kindMeta.kind === "sql-view"
+										? ["ViewDefinition", "SQLView"]
+										: ["ViewDefinition", "SQLQuery", "SQLView"]
+								}
 							/>
 						</div>
 						<HSComp.Button
@@ -850,11 +857,11 @@ export function PropertiesTree() {
 		}
 	};
 
-	const urlHistory = readUrlHistory(URL_HISTORY_KEY);
+	const urlHistory = readUrlHistory(kindMeta.urlHistoryKey);
 
 	return (
 		<div ref={treeContainerRef}>
-			<datalist id="sqlquery-library-url-history">
+			<datalist id={kindMeta.urlHistoryKey}>
 				{urlHistory.map((u) => (
 					<option key={u} value={u} />
 				))}

--- a/src/components/SQLQueryBuilder/resource-picker.tsx
+++ b/src/components/SQLQueryBuilder/resource-picker.tsx
@@ -1,12 +1,16 @@
 import type { Bundle } from "@aidbox-ui/fhir-types/hl7-fhir-r5-core";
 import * as HSComp from "@health-samurai/react-components";
 import { useQuery } from "@tanstack/react-query";
-import { ChevronDown, FileCode2, Info, Table } from "lucide-react";
+import { ChevronDown, FileCode2, Info, Layers, Table } from "lucide-react";
 import * as React from "react";
 import { useAidboxClient } from "../../AidboxClient";
-import { SQL_QUERY_TYPE_CODE, SQL_QUERY_TYPE_SYSTEM } from "./types";
+import {
+	SQL_QUERY_TYPE_CODE,
+	SQL_QUERY_TYPE_SYSTEM,
+	SQL_VIEW_TYPE_CODE,
+} from "./types";
 
-type CandidateKind = "ViewDefinition" | "SQLQuery";
+type CandidateKind = "ViewDefinition" | "SQLQuery" | "SQLView";
 
 type RelatedArtifactRef = { url: string; label?: string };
 
@@ -60,6 +64,7 @@ function Badge({ text, accentClass }: { text: string; accentClass: string }) {
 }
 
 const SQL_QUERY_TYPE_TOKEN = `${SQL_QUERY_TYPE_SYSTEM}|${SQL_QUERY_TYPE_CODE}`;
+const SQL_VIEW_TYPE_TOKEN = `${SQL_QUERY_TYPE_SYSTEM}|${SQL_VIEW_TYPE_CODE}`;
 
 function useDebouncedValue<T>(value: T, delay: number): T {
 	const [v, setV] = React.useState(value);
@@ -73,7 +78,7 @@ function useDebouncedValue<T>(value: T, delay: number): T {
 function useCandidates(
 	search: string,
 	enabled = true,
-	kinds: CandidateKind[] = ["ViewDefinition", "SQLQuery"],
+	kinds: CandidateKind[] = ["ViewDefinition", "SQLQuery", "SQLView"],
 ) {
 	const client = useAidboxClient();
 	const debouncedSearch = useDebouncedValue(search, 200);
@@ -89,7 +94,7 @@ function useCandidates(
 			];
 			if (debouncedSearch) baseParams.push(["_ilike", debouncedSearch]);
 			const want = (k: CandidateKind) => kinds.includes(k);
-			const [vd, lib] = await Promise.all([
+			const [vd, sqlQueryLib, sqlViewLib] = await Promise.all([
 				want("ViewDefinition")
 					? client.request<Bundle>({
 							method: "GET",
@@ -102,6 +107,13 @@ function useCandidates(
 							method: "GET",
 							url: "/fhir/Library",
 							params: [...baseParams, ["type", SQL_QUERY_TYPE_TOKEN]],
+						})
+					: null,
+				want("SQLView")
+					? client.request<Bundle>({
+							method: "GET",
+							url: "/fhir/Library",
+							params: [...baseParams, ["type", SQL_VIEW_TYPE_TOKEN]],
 						})
 					: null,
 			]);
@@ -121,15 +133,19 @@ function useCandidates(
 					});
 				}
 			}
-			if (lib?.isOk()) {
-				for (const entry of lib.value.resource.entry ?? []) {
+			for (const [res, kind] of [
+				[sqlQueryLib, "SQLQuery"],
+				[sqlViewLib, "SQLView"],
+			] as const) {
+				if (!res?.isOk()) continue;
+				for (const entry of res.value.resource.entry ?? []) {
 					const r = entry.resource as unknown as RawCandidate;
 					const relatedArtifacts = (r.relatedArtifact ?? []).flatMap((ra) =>
 						ra.resource ? [{ url: ra.resource, label: ra.label }] : [],
 					);
 					out.push({
 						url: r.url,
-						kind: "SQLQuery",
+						kind,
 						id: r.id,
 						name: r.name,
 						title: r.title,
@@ -218,7 +234,8 @@ export function ResourcePicker({
 									<div className="flex items-start gap-1.5 text-left typo-body-xs text-text-secondary normal-case">
 										<Info className="size-3.5 shrink-0 mt-0.5 text-text-tertiary" />
 										<span>
-											Only ViewDefinitions and SQLQueries with a defined{" "}
+											Only ViewDefinitions, SQLQueries and SQLViews with a
+											defined{" "}
 											<span className="font-mono text-text-primary">url</span>{" "}
 											are listed — references rely on canonical URLs.
 										</span>
@@ -228,11 +245,19 @@ export function ResourcePicker({
 							{candidates.map((c) => {
 								const label = c.title || c.name || c.id;
 								const isView = c.kind === "ViewDefinition";
-								const Icon = isView ? Table : FileCode2;
-								const kindLabel = isView ? "View" : "Query";
-								const accentClass = isView
-									? "text-text-info-primary"
-									: "text-text-warning-primary";
+								const Icon =
+									c.kind === "ViewDefinition"
+										? Table
+										: c.kind === "SQLView"
+											? Layers
+											: FileCode2;
+								const kindLabel = c.kind;
+								const accentClass =
+									c.kind === "ViewDefinition"
+										? "text-text-info-primary"
+										: c.kind === "SQLView"
+											? "text-text-success-primary"
+											: "text-text-warning-primary";
 								const badges: React.ReactNode[] = [];
 								if (isView && c.resource) {
 									badges.push(

--- a/src/components/SQLQueryBuilder/run-payload.ts
+++ b/src/components/SQLQueryBuilder/run-payload.ts
@@ -1,28 +1,26 @@
 import {
-	SQL_QUERY_PROFILE,
-	SQL_QUERY_TYPE_CODE,
 	SQL_QUERY_TYPE_SYSTEM,
 	type SQLLibrary,
+	sqlLibraryKindMeta,
 } from "./types";
 
-export function ensureSQLQueryShape(lib: SQLLibrary): SQLLibrary {
+export function ensureSqlLibraryShape(lib: SQLLibrary): SQLLibrary {
+	const kindMeta = sqlLibraryKindMeta(lib);
 	const profiles = lib.meta?.profile ?? [];
-	const hasProfile = profiles.includes(SQL_QUERY_PROFILE);
+	const hasProfile = profiles.includes(kindMeta.profile);
 	const hasType = lib.type?.coding?.some(
-		(c) => c.system === SQL_QUERY_TYPE_SYSTEM && c.code === SQL_QUERY_TYPE_CODE,
+		(c) => c.system === SQL_QUERY_TYPE_SYSTEM && c.code === kindMeta.typeCode,
 	);
 	return {
 		...lib,
 		resourceType: "Library",
 		meta: hasProfile
 			? lib.meta
-			: { ...(lib.meta ?? {}), profile: [...profiles, SQL_QUERY_PROFILE] },
+			: { ...(lib.meta ?? {}), profile: [...profiles, kindMeta.profile] },
 		type: hasType
 			? lib.type
 			: {
-					coding: [
-						{ system: SQL_QUERY_TYPE_SYSTEM, code: SQL_QUERY_TYPE_CODE },
-					],
+					coding: [{ system: SQL_QUERY_TYPE_SYSTEM, code: kindMeta.typeCode }],
 				},
 		status: lib.status ?? "active",
 	};
@@ -84,7 +82,7 @@ export function buildRunPayload(
 	inheritedTypes: Map<string, string>,
 	paramValues: Record<string, string>,
 ): { resourceType: "Parameters"; parameter: Record<string, unknown>[] } {
-	const payload = ensureSQLQueryShape(library);
+	const payload = ensureSqlLibraryShape(library);
 	const valueEntries = buildAllParamEntries(
 		payload,
 		inheritedTypes,

--- a/src/components/SQLQueryBuilder/types.ts
+++ b/src/components/SQLQueryBuilder/types.ts
@@ -39,6 +39,58 @@ export const SQL_QUERY_TYPE_SYSTEM =
 	"https://sql-on-fhir.org/ig/CodeSystem/LibraryTypesCodes";
 export const SQL_QUERY_TYPE_CODE = "sql-query";
 
+export const SQL_VIEW_PROFILE =
+	"https://sql-on-fhir.org/ig/StructureDefinition/SQLView";
+export const SQL_VIEW_TYPE_CODE = "sql-view";
+
+export type SqlLibraryKind = "sql-query" | "sql-view";
+
+export type SqlLibraryKindMeta = {
+	kind: SqlLibraryKind;
+	profile: string;
+	typeCode: string;
+	label: string;
+	urlHistoryKey: string;
+	supportsParameters: boolean;
+};
+
+export const SQL_LIBRARY_KIND_META: Record<SqlLibraryKind, SqlLibraryKindMeta> =
+	{
+		"sql-query": {
+			kind: "sql-query",
+			profile: SQL_QUERY_PROFILE,
+			typeCode: SQL_QUERY_TYPE_CODE,
+			label: "SQLQuery",
+			urlHistoryKey: "sqlquery-library-url-history",
+			supportsParameters: true,
+		},
+		"sql-view": {
+			kind: "sql-view",
+			profile: SQL_VIEW_PROFILE,
+			typeCode: SQL_VIEW_TYPE_CODE,
+			label: "SQLView",
+			urlHistoryKey: "sqlview-library-url-history",
+			supportsParameters: false,
+		},
+	};
+
+export function sqlLibraryKind(lib: {
+	meta?: { profile?: string[] };
+	type?: { coding?: { system?: string; code?: string }[] };
+}): SqlLibraryKind {
+	if (lib.meta?.profile?.includes(SQL_VIEW_PROFILE)) return "sql-view";
+	if (lib.type?.coding?.some((c) => c.code === SQL_VIEW_TYPE_CODE)) {
+		return "sql-view";
+	}
+	return "sql-query";
+}
+
+export function sqlLibraryKindMeta(
+	lib: Parameters<typeof sqlLibraryKind>[0],
+): SqlLibraryKindMeta {
+	return SQL_LIBRARY_KIND_META[sqlLibraryKind(lib)];
+}
+
 // Types supported by Aidbox SQLQuery runner (sof/core.clj do-streaming-query):
 // string/date/dateTime → text (VARCHAR), integer → INTEGER, boolean → BOOLEAN, decimal → NUMERIC
 export const FHIR_PARAMETER_TYPES = [

--- a/src/components/ViewDefinition/lineage/resolve-graph.ts
+++ b/src/components/ViewDefinition/lineage/resolve-graph.ts
@@ -15,6 +15,7 @@ import {
 	SQL_QUERY_PROFILE,
 	SQL_QUERY_TYPE_CODE,
 	SQL_QUERY_TYPE_SYSTEM,
+	sqlLibraryKind,
 } from "../../SQLQueryBuilder/types";
 import type {
 	BackrefGraph,
@@ -236,6 +237,7 @@ function sqlQueryNodeData(
 ): SQLQueryNodeData {
 	return {
 		kind: "sql-query",
+		libraryKind: sqlLibraryKind(lib),
 		id: lib.id ?? "",
 		canonical: lib.url ?? "",
 		name: lib.name ?? "",

--- a/src/components/notebook-editor.tsx
+++ b/src/components/notebook-editor.tsx
@@ -29,7 +29,8 @@ export type CellType =
 	| "markdown"
 	| "rpc"
 	| "view-definition"
-	| "sql-query";
+	| "sql-query"
+	| "sql-view";
 
 export type EditableCell = {
 	id: string;
@@ -54,6 +55,7 @@ const CELL_TYPES: { value: CellType; label: string }[] = [
 	{ value: "markdown", label: "Markdown" },
 	{ value: "view-definition", label: "ViewDefinition" },
 	{ value: "sql-query", label: "SQLQuery" },
+	{ value: "sql-view", label: "SQLView" },
 ];
 
 const DEFAULT_CELL_VALUE: Record<CellType, string> = {
@@ -63,6 +65,7 @@ const DEFAULT_CELL_VALUE: Record<CellType, string> = {
 	markdown: "",
 	"view-definition": "",
 	"sql-query": "",
+	"sql-view": "",
 };
 
 function genCellId(): string {
@@ -173,6 +176,13 @@ function CellWrapper({
 		) : cell.type === "sql-query" ? (
 			<SqlQueryCellView
 				cell={cellLike}
+				onValueChange={handleValue}
+				onResultChange={handleResult}
+			/>
+		) : cell.type === "sql-view" ? (
+			<SqlQueryCellView
+				cell={cellLike}
+				kind="sql-view"
 				onValueChange={handleValue}
 				onResultChange={handleResult}
 			/>

--- a/src/components/notebook-resource-picker.tsx
+++ b/src/components/notebook-resource-picker.tsx
@@ -1,12 +1,13 @@
 import type { Bundle } from "@aidbox-ui/fhir-types/hl7-fhir-r5-core";
 import * as HSComp from "@health-samurai/react-components";
 import { useQuery } from "@tanstack/react-query";
-import { ChevronDown, FileCode2, Table } from "lucide-react";
+import { ChevronDown, FileCode2, Layers, Table } from "lucide-react";
 import * as React from "react";
 import { useAidboxClient } from "../AidboxClient";
 import {
 	SQL_QUERY_TYPE_CODE,
 	SQL_QUERY_TYPE_SYSTEM,
+	SQL_VIEW_TYPE_CODE,
 } from "./SQLQueryBuilder/types";
 
 // Notebook-specific copy of the SQLQueryBuilder ResourcePicker. Unlike the
@@ -14,7 +15,7 @@ import {
 // just run an existing one — so a `url` is not required: candidates are listed
 // regardless of `url`, and the cell references the resource by `Type/id`.
 
-type CandidateKind = "ViewDefinition" | "SQLQuery";
+type CandidateKind = "ViewDefinition" | "SQLQuery" | "SQLView";
 
 type RelatedArtifactRef = { url: string; label?: string };
 
@@ -58,7 +59,7 @@ function extractCreatedAt(r: RawCandidate): string | undefined {
 }
 
 function referenceFor(c: CandidateOption): string {
-	return `${c.kind === "SQLQuery" ? "Library" : "ViewDefinition"}/${c.id}`;
+	return `${c.kind === "ViewDefinition" ? "ViewDefinition" : "Library"}/${c.id}`;
 }
 
 function Badge({ text, accentClass }: { text: string; accentClass: string }) {
@@ -72,6 +73,7 @@ function Badge({ text, accentClass }: { text: string; accentClass: string }) {
 }
 
 const SQL_QUERY_TYPE_TOKEN = `${SQL_QUERY_TYPE_SYSTEM}|${SQL_QUERY_TYPE_CODE}`;
+const SQL_VIEW_TYPE_TOKEN = `${SQL_QUERY_TYPE_SYSTEM}|${SQL_VIEW_TYPE_CODE}`;
 
 function useDebouncedValue<T>(value: T, delay: number): T {
 	const [v, setV] = React.useState(value);
@@ -85,7 +87,7 @@ function useDebouncedValue<T>(value: T, delay: number): T {
 function useCandidates(
 	search: string,
 	enabled = true,
-	kinds: CandidateKind[] = ["ViewDefinition", "SQLQuery"],
+	kinds: CandidateKind[] = ["ViewDefinition", "SQLQuery", "SQLView"],
 ) {
 	const client = useAidboxClient();
 	const debouncedSearch = useDebouncedValue(search, 200);
@@ -100,7 +102,7 @@ function useCandidates(
 			];
 			if (debouncedSearch) baseParams.push(["_ilike", debouncedSearch]);
 			const want = (k: CandidateKind) => kinds.includes(k);
-			const [vd, lib] = await Promise.all([
+			const [vd, sqlQueryLib, sqlViewLib] = await Promise.all([
 				want("ViewDefinition")
 					? client.request<Bundle>({
 							method: "GET",
@@ -113,6 +115,13 @@ function useCandidates(
 							method: "GET",
 							url: "/fhir/Library",
 							params: [...baseParams, ["type", SQL_QUERY_TYPE_TOKEN]],
+						})
+					: null,
+				want("SQLView")
+					? client.request<Bundle>({
+							method: "GET",
+							url: "/fhir/Library",
+							params: [...baseParams, ["type", SQL_VIEW_TYPE_TOKEN]],
 						})
 					: null,
 			]);
@@ -132,15 +141,19 @@ function useCandidates(
 					});
 				}
 			}
-			if (lib?.isOk()) {
-				for (const entry of lib.value.resource.entry ?? []) {
+			for (const [res, kind] of [
+				[sqlQueryLib, "SQLQuery"],
+				[sqlViewLib, "SQLView"],
+			] as const) {
+				if (!res?.isOk()) continue;
+				for (const entry of res.value.resource.entry ?? []) {
 					const r = entry.resource as unknown as RawCandidate;
 					const relatedArtifacts = (r.relatedArtifact ?? []).flatMap((ra) =>
 						ra.resource ? [{ url: ra.resource, label: ra.label }] : [],
 					);
 					out.push({
 						url: r.url,
-						kind: "SQLQuery",
+						kind,
 						id: r.id,
 						name: r.name,
 						title: r.title,
@@ -231,11 +244,19 @@ export function NotebookResourcePicker({
 							{candidates.map((c) => {
 								const label = c.title || c.name || c.id;
 								const isView = c.kind === "ViewDefinition";
-								const Icon = isView ? Table : FileCode2;
-								const kindLabel = isView ? "View" : "Query";
-								const accentClass = isView
-									? "text-text-info-primary"
-									: "text-text-warning-primary";
+								const Icon =
+									c.kind === "ViewDefinition"
+										? Table
+										: c.kind === "SQLView"
+											? Layers
+											: FileCode2;
+								const kindLabel = c.kind;
+								const accentClass =
+									c.kind === "ViewDefinition"
+										? "text-text-info-primary"
+										: c.kind === "SQLView"
+											? "text-text-success-primary"
+											: "text-text-warning-primary";
 								const badges: React.ReactNode[] = [];
 								if (isView && c.resource) {
 									badges.push(

--- a/src/layout/navbar.tsx
+++ b/src/layout/navbar.tsx
@@ -131,6 +131,12 @@ function CurrentCrumb({
 	);
 }
 
+const NON_NAVIGABLE_CRUMB_PATHS = new Set([
+	"/analytics/queries",
+	"/analytics/views",
+	"/analytics/sqlview",
+]);
+
 function MiddleCrumb({ crumb }: { crumb: { title: string; path: string } }) {
 	const isNotebookView = /^\/notebooks\/[0-9a-f-]{36}\/?$/i.test(crumb.path);
 	const isUuid = /^[0-9a-f-]{36}$/i.test(crumb.title);
@@ -138,9 +144,13 @@ function MiddleCrumb({ crumb }: { crumb: { title: string; path: string } }) {
 		isNotebookView && isUuid ? crumb.title : null,
 		null,
 	);
+	const label = display ?? crumb.title;
+	if (NON_NAVIGABLE_CRUMB_PATHS.has(crumb.path)) {
+		return <span className="px-3 py-1 text-text-tertiary">{label}</span>;
+	}
 	return (
 		<BreadcrumbLink className="px-3" asChild>
-			<Link to={crumb.path}>{display ?? crumb.title}</Link>
+			<Link to={crumb.path}>{label}</Link>
 		</BreadcrumbLink>
 	);
 }

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -36,6 +36,7 @@ import { Route as DatabaseSchemaRouteImport } from './routes/database.schema'
 import { Route as DatabaseQueriesRouteImport } from './routes/database.queries'
 import { Route as AsyncOperationsOperationIdRouteImport } from './routes/async-operations.$operationId'
 import { Route as AnalyticsViewsRouteImport } from './routes/analytics.views'
+import { Route as AnalyticsSqlviewRouteImport } from './routes/analytics.sqlview'
 import { Route as AnalyticsQueriesRouteImport } from './routes/analytics.queries'
 import { Route as ResourceResourceTypeIndexRouteImport } from './routes/resource.$resourceType.index'
 import { Route as IgPackageIdIndexRouteImport } from './routes/ig.$packageId.index'
@@ -44,9 +45,11 @@ import { Route as AnalyticsQueriesIndexRouteImport } from './routes/analytics.qu
 import { Route as ResourceResourceTypeCreateRouteImport } from './routes/resource.$resourceType.create'
 import { Route as NotebooksIdEditRouteImport } from './routes/notebooks.$id_.edit'
 import { Route as AnalyticsViewsCreateRouteImport } from './routes/analytics.views.create'
+import { Route as AnalyticsSqlviewCreateRouteImport } from './routes/analytics.sqlview.create'
 import { Route as AnalyticsQueriesCreateRouteImport } from './routes/analytics.queries.create'
 import { Route as ResourceResourceTypeEditIdRouteImport } from './routes/resource.$resourceType.edit.$id'
 import { Route as AnalyticsViewsEditIdRouteImport } from './routes/analytics.views.edit.$id'
+import { Route as AnalyticsSqlviewEditIdRouteImport } from './routes/analytics.sqlview.edit.$id'
 import { Route as AnalyticsQueriesEditIdRouteImport } from './routes/analytics.queries.edit.$id'
 import { Route as IgPackageIdResourceResourceTypeResourceIdRouteImport } from './routes/ig.$packageId.resource.$resourceType.$resourceId'
 
@@ -186,6 +189,11 @@ const AnalyticsViewsRoute = AnalyticsViewsRouteImport.update({
   path: '/views',
   getParentRoute: () => AnalyticsRoute,
 } as any)
+const AnalyticsSqlviewRoute = AnalyticsSqlviewRouteImport.update({
+  id: '/sqlview',
+  path: '/sqlview',
+  getParentRoute: () => AnalyticsRoute,
+} as any)
 const AnalyticsQueriesRoute = AnalyticsQueriesRouteImport.update({
   id: '/queries',
   path: '/queries',
@@ -228,6 +236,11 @@ const AnalyticsViewsCreateRoute = AnalyticsViewsCreateRouteImport.update({
   path: '/create',
   getParentRoute: () => AnalyticsViewsRoute,
 } as any)
+const AnalyticsSqlviewCreateRoute = AnalyticsSqlviewCreateRouteImport.update({
+  id: '/create',
+  path: '/create',
+  getParentRoute: () => AnalyticsSqlviewRoute,
+} as any)
 const AnalyticsQueriesCreateRoute = AnalyticsQueriesCreateRouteImport.update({
   id: '/create',
   path: '/create',
@@ -243,6 +256,11 @@ const AnalyticsViewsEditIdRoute = AnalyticsViewsEditIdRouteImport.update({
   id: '/edit/$id',
   path: '/edit/$id',
   getParentRoute: () => AnalyticsViewsRoute,
+} as any)
+const AnalyticsSqlviewEditIdRoute = AnalyticsSqlviewEditIdRouteImport.update({
+  id: '/edit/$id',
+  path: '/edit/$id',
+  getParentRoute: () => AnalyticsSqlviewRoute,
 } as any)
 const AnalyticsQueriesEditIdRoute = AnalyticsQueriesEditIdRouteImport.update({
   id: '/edit/$id',
@@ -269,6 +287,7 @@ export interface FileRoutesByFullPath {
   '/rest': typeof RestRoute
   '/settings': typeof SettingsRoute
   '/analytics/queries': typeof AnalyticsQueriesRouteWithChildren
+  '/analytics/sqlview': typeof AnalyticsSqlviewRouteWithChildren
   '/analytics/views': typeof AnalyticsViewsRouteWithChildren
   '/async-operations/$operationId': typeof AsyncOperationsOperationIdRoute
   '/database/queries': typeof DatabaseQueriesRoute
@@ -286,6 +305,7 @@ export interface FileRoutesByFullPath {
   '/notebooks/': typeof NotebooksIndexRoute
   '/resource/': typeof ResourceIndexRoute
   '/analytics/queries/create': typeof AnalyticsQueriesCreateRoute
+  '/analytics/sqlview/create': typeof AnalyticsSqlviewCreateRoute
   '/analytics/views/create': typeof AnalyticsViewsCreateRoute
   '/notebooks/$id/edit': typeof NotebooksIdEditRoute
   '/resource/$resourceType/create': typeof ResourceResourceTypeCreateRoute
@@ -294,6 +314,7 @@ export interface FileRoutesByFullPath {
   '/ig/$packageId/': typeof IgPackageIdIndexRoute
   '/resource/$resourceType/': typeof ResourceResourceTypeIndexRoute
   '/analytics/queries/edit/$id': typeof AnalyticsQueriesEditIdRoute
+  '/analytics/sqlview/edit/$id': typeof AnalyticsSqlviewEditIdRoute
   '/analytics/views/edit/$id': typeof AnalyticsViewsEditIdRoute
   '/resource/$resourceType/edit/$id': typeof ResourceResourceTypeEditIdRoute
   '/ig/$packageId/resource/$resourceType/$resourceId': typeof IgPackageIdResourceResourceTypeResourceIdRoute
@@ -304,6 +325,7 @@ export interface FileRoutesByTo {
   '/db-console': typeof DbConsoleRoute
   '/rest': typeof RestRoute
   '/settings': typeof SettingsRoute
+  '/analytics/sqlview': typeof AnalyticsSqlviewRouteWithChildren
   '/async-operations/$operationId': typeof AsyncOperationsOperationIdRoute
   '/database/queries': typeof DatabaseQueriesRoute
   '/database/schema': typeof DatabaseSchemaRoute
@@ -318,6 +340,7 @@ export interface FileRoutesByTo {
   '/notebooks': typeof NotebooksIndexRoute
   '/resource': typeof ResourceIndexRoute
   '/analytics/queries/create': typeof AnalyticsQueriesCreateRoute
+  '/analytics/sqlview/create': typeof AnalyticsSqlviewCreateRoute
   '/analytics/views/create': typeof AnalyticsViewsCreateRoute
   '/notebooks/$id/edit': typeof NotebooksIdEditRoute
   '/resource/$resourceType/create': typeof ResourceResourceTypeCreateRoute
@@ -326,6 +349,7 @@ export interface FileRoutesByTo {
   '/ig/$packageId': typeof IgPackageIdIndexRoute
   '/resource/$resourceType': typeof ResourceResourceTypeIndexRoute
   '/analytics/queries/edit/$id': typeof AnalyticsQueriesEditIdRoute
+  '/analytics/sqlview/edit/$id': typeof AnalyticsSqlviewEditIdRoute
   '/analytics/views/edit/$id': typeof AnalyticsViewsEditIdRoute
   '/resource/$resourceType/edit/$id': typeof ResourceResourceTypeEditIdRoute
   '/ig/$packageId/resource/$resourceType/$resourceId': typeof IgPackageIdResourceResourceTypeResourceIdRoute
@@ -344,6 +368,7 @@ export interface FileRoutesById {
   '/rest': typeof RestRoute
   '/settings': typeof SettingsRoute
   '/analytics/queries': typeof AnalyticsQueriesRouteWithChildren
+  '/analytics/sqlview': typeof AnalyticsSqlviewRouteWithChildren
   '/analytics/views': typeof AnalyticsViewsRouteWithChildren
   '/async-operations/$operationId': typeof AsyncOperationsOperationIdRoute
   '/database/queries': typeof DatabaseQueriesRoute
@@ -361,6 +386,7 @@ export interface FileRoutesById {
   '/notebooks/': typeof NotebooksIndexRoute
   '/resource/': typeof ResourceIndexRoute
   '/analytics/queries/create': typeof AnalyticsQueriesCreateRoute
+  '/analytics/sqlview/create': typeof AnalyticsSqlviewCreateRoute
   '/analytics/views/create': typeof AnalyticsViewsCreateRoute
   '/notebooks/$id_/edit': typeof NotebooksIdEditRoute
   '/resource/$resourceType/create': typeof ResourceResourceTypeCreateRoute
@@ -369,6 +395,7 @@ export interface FileRoutesById {
   '/ig/$packageId/': typeof IgPackageIdIndexRoute
   '/resource/$resourceType/': typeof ResourceResourceTypeIndexRoute
   '/analytics/queries/edit/$id': typeof AnalyticsQueriesEditIdRoute
+  '/analytics/sqlview/edit/$id': typeof AnalyticsSqlviewEditIdRoute
   '/analytics/views/edit/$id': typeof AnalyticsViewsEditIdRoute
   '/resource/$resourceType/edit/$id': typeof ResourceResourceTypeEditIdRoute
   '/ig/$packageId/resource/$resourceType/$resourceId': typeof IgPackageIdResourceResourceTypeResourceIdRoute
@@ -388,6 +415,7 @@ export interface FileRouteTypes {
     | '/rest'
     | '/settings'
     | '/analytics/queries'
+    | '/analytics/sqlview'
     | '/analytics/views'
     | '/async-operations/$operationId'
     | '/database/queries'
@@ -405,6 +433,7 @@ export interface FileRouteTypes {
     | '/notebooks/'
     | '/resource/'
     | '/analytics/queries/create'
+    | '/analytics/sqlview/create'
     | '/analytics/views/create'
     | '/notebooks/$id/edit'
     | '/resource/$resourceType/create'
@@ -413,6 +442,7 @@ export interface FileRouteTypes {
     | '/ig/$packageId/'
     | '/resource/$resourceType/'
     | '/analytics/queries/edit/$id'
+    | '/analytics/sqlview/edit/$id'
     | '/analytics/views/edit/$id'
     | '/resource/$resourceType/edit/$id'
     | '/ig/$packageId/resource/$resourceType/$resourceId'
@@ -423,6 +453,7 @@ export interface FileRouteTypes {
     | '/db-console'
     | '/rest'
     | '/settings'
+    | '/analytics/sqlview'
     | '/async-operations/$operationId'
     | '/database/queries'
     | '/database/schema'
@@ -437,6 +468,7 @@ export interface FileRouteTypes {
     | '/notebooks'
     | '/resource'
     | '/analytics/queries/create'
+    | '/analytics/sqlview/create'
     | '/analytics/views/create'
     | '/notebooks/$id/edit'
     | '/resource/$resourceType/create'
@@ -445,6 +477,7 @@ export interface FileRouteTypes {
     | '/ig/$packageId'
     | '/resource/$resourceType'
     | '/analytics/queries/edit/$id'
+    | '/analytics/sqlview/edit/$id'
     | '/analytics/views/edit/$id'
     | '/resource/$resourceType/edit/$id'
     | '/ig/$packageId/resource/$resourceType/$resourceId'
@@ -462,6 +495,7 @@ export interface FileRouteTypes {
     | '/rest'
     | '/settings'
     | '/analytics/queries'
+    | '/analytics/sqlview'
     | '/analytics/views'
     | '/async-operations/$operationId'
     | '/database/queries'
@@ -479,6 +513,7 @@ export interface FileRouteTypes {
     | '/notebooks/'
     | '/resource/'
     | '/analytics/queries/create'
+    | '/analytics/sqlview/create'
     | '/analytics/views/create'
     | '/notebooks/$id_/edit'
     | '/resource/$resourceType/create'
@@ -487,6 +522,7 @@ export interface FileRouteTypes {
     | '/ig/$packageId/'
     | '/resource/$resourceType/'
     | '/analytics/queries/edit/$id'
+    | '/analytics/sqlview/edit/$id'
     | '/analytics/views/edit/$id'
     | '/resource/$resourceType/edit/$id'
     | '/ig/$packageId/resource/$resourceType/$resourceId'
@@ -697,6 +733,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AnalyticsViewsRouteImport
       parentRoute: typeof AnalyticsRoute
     }
+    '/analytics/sqlview': {
+      id: '/analytics/sqlview'
+      path: '/sqlview'
+      fullPath: '/analytics/sqlview'
+      preLoaderRoute: typeof AnalyticsSqlviewRouteImport
+      parentRoute: typeof AnalyticsRoute
+    }
     '/analytics/queries': {
       id: '/analytics/queries'
       path: '/queries'
@@ -753,6 +796,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AnalyticsViewsCreateRouteImport
       parentRoute: typeof AnalyticsViewsRoute
     }
+    '/analytics/sqlview/create': {
+      id: '/analytics/sqlview/create'
+      path: '/create'
+      fullPath: '/analytics/sqlview/create'
+      preLoaderRoute: typeof AnalyticsSqlviewCreateRouteImport
+      parentRoute: typeof AnalyticsSqlviewRoute
+    }
     '/analytics/queries/create': {
       id: '/analytics/queries/create'
       path: '/create'
@@ -773,6 +823,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/analytics/views/edit/$id'
       preLoaderRoute: typeof AnalyticsViewsEditIdRouteImport
       parentRoute: typeof AnalyticsViewsRoute
+    }
+    '/analytics/sqlview/edit/$id': {
+      id: '/analytics/sqlview/edit/$id'
+      path: '/edit/$id'
+      fullPath: '/analytics/sqlview/edit/$id'
+      preLoaderRoute: typeof AnalyticsSqlviewEditIdRouteImport
+      parentRoute: typeof AnalyticsSqlviewRoute
     }
     '/analytics/queries/edit/$id': {
       id: '/analytics/queries/edit/$id'
@@ -806,6 +863,19 @@ const AnalyticsQueriesRouteChildren: AnalyticsQueriesRouteChildren = {
 const AnalyticsQueriesRouteWithChildren =
   AnalyticsQueriesRoute._addFileChildren(AnalyticsQueriesRouteChildren)
 
+interface AnalyticsSqlviewRouteChildren {
+  AnalyticsSqlviewCreateRoute: typeof AnalyticsSqlviewCreateRoute
+  AnalyticsSqlviewEditIdRoute: typeof AnalyticsSqlviewEditIdRoute
+}
+
+const AnalyticsSqlviewRouteChildren: AnalyticsSqlviewRouteChildren = {
+  AnalyticsSqlviewCreateRoute: AnalyticsSqlviewCreateRoute,
+  AnalyticsSqlviewEditIdRoute: AnalyticsSqlviewEditIdRoute,
+}
+
+const AnalyticsSqlviewRouteWithChildren =
+  AnalyticsSqlviewRoute._addFileChildren(AnalyticsSqlviewRouteChildren)
+
 interface AnalyticsViewsRouteChildren {
   AnalyticsViewsCreateRoute: typeof AnalyticsViewsCreateRoute
   AnalyticsViewsIndexRoute: typeof AnalyticsViewsIndexRoute
@@ -824,12 +894,14 @@ const AnalyticsViewsRouteWithChildren = AnalyticsViewsRoute._addFileChildren(
 
 interface AnalyticsRouteChildren {
   AnalyticsQueriesRoute: typeof AnalyticsQueriesRouteWithChildren
+  AnalyticsSqlviewRoute: typeof AnalyticsSqlviewRouteWithChildren
   AnalyticsViewsRoute: typeof AnalyticsViewsRouteWithChildren
   AnalyticsIndexRoute: typeof AnalyticsIndexRoute
 }
 
 const AnalyticsRouteChildren: AnalyticsRouteChildren = {
   AnalyticsQueriesRoute: AnalyticsQueriesRouteWithChildren,
+  AnalyticsSqlviewRoute: AnalyticsSqlviewRouteWithChildren,
   AnalyticsViewsRoute: AnalyticsViewsRouteWithChildren,
   AnalyticsIndexRoute: AnalyticsIndexRoute,
 }

--- a/src/routes/analytics.index.tsx
+++ b/src/routes/analytics.index.tsx
@@ -8,6 +8,7 @@ import {
 	EllipsisVertical,
 	FileCode2,
 	GitBranch,
+	Layers,
 	Plus,
 	Search,
 	Table,
@@ -26,6 +27,43 @@ import { parseQuery, tagSlug } from "../utils/tag-search";
 
 const SQL_QUERY_TYPE_TOKEN =
 	"https://sql-on-fhir.org/ig/CodeSystem/LibraryTypesCodes|sql-query";
+const SQL_VIEW_TYPE_TOKEN =
+	"https://sql-on-fhir.org/ig/CodeSystem/LibraryTypesCodes|sql-view";
+
+type AnalyticsKind = "view" | "query" | "sql-view";
+
+const KIND_META: Record<
+	AnalyticsKind,
+	{ label: string; accentClass: string; Icon: typeof Table }
+> = {
+	view: {
+		label: "ViewDefinition",
+		accentClass: "text-text-info-primary",
+		Icon: Table,
+	},
+	query: {
+		label: "SQLQuery",
+		accentClass: "text-text-warning-primary",
+		Icon: FileCode2,
+	},
+	"sql-view": {
+		label: "SQLView",
+		accentClass: "text-text-success-primary",
+		Icon: Layers,
+	},
+};
+
+const RECENT_QUERY_KEY: Record<AnalyticsKind, string> = {
+	view: "analytics-recent-views",
+	query: "analytics-recent-queries",
+	"sql-view": "analytics-recent-sql-views",
+};
+
+function editRoutePath(kind: AnalyticsKind) {
+	if (kind === "view") return "/analytics/views/edit/$id" as const;
+	if (kind === "sql-view") return "/analytics/sqlview/edit/$id" as const;
+	return "/analytics/queries/edit/$id" as const;
+}
 
 type LibraryResource = {
 	resourceType: "Library";
@@ -48,7 +86,7 @@ type RelatedArtifactRef = {
 };
 
 type RecentItem = {
-	kind: "view" | "query";
+	kind: AnalyticsKind;
 	id: string;
 	url?: string;
 	resource?: string;
@@ -70,7 +108,6 @@ const QUERY_EDIT_SEARCH = {
 	mode: "json" as const,
 	builderTab: "form" as const,
 };
-
 function pickLabel(r: { id?: string; name?: string; title?: string }): string {
 	return r.title || r.name || r.id || "(unnamed)";
 }
@@ -152,6 +189,44 @@ function useRecentQueries() {
 	});
 }
 
+function useRecentSqlViews() {
+	const client = useAidboxClient();
+	return useQuery<RecentItem[]>({
+		queryKey: ["analytics-recent-sql-views"],
+		queryFn: async () => {
+			const r = await client.request<Bundle>({
+				method: "GET",
+				url: "/fhir/Library",
+				params: [
+					["_count", "1000"],
+					["_sort", "-_lastUpdated"],
+					["type", SQL_VIEW_TYPE_TOKEN],
+				],
+			});
+			if (r.isErr()) return [];
+			return (r.value.resource.entry ?? []).flatMap((e) => {
+				const lib = e.resource as LibraryResource | undefined;
+				if (!lib?.id) return [];
+				const relatedArtifacts = (lib.relatedArtifact ?? []).flatMap((ra) =>
+					ra.resource ? [{ url: ra.resource, label: ra.label }] : [],
+				);
+				return [
+					{
+						kind: "sql-view",
+						id: lib.id,
+						url: lib.url,
+						relatedArtifacts:
+							relatedArtifacts.length > 0 ? relatedArtifacts : undefined,
+						label: pickLabel(lib),
+						description: lib.description,
+						lastUpdated: lib.meta?.lastUpdated,
+					} satisfies RecentItem,
+				];
+			});
+		},
+	});
+}
+
 type LookupByUrl = (url: string) => RecentItem | undefined;
 
 function getItemTagSlugs(item: RecentItem, lookup: LookupByUrl): string[] {
@@ -183,9 +258,11 @@ function chipStyleFor(tag: string, items: RecentItem[]): string {
 	const slug = tagSlug(tag);
 	for (const item of items) {
 		if (tagSlug(item.label) === slug) {
-			return item.kind === "view"
-				? "bg-blue-50 text-text-info-primary"
-				: "bg-yellow-50 text-text-warning-primary";
+			if (item.kind === "view") return "bg-blue-50 text-text-info-primary";
+			if (item.kind === "sql-view") {
+				return "bg-green-50 text-text-success-primary";
+			}
+			return "bg-yellow-50 text-text-warning-primary";
 		}
 	}
 	for (const item of items) {
@@ -236,11 +313,7 @@ function ItemRow({
 	onTagClick?: (text: string) => void;
 }) {
 	const isView = item.kind === "view";
-	const Icon = isView ? Table : FileCode2;
-	const kindLabel = isView ? "View" : "Query";
-	const accentClass = isView
-		? "text-text-info-primary"
-		: "text-text-warning-primary";
+	const { Icon, label: kindLabel, accentClass } = KIND_META[item.kind];
 	const badges: React.ReactNode[] = [];
 	if (isView && item.resource) {
 		const resourceText = item.resource;
@@ -256,18 +329,17 @@ function ItemRow({
 	if (!isView && item.relatedArtifacts) {
 		for (const ra of item.relatedArtifacts) {
 			const linked = lookup(ra.url);
-			const isLinkedView =
-				linked?.kind === "view" || ra.url.includes("/ViewDefinition/");
 			const text = linked?.label ?? ra.label ?? ra.url;
+			const accent = linked
+				? KIND_META[linked.kind].accentClass
+				: ra.url.includes("/ViewDefinition/")
+					? KIND_META.view.accentClass
+					: KIND_META.query.accentClass;
 			badges.push(
 				<Badge
 					key={ra.url}
 					text={text}
-					accentClass={
-						isLinkedView
-							? "text-text-info-primary"
-							: "text-text-warning-primary"
-					}
+					accentClass={accent}
 					onClick={onTagClick ? () => onTagClick(text) : undefined}
 				/>,
 			);
@@ -300,7 +372,7 @@ function ItemRow({
 	);
 }
 
-export type AnalyticsListKind = "view" | "query";
+export type AnalyticsListKind = AnalyticsKind;
 
 const VIEW_CREATE_SEARCH = {
 	tab: "builder" as const,
@@ -312,6 +384,7 @@ const QUERY_CREATE_SEARCH = {
 	mode: "json" as const,
 	builderTab: "form" as const,
 };
+const SQLVIEW_CREATE_SEARCH = QUERY_CREATE_SEARCH;
 
 function SearchBar({
 	chips,
@@ -392,6 +465,7 @@ export function AnalyticsListPage({
 }) {
 	const views = useRecentViews();
 	const queries = useRecentQueries();
+	const sqlViews = useRecentSqlViews();
 	const client = useAidboxClient();
 	const queryClient = useQueryClient();
 	const navigate = useNavigate();
@@ -407,15 +481,9 @@ export function AnalyticsListPage({
 		},
 		onSuccess: (_data, item) => {
 			queryClient.invalidateQueries({
-				queryKey: [
-					item.kind === "view"
-						? "analytics-recent-views"
-						: "analytics-recent-queries",
-				],
+				queryKey: [RECENT_QUERY_KEY[item.kind]],
 			});
-			HSComp.toast.success(
-				`${item.kind === "view" ? "View" : "Query"} deleted`,
-			);
+			HSComp.toast.success(`${KIND_META[item.kind].label} deleted`);
 		},
 		onError: () => {
 			HSComp.toast.error("Failed to delete");
@@ -425,19 +493,11 @@ export function AnalyticsListPage({
 	const [confirmingDelete, setConfirmingDelete] =
 		React.useState<RecentItem | null>(null);
 	const openLineage = (item: RecentItem) => {
-		if (item.kind === "view") {
-			navigate({
-				to: "/analytics/views/edit/$id",
-				params: { id: item.id },
-				search: { tab: "lineage", mode: "json", builderTab: "form" },
-			});
-		} else {
-			navigate({
-				to: "/analytics/queries/edit/$id",
-				params: { id: item.id },
-				search: { tab: "lineage", mode: "json", builderTab: "form" },
-			});
-		}
+		navigate({
+			to: editRoutePath(item.kind),
+			params: { id: item.id },
+			search: { tab: "lineage", mode: "json", builderTab: "form" },
+		});
 	};
 	const didFocus = React.useRef(false);
 	const setSearchInputRef = React.useCallback((el: HTMLInputElement | null) => {
@@ -450,13 +510,16 @@ export function AnalyticsListPage({
 	const combined: RecentItem[] = [
 		...(views.data ?? []),
 		...(queries.data ?? []),
+		...(sqlViews.data ?? []),
 	];
 	const allItems: RecentItem[] = (
 		kind === "view"
 			? (views.data ?? [])
 			: kind === "query"
 				? (queries.data ?? [])
-				: combined
+				: kind === "sql-view"
+					? (sqlViews.data ?? [])
+					: combined
 	)
 		.slice()
 		.sort((a, b) => {
@@ -466,11 +529,15 @@ export function AnalyticsListPage({
 		});
 	const lookup: LookupByUrl = React.useMemo(() => {
 		const map = new Map<string, RecentItem>();
-		for (const it of [...(views.data ?? []), ...(queries.data ?? [])]) {
+		for (const it of [
+			...(views.data ?? []),
+			...(queries.data ?? []),
+			...(sqlViews.data ?? []),
+		]) {
 			if (it.url) map.set(it.url, it);
 		}
 		return (url: string) => map.get(url);
-	}, [views.data, queries.data]);
+	}, [views.data, queries.data, sqlViews.data]);
 	const tagTokens = tags.map(tagSlug);
 	const textQuery = text;
 
@@ -509,20 +576,19 @@ export function AnalyticsListPage({
 			})
 		: tagFiltered;
 
-	const noun =
-		kind === "view" ? "view" : kind === "query" ? "query" : "view or query";
+	const noun = kind ? KIND_META[kind].label : "view, query or SQL view";
 	const isEmpty = allItems.length === 0 && tags.length === 0 && !text;
 
-	const placeholder =
-		kind === "view"
-			? "Search views by name or description…"
-			: kind === "query"
-				? "Search queries by name or description…"
-				: "Search by name or description…";
+	const placeholder = "Search by name or description…";
 	const createView = () =>
 		navigate({ to: "/analytics/views/create", search: VIEW_CREATE_SEARCH });
 	const createQuery = () =>
 		navigate({ to: "/analytics/queries/create", search: QUERY_CREATE_SEARCH });
+	const createSqlView = () =>
+		navigate({
+			to: "/analytics/sqlview/create",
+			search: SQLVIEW_CREATE_SEARCH,
+		});
 	const handleTagClick = (tagText: string) => {
 		const slug = tagSlug(tagText);
 		if (tags.some((t) => tagSlug(t) === slug)) return;
@@ -581,19 +647,11 @@ export function AnalyticsListPage({
 	}, [text, items.length]);
 
 	const openItem = (it: RecentItem) => {
-		if (it.kind === "view") {
-			navigate({
-				to: "/analytics/views/edit/$id",
-				params: { id: it.id },
-				search: VIEW_EDIT_SEARCH,
-			});
-		} else {
-			navigate({
-				to: "/analytics/queries/edit/$id",
-				params: { id: it.id },
-				search: QUERY_EDIT_SEARCH,
-			});
-		}
+		navigate({
+			to: editRoutePath(it.kind),
+			params: { id: it.id },
+			search: it.kind === "view" ? VIEW_EDIT_SEARCH : QUERY_EDIT_SEARCH,
+		});
 	};
 
 	const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -651,14 +709,21 @@ export function AnalyticsListPage({
 									onSelect={createView}
 								>
 									<Table className="size-4 text-text-info-primary" />
-									View
+									ViewDefinition
 								</HSComp.DropdownMenuItem>
 								<HSComp.DropdownMenuItem
 									className="justify-start! text-text-warning-primary!"
 									onSelect={createQuery}
 								>
 									<FileCode2 className="size-4 text-text-warning-primary" />
-									Query
+									SQLQuery
+								</HSComp.DropdownMenuItem>
+								<HSComp.DropdownMenuItem
+									className="justify-start! text-text-success-primary!"
+									onSelect={createSqlView}
+								>
+									<Layers className="size-4 text-text-success-primary" />
+									SQLView
 								</HSComp.DropdownMenuItem>
 							</HSComp.DropdownMenuContent>
 						</HSComp.DropdownMenu>
@@ -695,14 +760,21 @@ export function AnalyticsListPage({
 											onSelect={createView}
 										>
 											<Table className="size-4 text-text-info-primary" />
-											View
+											ViewDefinition
 										</HSComp.DropdownMenuItem>
 										<HSComp.DropdownMenuItem
 											className="justify-start! text-text-warning-primary!"
 											onSelect={createQuery}
 										>
 											<FileCode2 className="size-4 text-text-warning-primary" />
-											Query
+											SQLQuery
+										</HSComp.DropdownMenuItem>
+										<HSComp.DropdownMenuItem
+											className="justify-start! text-text-success-primary!"
+											onSelect={createSqlView}
+										>
+											<Layers className="size-4 text-text-success-primary" />
+											SQLView
 										</HSComp.DropdownMenuItem>
 									</HSComp.DropdownMenuContent>
 								</HSComp.DropdownMenu>
@@ -726,35 +798,21 @@ export function AnalyticsListPage({
 									ref={focused ? focusedRowRef : undefined}
 									className={`relative group/row transition-colors hover:bg-bg-secondary first:rounded-t-lg last:rounded-b-lg ${focused ? "bg-bg-secondary" : ""}`}
 								>
-									{it.kind === "view" ? (
-										<Link
-											to="/analytics/views/edit/$id"
-											params={{ id: it.id }}
-											search={VIEW_EDIT_SEARCH}
-											className="block"
-										>
-											<ItemRow
-												item={it}
-												lookup={lookup}
-												showKindLabel={!kind}
-												onTagClick={handleTagClick}
-											/>
-										</Link>
-									) : (
-										<Link
-											to="/analytics/queries/edit/$id"
-											params={{ id: it.id }}
-											search={QUERY_EDIT_SEARCH}
-											className="block"
-										>
-											<ItemRow
-												item={it}
-												lookup={lookup}
-												showKindLabel={!kind}
-												onTagClick={handleTagClick}
-											/>
-										</Link>
-									)}
+									<Link
+										to={editRoutePath(it.kind)}
+										params={{ id: it.id }}
+										search={
+											it.kind === "view" ? VIEW_EDIT_SEARCH : QUERY_EDIT_SEARCH
+										}
+										className="block"
+									>
+										<ItemRow
+											item={it}
+											lookup={lookup}
+											showKindLabel={!kind}
+											onTagClick={handleTagClick}
+										/>
+									</Link>
 									<div
 										className={`${isMenuOpen ? "block" : "hidden group-hover/row:block focus-within:block"} absolute top-2 right-2`}
 									>
@@ -805,7 +863,8 @@ export function AnalyticsListPage({
 				<HSComp.AlertDialogContent>
 					<HSComp.AlertDialogHeader>
 						<HSComp.AlertDialogTitle>
-							Delete {confirmingDelete?.kind === "view" ? "view" : "query"}
+							Delete{" "}
+							{confirmingDelete ? KIND_META[confirmingDelete.kind].label : ""}
 						</HSComp.AlertDialogTitle>
 					</HSComp.AlertDialogHeader>
 					<HSComp.AlertDialogDescription>

--- a/src/routes/analytics.queries.create.tsx
+++ b/src/routes/analytics.queries.create.tsx
@@ -34,17 +34,7 @@ const PageComponent = () => {
 			tab={tab}
 			mode={mode}
 			navigate={navigate}
-			onCreated={(id) =>
-				navigate({
-					to: "/analytics/queries/edit/$id",
-					params: { id },
-					search: {
-						tab: "sqlquery" as const,
-						mode: "json" as const,
-						builderTab: "form" as const,
-					},
-				})
-			}
+			onCreated={() => navigate({ to: "/analytics" })}
 		/>
 	);
 };

--- a/src/routes/analytics.queries.index.tsx
+++ b/src/routes/analytics.queries.index.tsx
@@ -1,34 +1,7 @@
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { AnalyticsListPage, validateAnalyticsSearch } from "./analytics.index";
-
-function QueriesRoute() {
-	const search = Route.useSearch();
-	const text = search.q ?? "";
-	const tags = search.tags ?? [];
-	const navigate = useNavigate({ from: "/analytics/queries/" });
-	const setText = (next: string) =>
-		navigate({
-			search: (prev) => ({ ...prev, q: next || undefined }),
-			replace: true,
-		});
-	const setTags = (next: string[]) =>
-		navigate({
-			search: (prev) => ({ ...prev, tags: next.length > 0 ? next : undefined }),
-			replace: true,
-		});
-	return (
-		<AnalyticsListPage
-			kind="query"
-			text={text}
-			tags={tags}
-			setText={setText}
-			setTags={setTags}
-		/>
-	);
-}
+import { createFileRoute, redirect } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/analytics/queries/")({
-	staticData: { title: "Queries" },
-	component: QueriesRoute,
-	validateSearch: validateAnalyticsSearch,
+	beforeLoad: () => {
+		throw redirect({ to: "/analytics" });
+	},
 });

--- a/src/routes/analytics.sqlview.create.tsx
+++ b/src/routes/analytics.sqlview.create.tsx
@@ -8,20 +8,29 @@ import {
 import { validateSearch } from "./resource.$resourceType.create";
 
 const initialResource: Resource = {
-	resource: "Patient",
-	resourceType: "ViewDefinition",
-	status: "draft",
-	select: [],
+	resourceType: "Library",
+	meta: {
+		profile: ["https://sql-on-fhir.org/ig/StructureDefinition/SQLView"],
+	},
+	status: "active",
+	type: {
+		coding: [
+			{
+				system: "https://sql-on-fhir.org/ig/CodeSystem/LibraryTypesCodes",
+				code: "sql-view",
+			},
+		],
+	},
 } as Resource;
 
 const PageComponent = () => {
 	const navigate = useNavigate();
-	const { tab, mode } = useSearch({ from: "/analytics/views/create" });
+	const { tab, mode } = useSearch({ from: "/analytics/sqlview/create" });
 
 	return (
 		<ResourceEditorPage
 			initialResource={initialResource}
-			resourceType="ViewDefinition"
+			resourceType="Library"
 			tab={tab}
 			mode={mode}
 			navigate={navigate}
@@ -30,9 +39,9 @@ const PageComponent = () => {
 	);
 };
 
-export const Route = createFileRoute("/analytics/views/create")({
+export const Route = createFileRoute("/analytics/sqlview/create")({
 	component: PageComponent,
 	validateSearch,
-	staticData: { title: "Create View" },
+	staticData: { title: "Create SQLView" },
 	loader: () => ({ breadCrumb: "Create" }),
 });

--- a/src/routes/analytics.sqlview.edit.$id.tsx
+++ b/src/routes/analytics.sqlview.edit.$id.tsx
@@ -1,0 +1,35 @@
+import { ResourceEditorPageWithLoader } from "@aidbox-ui/components/ResourceEditor/page";
+import {
+	createFileRoute,
+	useNavigate,
+	useSearch,
+} from "@tanstack/react-router";
+import { validateSearch } from "./resource.$resourceType.create";
+
+const PageComponent = () => {
+	const { id } = Route.useParams();
+	const navigate = useNavigate({ from: "/analytics/sqlview/edit/$id" });
+	const { tab, mode } = useSearch({
+		from: "/analytics/sqlview/edit/$id",
+	});
+	return (
+		<ResourceEditorPageWithLoader
+			id={id}
+			resourceType="Library"
+			tab={tab}
+			mode={mode}
+			navigate={navigate}
+			onDeleted={() =>
+				navigate({
+					to: "/analytics",
+				})
+			}
+		/>
+	);
+};
+
+export const Route = createFileRoute("/analytics/sqlview/edit/$id")({
+	component: PageComponent,
+	validateSearch,
+	loader: (cx) => ({ breadCrumb: cx.params.id }),
+});

--- a/src/routes/analytics.sqlview.tsx
+++ b/src/routes/analytics.sqlview.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute, Outlet } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/analytics/sqlview")({
+	staticData: { title: "SQLView" },
+	loader: () => ({ breadCrumb: "SQLView" }),
+	component: () => <Outlet />,
+});

--- a/src/routes/analytics.views.index.tsx
+++ b/src/routes/analytics.views.index.tsx
@@ -1,34 +1,7 @@
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { AnalyticsListPage, validateAnalyticsSearch } from "./analytics.index";
-
-function ViewsRoute() {
-	const search = Route.useSearch();
-	const text = search.q ?? "";
-	const tags = search.tags ?? [];
-	const navigate = useNavigate({ from: "/analytics/views/" });
-	const setText = (next: string) =>
-		navigate({
-			search: (prev) => ({ ...prev, q: next || undefined }),
-			replace: true,
-		});
-	const setTags = (next: string[]) =>
-		navigate({
-			search: (prev) => ({ ...prev, tags: next.length > 0 ? next : undefined }),
-			replace: true,
-		});
-	return (
-		<AnalyticsListPage
-			kind="view"
-			text={text}
-			tags={tags}
-			setText={setText}
-			setTags={setTags}
-		/>
-	);
-}
+import { createFileRoute, redirect } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/analytics/views/")({
-	staticData: { title: "Views" },
-	component: ViewsRoute,
-	validateSearch: validateAnalyticsSearch,
+	beforeLoad: () => {
+		throw redirect({ to: "/analytics" });
+	},
 });

--- a/src/routes/notebooks.$id.tsx
+++ b/src/routes/notebooks.$id.tsx
@@ -11,6 +11,7 @@ import {
 	FileDown,
 	Globe,
 	GlobeOff,
+	Layers,
 	Link2,
 	Loader2,
 	Pencil,
@@ -346,7 +347,10 @@ export function RestCellView({
 					...(body ? { body } : {}),
 				});
 			} catch (e) {
-				if (e && typeof e === "object" && "response" in e) {
+				if (e && typeof e === "object" && "responseWithMeta" in e) {
+					respObj = (e as { responseWithMeta: { response: Response } })
+						.responseWithMeta;
+				} else if (e && typeof e === "object" && "response" in e) {
 					respObj = e as { response: Response };
 				} else {
 					const next: CellResponse = {
@@ -1098,12 +1102,15 @@ export function SqlQueryCellView({
 	onValueChange,
 	onResultChange,
 	readOnly,
+	kind = "sql-query",
 }: {
 	cell: Cell;
 	onValueChange?: (value: string) => void;
 	onResultChange?: (result: unknown) => void;
 	readOnly?: boolean;
+	kind?: "sql-query" | "sql-view";
 }) {
+	const isView = kind === "sql-view";
 	const client = useAidboxClient();
 	const isReadOnly = readOnly ?? !onValueChange;
 	const editable = !isReadOnly;
@@ -1177,8 +1184,12 @@ export function SqlQueryCellView({
 			<div className="flex items-center justify-between bg-bg-secondary pl-3 pr-4 border-b border-border-default h-10 gap-3">
 				<div className="flex items-center gap-3 min-w-0">
 					<span className="text-sm font-medium text-text-secondary w-[140px] shrink-0 flex items-center gap-1.5">
-						<FileCode className="size-4" />
-						SQLQuery
+						{isView ? (
+							<Layers className="size-4" />
+						) : (
+							<FileCode className="size-4" />
+						)}
+						{isView ? "SQLView" : "SQLQuery"}
 					</span>
 					{editable && (
 						<NotebookResourcePicker
@@ -1187,8 +1198,10 @@ export function SqlQueryCellView({
 								setParamValues({});
 								onValueChange?.(v);
 							}}
-							kinds={["SQLQuery"]}
-							placeholder={url ? "Change…" : "Select query…"}
+							kinds={[isView ? "SQLView" : "SQLQuery"]}
+							placeholder={
+								url ? "Change…" : isView ? "Select view…" : "Select query…"
+							}
 							className={url ? "max-w-[200px]" : "max-w-[500px]"}
 						/>
 					)}
@@ -1344,6 +1357,9 @@ export function CellView({ cell }: { cell: Cell }) {
 	}
 	if (type === "sql-query") {
 		return <SqlQueryCellView cell={cell} readOnly />;
+	}
+	if (type === "sql-view") {
+		return <SqlQueryCellView cell={cell} kind="sql-view" readOnly />;
 	}
 	if (type === "markdown") {
 		return (


### PR DESCRIPTION
## What

SQLView support across the Analytics UI and notebooks, plus two related fixes.

### SQLView (Analytics)
- New **create/edit pages** for SQLView that reuse the SQLQuery builder, parametrised by Library kind (`sql-query` | `sql-view`): fixed `type`/profile, parameters section hidden for views, per-kind url-history datalist.
- Unified `/analytics` list shows **ViewDefinition / SQLQuery / SQLView** with a per-type Create menu. Standalone `/analytics/queries` and `/analytics/views` list routes now **redirect** to `/analytics`; after-create navigates to the shared list.
- **ResourcePicker** resolves SQLView as a dependency: SQLQuery → `ViewDefinition + SQLQuery + SQLView`, SQLView → `ViewDefinition + SQLView`.
- **Lineage**: distinct SQLView node (label/icon/colour); parameters hidden for views.
- **Breadcrumb**: removed list segments render as non-navigable text.

### Notebooks
- New `sql-view` cell type (reuses the SQLQuery cell, picks only SQLView resources).
- **REST cell** now surfaces the response **body** on error (handles `ErrorResponse.responseWithMeta`) instead of only the status line.

### Submodule (aidbox-ts-sdk → development @9701460)
- Explicit `Authorization` header now takes precedence over the session cookie (`credentials: "omit"`, no 401→login redirect) — manual auth in a REST cell is no longer overridden by the admin cookie.

## Dependencies (separate, not in this PR)
- Backend `SQLView` StructureDefinition + `LibraryTypesCodes#sql-view` (sansara `dev-resources/aidbox-ig`).
- Notebook `code-cell.type` zen enum `sql-view` (sansara + portal `zrc/aidbox/notebooks.edn`).

The UI does not break without them, but SQLView profile validation is complete only once the backend ships these.

## Checks
- `pnpm typecheck` — clean.
- `pnpm lint:check` — clean (2 pre-existing a11y warnings, unrelated to this change).

## Testing
- Analytics → Create → **SQLView** → build/save → lands on `/analytics`.
- SQLQuery referencing an SQLView → **Lineage** shows SQLQuery → SQLView → ViewDefinition.
- Notebook → add **SQLView** cell → pick a view → Run.
- REST cell with a failing request → response shows the `OperationOutcome` body.

## Screenshots
_TODO — add UI screenshots (Analytics list, SQLView builder, lineage)._
