### PR TITLE
Resource Browser: measure page size before first fetch to fix table flicker

### DIFF
--- a/src/components/ResourceBrowser/page.tsx
+++ b/src/components/ResourceBrowser/page.tsx
@@ -299,8 +299,9 @@ const ResourcesTabContent = ({
 
 	const currentPage = parseSearchParam(decodedSearchQuery, "_page", 1);
 	const explicitPageSize = parseOptionalIntParam(decodedSearchQuery, "_count");
-	const [autoPageSize, setAutoPageSize] = React.useState(30);
-	const pageSize = explicitPageSize ?? autoPageSize;
+	const [autoPageSize, setAutoPageSize] = React.useState<number | null>(null);
+	const pageSizeReady = explicitPageSize !== null || autoPageSize !== null;
+	const pageSize = explicitPageSize ?? autoPageSize ?? 30;
 	const scrollAreaRef = React.useRef<HTMLDivElement>(null);
 
 	const sort = parseSortParam(decodedSearchQuery);
@@ -355,6 +356,7 @@ const ResourcesTabContent = ({
 			resourceType,
 			effectiveSearchQuery,
 		],
+		enabled: pageSizeReady,
 		queryFn: async () => {
 			const result = await client.searchType({
 				type: resourcesPageContext.resourceType,
@@ -386,14 +388,11 @@ const ResourcesTabContent = ({
 		const el = scrollAreaRef.current;
 		if (!el) return;
 		const compute = () => {
-			const firstRow = el.querySelector<HTMLElement>("tbody tr");
-			const header = el.querySelector<HTMLElement>("thead");
-			const rowH = firstRow?.getBoundingClientRect().height || ROW_HEIGHT_PX;
-			const headerH =
-				header?.getBoundingClientRect().height || HEADER_HEIGHT_PX;
-			if (rowH <= 0) return;
-			const usable = el.clientHeight - headerH;
-			const fit = Math.max(MIN_FIT_PAGE_SIZE, Math.floor(usable / rowH));
+			const usable = el.clientHeight - HEADER_HEIGHT_PX;
+			const fit = Math.max(
+				MIN_FIT_PAGE_SIZE,
+				Math.floor(usable / ROW_HEIGHT_PX),
+			);
 			setAutoPageSize((prev) => (prev === fit ? prev : fit));
 		};
 		compute();


### PR DESCRIPTION
## Проблема

При первом открытии resource type таблица инстансов мигала: данные отображались → пропадали → снова отображались.

## Причина

`autoPageSize` стартовал с `30`, поэтому первый запрос уходил с `_count=30`. Затем `useLayoutEffect` мерил высоту **отрисованных** строк и пересчитывал `fit`, меняя `_count` (и `queryKey`) → второй запрос проходил через `loading`-состояние, которое прятало таблицу.

```
было:  _count=30 → запрос #1 (данные) → меряем строки → fit=N → _count=N → запрос #2 (loading прячет таблицу) → мигание
```

## Фикс

Высота строки фиксирована CSS (`h-7` = 28px, заголовок `h-8` = 32px == `ROW_HEIGHT_PX`/`HEADER_HEIGHT_PX`), поэтому `fit` считается из `clientHeight` контейнера **до** данных. Запрос списка теперь стартует только после замера:

- `autoPageSize` начинается с `null` + флаг `pageSizeReady`;
- `enabled: pageSizeReady` на запросе инстансов — запроса с дефолтным `_count=30` больше нет;
- `compute` считает по константам высоты, а не по `firstRow`/`thead`.

```
стало: измеряем контейнер → fit=N → один запрос _count=N → loading → данные
```

`useLayoutEffect` синхронный (до paint), так что лишний tick не виден. `ResizeObserver` сохранён (адаптив при ресайзе); ручной `?_count=N` в URL не меняется.

## Проверка

- `pnpm typecheck` — чисто.