### PR TITLE
Code editors: move format controls to toolbars, fix Tab indent

### DIFF
--- a/src/components/AccessPolicy/dev-tool-request-panel.tsx
+++ b/src/components/AccessPolicy/dev-tool-request-panel.tsx
@@ -1,3 +1,4 @@
+import type { EditorView } from "@codemirror/view";
 import type * as AidboxTypes from "@health-samurai/aidbox-client";
 import * as HSComp from "@health-samurai/react-components";
 import * as yaml from "js-yaml";
@@ -17,7 +18,10 @@ import { type Header, methodColors } from "../rest/active-tabs";
 import HeadersEditor from "../rest/headers-editor";
 import ParamsEditor from "../rest/params-editor";
 import { UrlAutocomplete } from "../rest/url-autocomplete";
-import { CodeEditorMenubar } from "../ViewDefinition/code-editor-menubar";
+import {
+	CodeEditorFormatButton,
+	CodeEditorFormatSelect,
+} from "../ViewDefinition/code-editor-menubar";
 import { AccessPolicyContext } from "./page";
 
 // ── Types ──────────────────────────────────────────────────────────────
@@ -87,6 +91,63 @@ function createTab(): RequestTab {
 		response: null,
 		activeResponseTab: "policy-eval",
 	};
+}
+
+// ── Body format helpers ────────────────────────────────────────────────
+
+function splitRaw(raw: string): { head: string; body: string } {
+	const idx = raw.indexOf("\n\n");
+	if (idx === -1) return { head: raw, body: "" };
+	return { head: raw.slice(0, idx), body: raw.slice(idx + 2) };
+}
+
+function convertBody(
+	body: string,
+	fromMode: "json" | "yaml",
+	toMode: "json" | "yaml",
+): string {
+	if (!body.trim() || fromMode === toMode) return body;
+	try {
+		const parsed = fromMode === "yaml" ? yaml.load(body) : JSON.parse(body);
+		return toMode === "yaml"
+			? yaml.dump(parsed, { indent: 2 })
+			: JSON.stringify(parsed, null, 2);
+	} catch {
+		return body;
+	}
+}
+
+function formatBody(body: string, mode: "json" | "yaml"): string {
+	if (!body.trim()) return body;
+	try {
+		if (mode === "yaml") {
+			return yaml.dump(yaml.load(body), { indent: 2 });
+		}
+		return JSON.stringify(JSON.parse(body), null, 2);
+	} catch {
+		return body;
+	}
+}
+
+function updateHeadersForMode(head: string, mode: "json" | "yaml"): string {
+	const ct = mode === "yaml" ? "text/yaml" : "application/json";
+	const lines = head.split("\n");
+	let foundCt = false;
+	let foundAccept = false;
+	const updated = lines.map((line) => {
+		if (/^content-type\s*:/i.test(line)) {
+			foundCt = true;
+			return `Content-Type: ${ct}`;
+		}
+		if (/^accept\s*:/i.test(line)) {
+			foundAccept = true;
+			return `Accept: ${ct}`;
+		}
+		return line;
+	});
+	if (!foundCt) updated.push(`Content-Type: ${ct}`);
+	if (!foundAccept) updated.push(`Accept: ${ct}`);
+	return updated.join("\n");
 }
 
 // ── Debug helpers ──────────────────────────────────────────────────────
@@ -244,86 +305,23 @@ function updateHeaderValue(
 }
 
 function RequestBodyEditor({
-	tab,
-	onBodyChange,
-	onHeadersUpdate,
+	tabId,
+	mode,
+	value,
+	onChange,
 }: {
-	tab: RequestTab;
-	onBodyChange: (body: string) => void;
-	onHeadersUpdate: (headers: Header[]) => void;
+	tabId: string;
+	mode: "json" | "yaml";
+	value: string;
+	onChange: (value: string) => void;
 }) {
-	const [bodyMode, setBodyMode] = useLocalStorage<"json" | "yaml">({
-		key: "access-policy-devtool-body-mode",
-		getInitialValueInEffect: false,
-		defaultValue: "json",
-	});
-
-	const [bodyValue, setBodyValue] = React.useState(tab.body);
-
-	React.useEffect(() => {
-		setBodyValue(tab.body);
-	}, [tab.body]);
-
-	const handleChange = (value: string) => {
-		setBodyValue(value);
-		onBodyChange(value);
-	};
-
-	const handleModeChange = (newMode: "json" | "yaml") => {
-		try {
-			const parsed =
-				bodyMode === "json" ? JSON.parse(bodyValue) : yaml.load(bodyValue);
-			const converted =
-				newMode === "yaml"
-					? yaml.dump(parsed, { indent: 2 })
-					: JSON.stringify(parsed, null, 2);
-			setBodyValue(converted);
-			onBodyChange(converted);
-		} catch {
-			// If parsing fails, just switch mode without converting
-		}
-		setBodyMode(newMode);
-
-		const contentType = newMode === "yaml" ? "text/yaml" : "application/json";
-		let headers = updateHeaderValue(tab.headers, "Content-Type", contentType);
-		headers = updateHeaderValue(headers, "Accept", contentType);
-		onHeadersUpdate(headers);
-	};
-
-	const handleFormat = () => {
-		try {
-			const current = bodyValue.trim();
-			if (!current) return;
-			let formatted: string;
-			if (bodyMode === "yaml") {
-				formatted = yaml.dump(yaml.load(current), { indent: 2 });
-			} else {
-				formatted = JSON.stringify(JSON.parse(current), null, 2);
-			}
-			setBodyValue(formatted);
-			onBodyChange(formatted);
-		} catch {
-			// ignore
-		}
-	};
-
 	return (
-		<div className="relative h-full">
-			<div className="sticky min-h-0 h-0 flex justify-end pt-2 pr-3 top-0 right-0 z-10">
-				<CodeEditorMenubar
-					mode={bodyMode}
-					onModeChange={handleModeChange}
-					textToCopy={bodyValue}
-					onFormat={handleFormat}
-				/>
-			</div>
-			<HSComp.CodeEditor
-				key={`body-${tab.id}`}
-				currentValue={bodyValue}
-				mode={bodyMode}
-				onChange={handleChange}
-			/>
-		</div>
+		<HSComp.CodeEditor
+			key={`body-${tabId}`}
+			currentValue={value}
+			mode={mode}
+			onChange={onChange}
+		/>
 	);
 }
 
