### PR TITLE
DB Console: random call-to-action placeholder

### DIFF
--- a/src/components/db-console/active-tabs.tsx
+++ b/src/components/db-console/active-tabs.tsx
@@ -33,7 +33,7 @@ export interface SqlTab {
 	settings?: Partial<SqlTabSettings>;
 }
 
-const DEFAULT_QUERY = "select * from patient";
+const DEFAULT_QUERY = "";
 
 export const DEFAULT_SQL_TAB_ID: SqlTabId = "sql-tab-default";
 

--- a/src/routes/db-console.tsx
+++ b/src/routes/db-console.tsx
@@ -71,6 +71,18 @@ import { useWebMCPSql } from "../webmcp/sql";
 
 const TITLE = "SQL console";
 
+const SQL_PLACEHOLDER_CTAS = [
+	"Query now, panic later",
+	"Your masterpiece starts here",
+	"Every great report starts with a SELECT",
+	"Great answers begin with good queries",
+	"Big decisions start with small queries",
+	"Your query could be here",
+	"Query twice, run on prod once",
+	"Before TRUNCATE, make sure this isn't prod",
+	"Ctrl+Z works on code, not on prod",
+];
+
 /**
  * Shift-Tab handler that de-indents only when the cursor is in the leading
  * whitespace of the current line (or the line is empty / whitespace-only).
@@ -323,6 +335,20 @@ function DbConsolePage() {
 		() => new Map(),
 	);
 	const selectedTabId = selectedTab?.id;
+	const placeholderCacheRef = useRef<Map<string, string>>(new Map());
+	const sqlPlaceholder = useMemo(() => {
+		const key = selectedTabId ?? "";
+		const cache = placeholderCacheRef.current;
+		const cached = cache.get(key);
+		if (cached) return cached;
+		const cta =
+			SQL_PLACEHOLDER_CTAS[
+				Math.floor(Math.random() * SQL_PLACEHOLDER_CTAS.length)
+			];
+		const value = `-- ${cta}\nselect * from patient`;
+		cache.set(key, value);
+		return value;
+	}, [selectedTabId]);
 	const isLoading = !!(selectedTabId && runningTabs.has(selectedTabId));
 	const [showStop, setShowStop] = useState(false);
 	useEffect(() => {
@@ -1060,6 +1086,7 @@ function DbConsolePage() {
 										<CodeEditor
 											key={selectedTab?.id}
 											mode="sql"
+											placeholder={sqlPlaceholder}
 											defaultValue={query}
 											onChange={handleQueryChange}
 											additionalExtensions={sqlEditorExtensions}


### PR DESCRIPTION
## What

- SQL Console default tab query is now **empty** (was `select * from patient`).
- On the empty editor state it shows a placeholder: a random call-to-action comment above `select * from patient`, e.g.

  ```
  -- Query twice, run on prod once
  select * from patient
  ```

  The phrase is picked at random per tab and cached (`placeholderCacheRef`), so each tab keeps its own; a new tab / re-entering the console re-rolls it.

## CodeEditor `placeholder` prop

Adds an optional `placeholder?: string` prop to `CodeEditor`, wired through a CodeMirror `placeholder` extension inside a `Compartment` — consistent with the other reactive props (theme, readOnly, vim, additional extensions).

Depends on submodule **aidbox-ts-sdk** commit `2c61a84` on `development` (already pushed): *"code-editor: add placeholder prop"*. This PR bumps the submodule pointer to it.

## Notes

- Placeholder is visible **only when the editor is empty** (CodeMirror behavior).
- Tabs already persisted in `localStorage` keep their stored query; the empty default applies to fresh tabs.