@@ -333,10 +331,12 @@ function RawEditor({
 	selectedTab,
 	onRawChange,
 	requestLineVersion,
+	viewCallback,
 }: {
 	selectedTab: RequestTab;
 	onRawChange: (rawText: string) => void;
 	requestLineVersion: string;
+	viewCallback: (view: EditorView) => void;
 }) {
 	const requestLine = `${selectedTab.method} ${selectedTab.path || "/"}`;
 	const headersText =
@@ -352,6 +352,7 @@ function RawEditor({
 			defaultValue={defaultValue}
 			mode="http"
 			onChange={onRawChange}
+			viewCallback={viewCallback}
 		/>
 	);
 }
@@ -493,8 +494,6 @@ function PolicyEvalView({
 // ── Response views for other tabs ──────────────────────────────────────
 
 function RequestContextView({ response }: { response: ResponseData | null }) {
-	const [mode, setMode] = React.useState<"json" | "yaml">("yaml");
-
 	if (!response) {
 		return (
 			<NoResponsePlaceholder>
@@ -504,35 +503,16 @@ function RequestContextView({ response }: { response: ResponseData | null }) {
 	}
 
 	const request = response.debugData?.request;
-	const content = request
-		? mode === "yaml"
-			? yaml.dump(request, { indent: 2 })
-			: JSON.stringify(request, null, 2)
-		: response.body;
+	const content = request ? yaml.dump(request, { indent: 2 }) : response.body;
 
 	return (
 		<div className="relative size-full">
 			<HSComp.CodeEditor
 				readOnly
-				key={`request-context-${response.status}-${mode}`}
+				key={`request-context-${response.status}`}
 				currentValue={content}
-				mode={request ? mode : "json"}
+				mode={request ? "yaml" : "json"}
 			/>
-			{request && (
-				<div className="absolute top-2 right-4 flex items-center gap-2 border rounded-full p-2 border-border-secondary bg-bg-primary shadow-sm">
-					<HSComp.SegmentControl
-						value={mode}
-						onValueChange={setMode}
-						items={[
-							{ value: "json" as const, label: "JSON" },
-							{ value: "yaml" as const, label: "YAML" },
-						]}
-					/>
-					<HSComp.Button variant="ghost" size="small" asChild>
-						<HSComp.CopyIcon text={content} />
-					</HSComp.Button>
-				</div>
-			)}
 		</div>
 	);
 }
@@ -926,6 +906,88 @@ export function DevToolRequestPanel() {
 		}
 	};
 
+	const [bodyMode, setBodyMode] = useLocalStorage<"json" | "yaml">({
+		key: "access-policy-devtool-body-mode",
+		getInitialValueInEffect: false,
+		defaultValue: "json",
+	});
+	const [bodyValue, setBodyValue] = React.useState(selectedTab.body);
+	React.useEffect(() => {
+		setBodyValue(selectedTab.body);
+	}, [selectedTab.body]);
+
+	const handleBodyEditorChange = (value: string) => {
+		setBodyValue(value);
+		handleBodyChange(value);
+	};
+
+	const handleBodyModeChange = (newMode: "json" | "yaml") => {
+		const converted = convertBody(bodyValue, bodyMode, newMode);
+		setBodyValue(converted);
+		handleBodyChange(converted);
+		setBodyMode(newMode);
+		const contentType = newMode === "yaml" ? "text/yaml" : "application/json";
+		let headers = updateHeaderValue(
+			selectedTab.headers,
+			"Content-Type",
+			contentType,
+		);
+		headers = updateHeaderValue(headers, "Accept", contentType);
+		updateSelected(() => ({ headers }));
+	};
+
+	const handleBodyFormat = () => {
+		const formatted = formatBody(bodyValue, bodyMode);
+		setBodyValue(formatted);
+		handleBodyChange(formatted);
+	};
+
+	const [rawBodyMode, setRawBodyMode] = useLocalStorage<"json" | "yaml">({
+		key: "access-policy-devtool-raw-body-mode",
+		getInitialValueInEffect: false,
+		defaultValue: "json",
+	});
+	const rawViewRef = React.useRef<EditorView | null>(null);
+
+	const replaceRawBody = (newBody: string, newHead?: string) => {
+		const view = rawViewRef.current;
+		if (!view) return;
+		const doc = view.state.doc.toString();
+		const sepIdx = doc.indexOf("\n\n");
+		if (sepIdx === -1) return;
+		const head = doc.slice(0, sepIdx);
+		const finalHead = newHead ?? head;
+		const newDoc = `${finalHead}\n\n${newBody}`;
+		const cursor = Math.min(view.state.selection.main.head, newDoc.length);
+		view.dispatch({
+			changes: { from: 0, to: doc.length, insert: newDoc },
+			selection: { anchor: cursor },
+		});
+		handleRawChange(newDoc);
+	};
+
+	const handleRawModeChange = (newMode: "json" | "yaml") => {
+		const view = rawViewRef.current;
+		if (!view) return;
+		const { head, body } = splitRaw(view.state.doc.toString());
+		const converted = convertBody(body, rawBodyMode, newMode);
+		const updatedHead = updateHeadersForMode(head, newMode);
+		setRawBodyMode(newMode);
+		replaceRawBody(converted, updatedHead);
+	};
+
+	const handleRawFormat = () => {
+		const view = rawViewRef.current;
+		if (!view) return;
+		const { body } = splitRaw(view.state.doc.toString());
+		const formatted = formatBody(body, rawBodyMode);
+		replaceRawBody(formatted);
+	};
+
+	const activeSubTab = selectedTab.activeRequestSubTab;
+	const showCodeControls = activeSubTab === "body" || activeSubTab === "raw";
+	const isRawSubTab = activeSubTab === "raw";
+
 	const handleRequestSubTabChange = (subTab: RequestSubTab) =>
 		updateSelected(() => ({ activeRequestSubTab: subTab }));
 
@@ -1161,28 +1223,49 @@ export function DevToolRequestPanel() {
 										<HSComp.TabsTrigger value="raw">Raw</HSComp.TabsTrigger>
 									</HSComp.TabsList>
 								</div>
-								<HSComp.Tooltip>
-									<HSComp.TooltipTrigger asChild>
-										<HSComp.Button
-											variant="ghost"
-											size="small"
-											onClick={() =>
-												setMaximized(maximized === "request" ? null : "request")
-											}
-										>
-											{maximized === "request" ? (
-												<Lucide.PanelTopClose className="size-4" />
-											) : (
-												<Lucide.PanelTopOpen className="size-4" />
-											)}
-										</HSComp.Button>
-									</HSComp.TooltipTrigger>
-									<HSComp.TooltipContent align="end">
-										{maximized === "request"
-											? "Show response panel"
-											: "Hide response panel"}
-									</HSComp.TooltipContent>
-								</HSComp.Tooltip>
+								<div className="flex items-center gap-2">
+									{showCodeControls && (
+										<>
+											<CodeEditorFormatSelect
+												mode={isRawSubTab ? rawBodyMode : bodyMode}
+												onModeChange={
+													isRawSubTab
+														? handleRawModeChange
+														: handleBodyModeChange
+												}
+											/>
+											<CodeEditorFormatButton
+												onFormat={
+													isRawSubTab ? handleRawFormat : handleBodyFormat
+												}
+											/>
+										</>
+									)}
+									<HSComp.Tooltip>
+										<HSComp.TooltipTrigger asChild>
+											<HSComp.Button
+												variant="ghost"
+												size="small"
+												onClick={() =>
+													setMaximized(
+														maximized === "request" ? null : "request",
+													)
+												}
+											>
+												{maximized === "request" ? (
+													<Lucide.PanelTopClose className="size-4" />
+												) : (
+													<Lucide.PanelTopOpen className="size-4" />
+												)}
+											</HSComp.Button>
+										</HSComp.TooltipTrigger>
+										<HSComp.TooltipContent align="end">
+											{maximized === "request"
+												? "Show response panel"
+												: "Hide response panel"}
+										</HSComp.TooltipContent>
+									</HSComp.Tooltip>
+								</div>
 							</div>
 							<HSComp.TabsContent value="params" className="grow min-h-0">
 								<ParamsEditor
@@ -1203,11 +1286,10 @@ export function DevToolRequestPanel() {
 								className="relative grow min-h-0"
 							>
 								<RequestBodyEditor
-									tab={selectedTab}
-									onBodyChange={handleBodyChange}
-									onHeadersUpdate={(headers) =>
-										updateSelected(() => ({ headers }))
-									}
+									tabId={selectedTab.id}
+									mode={bodyMode}
+									value={bodyValue}
+									onChange={handleBodyEditorChange}
 								/>
 							</HSComp.TabsContent>
 							<HSComp.TabsContent value="raw" className="relative grow min-h-0">
@@ -1215,6 +1297,9 @@ export function DevToolRequestPanel() {
 									selectedTab={selectedTab}
 									onRawChange={handleRawChange}
 									requestLineVersion={requestLineVersion}
+									viewCallback={(view) => {
+										rawViewRef.current = view;
+									}}
 								/>
 							</HSComp.TabsContent>
 						</HSComp.Tabs>

--- a/src/components/ResourceEditor/editor-tab.tsx
+++ b/src/components/ResourceEditor/editor-tab.tsx
@@ -5,7 +5,10 @@ import type {
 } from "@health-samurai/react-components";
 import * as HSComp from "@health-samurai/react-components";
 import { useVimMode } from "../../shared/vim-mode";
-import { CodeEditorMenubar } from "../ViewDefinition/code-editor-menubar";
+import {
+	CodeEditorFormatButton,
+	CodeEditorFormatSelect,
+} from "../ViewDefinition/code-editor-menubar";
 import type { EditorMode } from "./types";
 
 type EditorTabProps = {
@@ -42,23 +45,15 @@ export const EditorTab = ({
 	const vimMode = useVimMode();
 	return (
 		<div className="flex flex-col h-full">
-			{(actions || trailingActions) && (
-				<div className="flex items-center justify-between bg-bg-secondary flex-none h-10 border-b px-4">
-					<div className="flex items-center gap-4">{actions}</div>
-					{trailingActions && (
-						<div className="flex items-center gap-4">{trailingActions}</div>
-					)}
+			<div className="flex items-center justify-between bg-bg-secondary flex-none h-10 border-b px-4">
+				<div className="flex items-center gap-4">{actions}</div>
+				<div className="flex items-center gap-2">
+					<CodeEditorFormatSelect mode={mode} onModeChange={setMode} />
+					<CodeEditorFormatButton onFormat={triggerFormat} />
+					{trailingActions}
 				</div>
-			)}
+			</div>
 			<div className="relative grow min-h-0">
-				<div className="sticky min-h-0 h-0 flex justify-end pr-3 top-0 right-0 z-10">
-					<CodeEditorMenubar
-						mode={mode}
-						onModeChange={setMode}
-						textToCopy={resourceText}
-						onFormat={triggerFormat}
-					/>
-				</div>
 				<HSComp.CodeEditor
 					mode={mode}
 					defaultValue={defaultResourceText}

--- a/src/components/ResourceEditor/versions-tab.tsx
+++ b/src/components/ResourceEditor/versions-tab.tsx
@@ -330,15 +330,27 @@ export const VersionsTab = ({
 						<HSComp.TabsTrigger value="raw">Raw</HSComp.TabsTrigger>
 						<HSComp.TabsTrigger value="diff">Diff</HSComp.TabsTrigger>
 					</HSComp.TabsList>
-					{selectedVersionId !== versions[0]?.versionId && (
-						<button
-							type="button"
-							className="text-text-link font-medium text-sm cursor-pointer px-4"
-							onClick={() => setConfirmRestore(true)}
-						>
-							Restore
-						</button>
-					)}
+					<div className="flex items-center gap-2 pr-2">
+						{viewMode === "raw" && (
+							<HSComp.SegmentControl
+								value={editorMode}
+								onValueChange={(value) => setEditorMode(value as EditorMode)}
+								items={[
+									{ value: "json", label: "JSON" },
+									{ value: "yaml", label: "YAML" },
+								]}
+							/>
+						)}
+						{selectedVersionId !== versions[0]?.versionId && (
+							<button
+								type="button"
+								className="text-text-link font-medium text-sm cursor-pointer"
+								onClick={() => setConfirmRestore(true)}
+							>
+								Restore
+							</button>
+						)}
+					</div>
 				</div>
 
 				{/* Content */}
@@ -348,35 +360,6 @@ export const VersionsTab = ({
 				>
 					{selectedVersion && (
 						<div className="relative h-full w-full bg-bg-primary">
-							<div className="absolute top-2 right-3 z-10">
-								<div className="flex items-center gap-2 border rounded-full py-2 pr-2 pl-2.5 border-border-secondary bg-bg-primary toolbar-shadow">
-									<HSComp.SegmentControl
-										value={editorMode}
-										onValueChange={(value) =>
-											setEditorMode(value as EditorMode)
-										}
-										items={[
-											{ value: "json", label: "JSON" },
-											{ value: "yaml", label: "YAML" },
-										]}
-									/>
-									<HSComp.Button variant="ghost" size="small" asChild>
-										<HSComp.CopyIcon
-											text={
-												editorMode === "yaml"
-													? yaml.dump(selectedVersion.resourceCurrent, {
-															indent: 2,
-														})
-													: JSON.stringify(
-															selectedVersion.resourceCurrent,
-															null,
-															2,
-														)
-											}
-										/>
-									</HSComp.Button>
-								</div>
-							</div>
 							<HSComp.CodeEditor
 								readOnly
 								currentValue={

--- a/src/components/ViewDefinition/example-tab-content.tsx
+++ b/src/components/ViewDefinition/example-tab-content.tsx
@@ -5,20 +5,15 @@ import type {
 import {
 	Button,
 	CodeEditor,
-	CopyIcon,
-	SegmentControl,
-	Separator,
 	Tooltip,
 	TooltipContent,
 	TooltipTrigger,
 } from "@health-samurai/react-components";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import * as yaml from "js-yaml";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import type { RefObject } from "react";
 import { useContext, useState } from "react";
 import { type AidboxClientR5, useAidboxClient } from "../../AidboxClient";
-import { useLocalStorage } from "../../hooks";
 import * as Utils from "../../utils";
 import type { ViewDefinitionBuilderActions } from "../../webmcp/view-definition-context";
 import { EmptyState } from "../empty-state";
@@ -28,7 +23,6 @@ import {
 	ViewDefinitionResourceTypeContext,
 } from "./page";
 import { SearchBar } from "./search-bar";
-import type { ViewDefinitionEditorMode } from "./types";
 
 const searchResources = async (
 	client: AidboxClientR5,
@@ -53,66 +47,44 @@ const searchResources = async (
 };
 
 const ExampleTabEditorMenu = ({
-	mode,
-	onModeChange,
-	textToCopy,
 	onPrevious,
 	onNext,
 	canGoToPrevious,
 	canGoToNext,
 }: {
-	mode: ViewDefinitionEditorMode;
-	onModeChange: (mode: ViewDefinitionEditorMode) => void;
-	textToCopy: string;
 	onPrevious: () => void;
 	onNext: () => void;
 	canGoToPrevious: boolean;
 	canGoToNext: boolean;
 }) => {
 	return (
-		<div className="flex items-center gap-2 border rounded-full py-2 pr-2 pl-2.5 border-border-secondary bg-bg-primary toolbar-shadow">
-			<SegmentControl
-				value={mode}
-				onValueChange={(value) =>
-					onModeChange(value as ViewDefinitionEditorMode)
-				}
-				items={[
-					{ value: "json", label: "JSON" },
-					{ value: "yaml", label: "YAML" },
-				]}
-			/>
-			<Button variant="ghost" size="small" asChild>
-				<CopyIcon text={textToCopy} />
-			</Button>
-			<Separator orientation="vertical" className="h-6!" />
-			<div className="flex items-center gap-0.5">
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<Button
-							variant="ghost"
-							size="small"
-							onClick={onPrevious}
-							disabled={!canGoToPrevious}
-						>
-							<ChevronLeft />
-						</Button>
-					</TooltipTrigger>
-					<TooltipContent>Previous instance</TooltipContent>
-				</Tooltip>
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<Button
-							variant="ghost"
-							size="small"
-							onClick={onNext}
-							disabled={!canGoToNext}
-						>
-							<ChevronRight />
-						</Button>
-					</TooltipTrigger>
-					<TooltipContent>Next instance</TooltipContent>
-				</Tooltip>
-			</div>
+		<div className="flex items-center gap-0.5 border rounded-full py-2 pr-2 pl-2.5 border-border-secondary bg-bg-primary toolbar-shadow">
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<Button
+						variant="ghost"
+						size="small"
+						onClick={onPrevious}
+						disabled={!canGoToPrevious}
+					>
+						<ChevronLeft />
+					</Button>
+				</TooltipTrigger>
+				<TooltipContent>Previous instance</TooltipContent>
+			</Tooltip>
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<Button
+						variant="ghost"
+						size="small"
+						onClick={onNext}
+						disabled={!canGoToNext}
+					>
+						<ChevronRight />
+					</Button>
+				</TooltipTrigger>
+				<TooltipContent>Next instance</TooltipContent>
+			</Tooltip>
 		</div>
 	);
 };
@@ -136,12 +108,6 @@ export function ExampleTabContent({
 	const isLoadingViewDef = viewDefinitionContext.isLoadingViewDef;
 
 	const [currentResultIndex, setCurrentResultIndex] = useState(0);
-	const [exampleMode, setExampleMode] =
-		useLocalStorage<ViewDefinitionEditorMode>({
-			key: `viewDefinition-infoPanel-exampleMode`,
-			defaultValue: "json",
-			getInitialValueInEffect: false,
-		});
 
 	const query = instancesQuery;
 	const setQuery = onInstancesQueryChange;
@@ -206,12 +172,6 @@ export function ExampleTabContent({
 		};
 	}
 
-	const getCopyText = () => {
-		return exampleMode === "yaml"
-			? yaml.dump(exampleResource, { indent: 2 })
-			: JSON.stringify(exampleResource, null, 2);
-	};
-
 	return (
 		<div className="flex flex-col flex-1 min-h-0">
 			<SearchBar
@@ -245,9 +205,6 @@ export function ExampleTabContent({
 							<>
 								<div className="absolute top-2 right-3 z-10">
 									<ExampleTabEditorMenu
-										mode={exampleMode}
-										onModeChange={setExampleMode}
-										textToCopy={getCopyText()}
 										onPrevious={handlePrevious}
 										onNext={handleNext}
 										canGoToPrevious={canGoToPrevious}
@@ -256,21 +213,14 @@ export function ExampleTabContent({
 								</div>
 								<CodeEditor
 									readOnly
-									currentValue={
-										exampleMode === "yaml"
-											? yaml.dump(exampleResource, { indent: 2 })
-											: JSON.stringify(exampleResource, null, 2)
-									}
-									mode={exampleMode}
+									currentValue={JSON.stringify(exampleResource, null, 2)}
+									mode="json"
 								/>
 							</>
 						) : status === "error" ? (
 							<>
 								<div className="absolute top-2 right-3 z-10">
 									<ExampleTabEditorMenu
-										mode={exampleMode}
-										onModeChange={setExampleMode}
-										textToCopy={getCopyText()}
 										onPrevious={() => {}}
 										onNext={() => {}}
 										canGoToPrevious={false}
@@ -279,12 +229,8 @@ export function ExampleTabContent({
 								</div>
 								<CodeEditor
 									readOnly
-									currentValue={
-										exampleMode === "yaml"
-											? yaml.dump(error.cause, { indent: 2 })
-											: JSON.stringify(error.cause, null, 2)
-									}
-									mode={exampleMode}
+									currentValue={JSON.stringify(error.cause, null, 2)}
+									mode="json"
 								/>
 							</>
 						) : (

--- a/src/routes/db-console.tsx
+++ b/src/routes/db-console.tsx
@@ -1,7 +1,5 @@
-import { indentLess, insertTab } from "@codemirror/commands";
-import { indentUnit } from "@codemirror/language";
 import { Prec } from "@codemirror/state";
-import { type Command, type EditorView, keymap } from "@codemirror/view";
+import { type EditorView, keymap } from "@codemirror/view";
 import {
 	Button,
 	CodeEditor,
@@ -82,25 +80,6 @@ const SQL_PLACEHOLDER_CTAS = [
 	"Before TRUNCATE, make sure this isn't prod",
 	"Ctrl+Z works on code, not on prod",
 ];
-
-/**
- * Shift-Tab handler that de-indents only when the cursor is in the leading
- * whitespace of the current line (or the line is empty / whitespace-only).
- * Outdenting from the middle of a token is rarely what users want, so consume
- * the keystroke as a no-op in that case. Multi-line selections always de-indent.
- */
-const smartIndentLess: Command = (view) => {
-	const { state } = view;
-	const sel = state.selection.main;
-	if (!sel.empty) return indentLess(view);
-	const line = state.doc.lineAt(sel.head);
-	const firstNonWs = line.text.search(/\S/);
-	const cursorCol = sel.head - line.from;
-	if (firstNonWs === -1 || cursorCol <= firstNonWs) {
-		return indentLess(view);
-	}
-	return true;
-};
 
 type SqlRunOpts = {
 	autocommit: boolean;
@@ -670,10 +649,6 @@ function DbConsolePage() {
 
 	const sqlEditorExtensions = useMemo(
 		() => [
-			// Use a literal tab as the indent unit so indentMore / indentLess
-			// (multi-line Tab and Shift-Tab) work in tabs, matching what
-			// insertTab does for single-cursor Tab.
-			indentUnit.of("\t"),
 			Prec.highest(
 				keymap.of([
 					{
@@ -703,12 +678,6 @@ function DbConsolePage() {
 							return true;
 						},
 					},
-					// Tab inserts a literal tab at the cursor (or indents the
-					// selection if multi-line). Shift-Tab de-indents the line
-					// only when the cursor sits in its leading whitespace
-					// (logical start of the line) — otherwise it's a no-op so
-					// users mid-token don't accidentally outdent.
-					{ key: "Tab", run: insertTab, shift: smartIndentLess },
 				]),
 			),
 		],

--- a/src/routes/rest.tsx
+++ b/src/routes/rest.tsx
@@ -77,7 +77,10 @@ import {
 	useRoutes,
 } from "../components/rest/url-autocomplete";
 import { SplitButton, type SplitDirection } from "../components/Split";
-import { CodeEditorMenubar } from "../components/ViewDefinition/code-editor-menubar";
+import {
+	CodeEditorFormatButton,
+	CodeEditorFormatSelect,
+} from "../components/ViewDefinition/code-editor-menubar";
 import { useExpandValueSet } from "../hooks/useExpandValueSet";
 import { useGetStructureDefinitions } from "../hooks/useGetStructureDefinition";
 import { useLocalStorage } from "../hooks/useLocalStorage";
@@ -189,18 +192,21 @@ function updateHeadersForMode(head: string, mode: "json" | "yaml"): string {
 }
 
 function RawEditor({
-	selectedTab,
+	selectedTabId,
 	requestLineVersion,
-	onRawChange,
+	initialValue,
+	issueLineNumbers,
 	getStructureDefinitions,
 	expandValueSet,
 	resourceTypeHint,
 	getUrlSuggestions,
-	issueLineNumbers,
+	onChange,
+	viewCallback,
 }: {
-	selectedTab: Tab;
+	selectedTabId: string;
 	requestLineVersion: string;
-	onRawChange?: (rawText: string) => void;
+	initialValue: string;
+	issueLineNumbers?: { line: number; message?: string }[];
 	getStructureDefinitions?: GetStructureDefinitions;
 	expandValueSet?: (
 		url: string,
@@ -213,111 +219,26 @@ function RawEditor({
 	) =>
 		| { label: string; value: string; type?: string }[]
 		| Promise<{ label: string; value: string; type?: string }[]>;
-	issueLineNumbers?: { line: number; message?: string }[];
+	onChange: (value: string) => void;
+	viewCallback: (view: EditorView) => void;
 }) {
 	const vimMode = useVimMode();
-	const defaultRequestLine = `${selectedTab.method} ${selectedTab.path || "/"}`;
-	const defaultHeaders =
-		selectedTab.headers
-			?.filter(
-				(header) => header.name && header.value && (header.enabled ?? true),
-			)
-			.map((header) => `${header.name}: ${header.value}`)
-			.join("\n") || "";
-
-	const initialValue = `${defaultRequestLine}\n${defaultHeaders}\n\n${selectedTab.body || ""}`;
-	const [rawValue, setRawValue] = useState(initialValue);
-	const [bodyMode, setBodyMode] = useLocalStorage<"json" | "yaml">({
-		key: `rest-console-raw-body-mode-${selectedTab.id}`,
-		getInitialValueInEffect: false,
-		defaultValue: "json",
-	});
-	const viewRef = useRef<EditorView | null>(null);
-
-	const bodyModeRef = useRef(bodyMode);
-	bodyModeRef.current = bodyMode;
-
-	// Shift issue line numbers to account for headers in raw mode
-	const rawIssueLines = useMemo(() => {
-		if (!issueLineNumbers) return undefined;
-		const sepIdx = rawValue.indexOf("\n\n");
-		if (sepIdx === -1) return undefined;
-		let headerLines = 0;
-		for (let i = 0; i < sepIdx; i++) {
-			if (rawValue[i] === "\n") headerLines++;
-		}
-		const offset = headerLines + 2; // +2 for the blank line
-		return issueLineNumbers.map((il) => ({
-			line: il.line + offset,
-			message: il.message,
-		}));
-	}, [issueLineNumbers, rawValue]);
-
-	const handleChange = (value: string) => {
-		setRawValue(value);
-		onRawChange?.(value);
-	};
-
-	const replaceBody = (newBody: string, newHead?: string) => {
-		const view = viewRef.current;
-		if (!view) return;
-		const doc = view.state.doc.toString();
-		const sepIdx = doc.indexOf("\n\n");
-		if (sepIdx === -1) return;
-		const head = doc.slice(0, sepIdx);
-		const finalHead = newHead ?? head;
-		const newDoc = `${finalHead}\n\n${newBody}`;
-		// Keep cursor at same relative position, clamped to new doc length
-		const cursor = Math.min(view.state.selection.main.head, newDoc.length);
-		view.dispatch({
-			changes: { from: 0, to: doc.length, insert: newDoc },
-			selection: { anchor: cursor },
-		});
-		setRawValue(newDoc);
-		onRawChange?.(newDoc);
-	};
-
-	const handleModeChange = (newMode: "json" | "yaml") => {
-		const { head, body } = splitRaw(rawValue);
-		const converted = convertBody(body, bodyMode, newMode);
-		const updatedHead = updateHeadersForMode(head, newMode);
-		setBodyMode(newMode);
-		replaceBody(converted, updatedHead);
-	};
-
-	const handleFormat = () => {
-		const { body } = splitRaw(rawValue);
-		const formatted = formatBody(body, bodyMode);
-		replaceBody(formatted);
-	};
 
 	return (
-		<div className="relative h-full">
-			<div className="sticky min-h-0 h-0 flex justify-end pt-2 pr-3 top-0 right-0 z-10">
-				<CodeEditorMenubar
-					mode={bodyMode}
-					onModeChange={handleModeChange}
-					textToCopy={rawValue}
-					onFormat={handleFormat}
-				/>
-			</div>
-			<CodeEditor
-				key={`raw-editor-${selectedTab.id}-${requestLineVersion}`}
-				defaultValue={initialValue}
-				mode="http"
-				additionalExtensions={[preventNewlineOnModEnter]}
-				getStructureDefinitions={getStructureDefinitions}
-				expandValueSet={expandValueSet}
-				resourceTypeHint={resourceTypeHint}
-				getUrlSuggestions={getUrlSuggestions}
-				issueLineNumbers={rawIssueLines}
-				vimMode={vimMode}
-				viewCallback={(v) => {
-					viewRef.current = v;
-				}}
-				onChange={handleChange}
-			/>
-		</div>
+		<CodeEditor
+			key={`raw-editor-${selectedTabId}-${requestLineVersion}`}
+			defaultValue={initialValue}
+			mode="http"
+			additionalExtensions={[preventNewlineOnModEnter]}
+			getStructureDefinitions={getStructureDefinitions}
+			expandValueSet={expandValueSet}
+			resourceTypeHint={resourceTypeHint}
+			getUrlSuggestions={getUrlSuggestions}
+			issueLineNumbers={issueLineNumbers}
+			vimMode={vimMode}
+			viewCallback={viewCallback}
+			onChange={onChange}
+		/>
 	);
 }
 
@@ -599,6 +520,90 @@ function RequestView({
 		setBodyEditedSinceResponse(true);
 	};
 
+	const rawInitialValue = `${selectedTab.method} ${selectedTab.path || "/"}\n${
+		selectedTab.headers
+			?.filter(
+				(header) => header.name && header.value && (header.enabled ?? true),
+			)
+			.map((header) => `${header.name}: ${header.value}`)
+			.join("\n") || ""
+	}\n\n${selectedTab.body || ""}`;
+	const [rawValue, setRawValue] = useState(rawInitialValue);
+	const [rawBodyMode, setRawBodyMode] = useLocalStorage<"json" | "yaml">({
+		key: `rest-console-raw-body-mode-${selectedTab.id}`,
+		getInitialValueInEffect: false,
+		defaultValue: "json",
+	});
+	const rawViewRef = useRef<EditorView | null>(null);
+
+	// Shift issue line numbers to account for headers in raw mode
+	const rawIssueLines = useMemo(() => {
+		if (!responseIssueLines) return undefined;
+		const sepIdx = rawValue.indexOf("\n\n");
+		if (sepIdx === -1) return undefined;
+		let headerLines = 0;
+		for (let i = 0; i < sepIdx; i++) {
+			if (rawValue[i] === "\n") headerLines++;
+		}
+		const offset = headerLines + 2; // +2 for the blank line
+		return responseIssueLines.map((il) => ({
+			line: il.line + offset,
+			message: il.message,
+		}));
+	}, [responseIssueLines, rawValue]);
+
+	const handleRawChange = (value: string) => {
+		setRawValue(value);
+		onRawChange(value);
+	};
+
+	const replaceRawBody = (newBody: string, newHead?: string) => {
+		const view = rawViewRef.current;
+		if (!view) return;
+		const doc = view.state.doc.toString();
+		const sepIdx = doc.indexOf("\n\n");
+		if (sepIdx === -1) return;
+		const head = doc.slice(0, sepIdx);
+		const finalHead = newHead ?? head;
+		const newDoc = `${finalHead}\n\n${newBody}`;
+		// Keep cursor at same relative position, clamped to new doc length
+		const cursor = Math.min(view.state.selection.main.head, newDoc.length);
+		view.dispatch({
+			changes: { from: 0, to: doc.length, insert: newDoc },
+			selection: { anchor: cursor },
+		});
+		setRawValue(newDoc);
+		onRawChange(newDoc);
+	};
+
+	const handleRawModeChange = (newMode: "json" | "yaml") => {
+		const view = rawViewRef.current;
+		if (!view) return;
+		const { head, body } = splitRaw(view.state.doc.toString());
+		const converted = convertBody(body, rawBodyMode, newMode);
+		const updatedHead = updateHeadersForMode(head, newMode);
+		setRawBodyMode(newMode);
+		replaceRawBody(converted, updatedHead);
+	};
+
+	const handleRawFormat = () => {
+		const view = rawViewRef.current;
+		if (!view) return;
+		const { body } = splitRaw(view.state.doc.toString());
+		const formatted = formatBody(body, rawBodyMode);
+		replaceRawBody(formatted);
+	};
+
+	const showCodeControls =
+		currentActiveSubTab === "body" || currentActiveSubTab === "raw";
+	const isRawSubTab = currentActiveSubTab === "raw";
+
+	const [rawSubTabWasActive, setRawSubTabWasActive] = useState(isRawSubTab);
+	if (isRawSubTab !== rawSubTabWasActive) {
+		setRawSubTabWasActive(isRawSubTab);
+		if (isRawSubTab) setRawValue(rawInitialValue);
+	}
+
 	// Override WebMCP stubs with real implementations
 	webmcpActionsRef.current.getBodyMode = () => bodyMode;
 	webmcpActionsRef.current.setBodyMode = handleBodyModeChange;
@@ -614,21 +619,54 @@ function RequestView({
 			>
 				<div className="flex items-center justify-between bg-bg-secondary px-4 border-b h-10">
 					<div className="flex items-center">
-						<span className="typo-label text-text-secondary pr-3">
+						<span className="typo-label text-text-secondary w-20">
 							Request:
 						</span>
 						<TabsList>
+							<TabsTrigger value="raw">Raw</TabsTrigger>
 							<TabsTrigger value="params">Params</TabsTrigger>
 							<TabsTrigger value="headers">Headers</TabsTrigger>
 							<TabsTrigger value="body">Body</TabsTrigger>
-							<TabsTrigger value="raw">Raw</TabsTrigger>
 						</TabsList>
 					</div>
-					<ExpandPane
-						onToggle={(state) => onFullScreenToggle(state)}
-						state={fullScreenState}
-					/>
+					<div className="flex items-center gap-2">
+						{showCodeControls && (
+							<>
+								<CodeEditorFormatSelect
+									mode={isRawSubTab ? rawBodyMode : bodyMode}
+									onModeChange={
+										isRawSubTab ? handleRawModeChange : handleBodyModeChange
+									}
+								/>
+								<CodeEditorFormatButton
+									onFormat={isRawSubTab ? handleRawFormat : handleFormatBody}
+								/>
+							</>
+						)}
+						<ExpandPane
+							onToggle={(state) => onFullScreenToggle(state)}
+							state={fullScreenState}
+						/>
+					</div>
 				</div>
+				<TabsContent value="raw">
+					<div className="h-full">
+						<RawEditor
+							selectedTabId={selectedTab.id}
+							requestLineVersion={requestLineVersion}
+							initialValue={rawInitialValue}
+							issueLineNumbers={rawIssueLines}
+							getStructureDefinitions={getStructureDefinitions}
+							expandValueSet={expandValueSet}
+							resourceTypeHint={resourceTypeHint}
+							getUrlSuggestions={getUrlSuggestions}
+							onChange={handleRawChange}
+							viewCallback={(view) => {
+								rawViewRef.current = view;
+							}}
+						/>
+					</div>
+				</TabsContent>
 				<TabsContent value="params">
 					<ParamsEditor
 						params={selectedTab.params || []}
@@ -644,14 +682,6 @@ function RequestView({
 					/>
 				</TabsContent>
 				<TabsContent value="body" className="relative h-full">
-					<div className="sticky min-h-0 h-0 flex justify-end pt-2 pr-3 top-0 right-0 z-10">
-						<CodeEditorMenubar
-							mode={bodyMode}
-							onModeChange={handleBodyModeChange}
-							textToCopy={bodyEditorValue}
-							onFormat={handleFormatBody}
-						/>
-					</div>
 					<div className="h-full">
 						<CodeEditor
 							id={`request-editor-${selectedTab.id}-${currentActiveSubTab}`}
@@ -665,20 +695,6 @@ function RequestView({
 							resourceTypeHint={resourceTypeHint}
 							issueLineNumbers={responseIssueLines}
 							vimMode={vimMode}
-						/>
-					</div>
-				</TabsContent>
-				<TabsContent value="raw">
-					<div className="h-full">
-						<RawEditor
-							requestLineVersion={requestLineVersion}
-							selectedTab={selectedTab}
-							onRawChange={onRawChange}
-							getStructureDefinitions={getStructureDefinitions}
-							expandValueSet={expandValueSet}
-							resourceTypeHint={resourceTypeHint}
-							getUrlSuggestions={getUrlSuggestions}
-							issueLineNumbers={responseIssueLines}
 						/>
 					</div>
 				</TabsContent>
@@ -1275,7 +1291,7 @@ function ResponsePane({
 		>
 			<div className="flex items-center justify-between bg-bg-secondary px-4 h-10 border-b">
 				<div className="flex items-center">
-					<span className="typo-label text-text-secondary pr-3">Response:</span>
+					<span className="typo-label text-text-secondary w-20">Response:</span>
 					<TabsList>
 						<TabsTrigger value="body">Body</TabsTrigger>
 						<TabsTrigger value="headers">Headers</TabsTrigger>


### PR DESCRIPTION
## What

Moves the JSON/YAML + format controls out of floating "pills" overlaid on the editors into the panel toolbars, and removes the copy buttons, across:

- **REST console** — Body & Raw
- **Resource Editor → Edit** (+ **Access Policy → Builder**, shared `EditorTab`)
- **Resource Editor → History/Versions**
- **Access Policy → dev-tool** request (Body & Raw) and RequestContext
- **ViewDefinition → Example** — kept only prev/next navigation

Also:
- REST console: **Raw** tab is now first; `Request:`/`Response:` labels are equal width so the tab rows line up.
- **Global Tab fix in `CodeEditor`**: `Tab` inserts indent / `Shift-Tab` dedents (was moving focus). Autocomplete `Tab` navigation and read-only editors are preserved.

## Submodule

The `CodeEditor` Tab fix lives in `aidbox-ts-sdk` — pushed directly to `development` per repo convention (commit `2465245`). This PR bumps the submodule pointer (`development`).

## Testing

- `pnpm typecheck` + `biome check` clean.
- `react-components` rebuilt; verified locally — Tab indents, controls in toolbars, copy removed.