### PR TITLE
Async Operations: polish list & redesign detail screen

### DIFF
--- a/src/components/AsyncOperations/api.ts
+++ b/src/components/AsyncOperations/api.ts
@@ -8,6 +8,7 @@ import type {
 
 const LIST_KEY = ["async-operations", "list"] as const;
 const STATUS_KEY = (id: string) => ["async-operations", "status", id] as const;
+const LIST_COUNT = 5000;
 
 function buildListUrl(q: ListQuery): string {
 	const params = new URLSearchParams();
@@ -15,6 +16,7 @@ function buildListUrl(q: ListQuery): string {
 	if (q.taskName.trim()) params.set("task-name", q.taskName.trim());
 	params.set("sort", q.sortField);
 	params.set("order", q.sortOrder);
+	params.set("_count", String(LIST_COUNT));
 	const qs = params.toString();
 	return qs ? `/$async-operations?${qs}` : "/$async-operations";
 }

--- a/src/components/AsyncOperations/detail.tsx
+++ b/src/components/AsyncOperations/detail.tsx
@@ -2,63 +2,73 @@ import {
 	Alert,
 	AlertDescription,
 	AlertTitle,
+	Badge,
 	Button,
-	Table,
-	TableBody,
-	TableCell,
-	TableHead,
-	TableHeader,
-	TableRow,
-	Tabs,
-	TabsContent,
-	TabsList,
-	TabsTrigger,
+	CodeEditor,
+	ResizableHandle,
+	ResizablePanel,
+	ResizablePanelGroup,
 } from "@health-samurai/react-components";
-import { Link } from "@tanstack/react-router";
-import { AlertCircle, ArrowLeft, RefreshCw, XCircle } from "lucide-react";
+import { AlertCircle, Ban, Check, Loader2, X } from "lucide-react";
 import { useState } from "react";
+import { ConfirmDialog } from "../confirm-dialog";
+import { DataTable } from "../data-table/data-table";
+import type { ColumnDef, SortState } from "../data-table/types";
 import { useAsyncOperationStatus, useCancelAsyncOperation } from "./api";
 import { StatusBadge } from "./status-badge";
-import type { AsyncOperationStatus, AsyncOperationTask } from "./types";
-import { formatDateTime } from "./utils";
+import type { AsyncOperationTask } from "./types";
+
+const CANCEL_MARKER = "async-api.operation/cancel-marker";
 
 function aggregate(tasks: AsyncOperationTask[]) {
-	const total = tasks.length;
-	const succeeded = tasks.filter((t) => t.success === true).length;
-	const failed = tasks.filter((t) => t.success === false).length;
+	const real = tasks.filter((t) => t.task_name !== CANCEL_MARKER);
+	const total = real.length;
+	const succeeded = real.filter((t) => t.success === true).length;
+	const failed = real.filter((t) => t.success === false).length;
 	const pending = total - succeeded - failed;
 	return { total, succeeded, failed, pending };
 }
 
-const PROGRESS_BAR_COLOR: Record<AsyncOperationStatus, string> = {
-	completed: "bg-utility-green",
-	failed: "bg-utility-red",
-	cancelled: "bg-utility-yellow",
-	"in-progress": "bg-utility-blue",
-};
+function parseMs(value: string | null | undefined): number | null {
+	return value ? new Date(value).getTime() : null;
+}
 
-function ProgressBar({
-	status,
-	counts,
-}: {
-	status: AsyncOperationStatus | "not-found";
-	counts: { total: number; succeeded: number; failed: number };
-}) {
-	if (status === "not-found" || counts.total === 0) return null;
-	const done = counts.succeeded + counts.failed;
-	// Show 100% on terminal states regardless of recorded count — operations can
-	// finish via cancel-marker without all chunks landing.
-	const pct =
-		status === "in-progress" ? Math.min(100, (done / counts.total) * 100) : 100;
-	const color = PROGRESS_BAR_COLOR[status];
-	return (
-		<div className="h-2 rounded bg-bg-tertiary overflow-hidden">
-			<div
-				className={`h-full transition-[width] duration-300 ease-in-out ${color}`}
-				style={{ width: `${pct}%` }}
-			/>
-		</div>
-	);
+function timeBounds(tasks: AsyncOperationTask[]) {
+	let startMs: number | null = null;
+	let startRaw: string | null = null;
+	let endMs: number | null = null;
+	let endRaw: string | null = null;
+	for (const t of tasks) {
+		if (t.task_name === CANCEL_MARKER) continue;
+		const sRaw = t.time_started ?? t.execution_time ?? null;
+		const s = parseMs(sRaw);
+		if (s !== null && (startMs === null || s < startMs)) {
+			startMs = s;
+			startRaw = sRaw;
+		}
+		const eRaw = t.time_done ?? t.last_heartbeat ?? null;
+		const e = parseMs(eRaw);
+		if (e !== null && (endMs === null || e > endMs)) {
+			endMs = e;
+			endRaw = eRaw;
+		}
+	}
+	return { startMs, startRaw, endMs, endRaw };
+}
+
+function formatDuration(ms: number): string {
+	const sec = Math.max(0, Math.floor(ms / 1000));
+	if (sec < 60) return `${sec}s`;
+	if (sec < 3600) return `${Math.floor(sec / 60)}m ${sec % 60}s`;
+	return `${Math.floor(sec / 3600)}h ${Math.floor((sec % 3600) / 60)}m`;
+}
+
+function taskDurationMs(task: AsyncOperationTask): number | null {
+	const start = parseMs(task.time_started ?? task.execution_time);
+	if (start === null) return null;
+	const end =
+		parseMs(task.time_done) ?? (task.success == null ? Date.now() : null);
+	return end === null ? null : end - start;
 }
 
 function getString(
@@ -86,23 +96,181 @@ function findFailureMessage(tasks: AsyncOperationTask[]): {
 	return null;
 }
 
-function JsonBlock({ value }: { value: unknown }) {
-	const text =
-		value === null || value === undefined
-			? "—"
-			: JSON.stringify(value, null, 2);
+function TaskStatus({ task }: { task: AsyncOperationTask }) {
+	if (task.success === true) {
+		return (
+			<span className="flex items-center gap-1 text-utility-green">
+				<Check className="size-4" />
+				Succeeded
+			</span>
+		);
+	}
+	if (task.success === false) {
+		return (
+			<span className="flex items-center gap-1 text-utility-red">
+				<X className="size-4" />
+				Failed
+			</span>
+		);
+	}
 	return (
-		<pre className="text-xs bg-bg-secondary border border-border-secondary rounded p-2 overflow-auto max-h-72 whitespace-pre-wrap break-words">
-			{text}
-		</pre>
+		<span className="flex items-center gap-1 text-utility-blue">
+			<Loader2 className="size-4 animate-spin" />
+			Running
+		</span>
 	);
 }
 
+function taskSortValue(
+	task: AsyncOperationTask,
+	column: string,
+): string | number {
+	switch (column) {
+		case "status":
+			return task.success === false ? 0 : task.success === true ? 1 : 2;
+		case "started":
+			return task.time_started ?? task.execution_time ?? "";
+		case "done":
+			return task.time_done ?? "";
+		case "duration":
+			return taskDurationMs(task) ?? 0;
+		default: {
+			const v = (task as unknown as Record<string, unknown>)[column];
+			if (typeof v === "number") return v;
+			if (typeof v === "boolean") return v ? 1 : 0;
+			if (typeof v === "string") return v;
+			return 0;
+		}
+	}
+}
+
+const TASK_COLUMNS: ColumnDef<AsyncOperationTask>[] = [
+	{
+		id: "status",
+		header: "Status",
+		sortable: true,
+		maxSize: 140,
+		cell: (t) => <TaskStatus task={t} />,
+	},
+	{
+		id: "task_instance",
+		header: "Task instance",
+		sortable: true,
+		maxSize: 400,
+		cell: (t) => <span className="font-mono">{t.task_instance}</span>,
+	},
+	{
+		id: "task_name",
+		header: "Task name",
+		sortable: true,
+		maxSize: 220,
+		cell: (t) => t.task_name,
+	},
+	{
+		id: "attempt",
+		header: "Attempt",
+		sortable: true,
+		maxSize: 100,
+		cell: (t) => t.attempt ?? "—",
+	},
+	{
+		id: "started",
+		header: "Started",
+		sortable: true,
+		maxSize: 260,
+		cell: (t) => t.time_started ?? t.execution_time ?? "—",
+	},
+	{
+		id: "done",
+		header: "Done",
+		sortable: true,
+		maxSize: 260,
+		cell: (t) => t.time_done ?? "—",
+	},
+	{
+		id: "duration",
+		header: "Duration",
+		sortable: true,
+		maxSize: 140,
+		cell: (t) => {
+			const ms = taskDurationMs(t);
+			return ms === null ? "—" : formatDuration(ms);
+		},
+	},
+	{
+		id: "execution_time",
+		header: "Execution time",
+		sortable: true,
+		maxSize: 260,
+		cell: (t) => t.execution_time ?? "—",
+	},
+	{
+		id: "executed_by",
+		header: "Executed by",
+		sortable: true,
+		maxSize: 220,
+		cell: (t) => t.executed_by ?? "—",
+	},
+	{
+		id: "picked_by",
+		header: "Picked by",
+		sortable: true,
+		maxSize: 180,
+		cell: (t) => t.picked_by ?? "—",
+	},
+	{
+		id: "last_heartbeat",
+		header: "Last heartbeat",
+		sortable: true,
+		maxSize: 260,
+		cell: (t) => t.last_heartbeat ?? "—",
+	},
+	{
+		id: "last_success",
+		header: "Last success",
+		sortable: true,
+		maxSize: 260,
+		cell: (t) => t.last_success ?? "—",
+	},
+	{
+		id: "last_failure",
+		header: "Last failure",
+		sortable: true,
+		maxSize: 260,
+		cell: (t) => t.last_failure ?? "—",
+	},
+	{
+		id: "consecutive_failures",
+		header: "Consecutive failures",
+		sortable: true,
+		maxSize: 170,
+		cell: (t) => t.consecutive_failures ?? "—",
+	},
+	{
+		id: "priority",
+		header: "Priority",
+		sortable: true,
+		maxSize: 100,
+		cell: (t) => t.priority ?? "—",
+	},
+	{
+		id: "version",
+		header: "Version",
+		sortable: true,
+		maxSize: 100,
+		cell: (t) => t.version ?? "—",
+	},
+];
+
 export function AsyncOperationDetail({ operationId }: { operationId: string }) {
-	const [tab, setTab] = useState("tasks");
-	const { data, isLoading, refetch, isFetching, error } =
+	const { data, isLoading, refetch, error } =
 		useAsyncOperationStatus(operationId);
 	const cancel = useCancelAsyncOperation();
+	const [terminateOpen, setTerminateOpen] = useState(false);
+	const [sort, setSort] = useState<SortState>({
+		column: "started",
+		direction: "desc",
+	});
 
 	if (isLoading) {
 		return (
@@ -124,80 +292,89 @@ export function AsyncOperationDetail({ operationId }: { operationId: string }) {
 	}
 
 	const status = data.status;
-	const tasks = data.tasks ?? [];
-	const counts = aggregate(tasks);
 	const isActive = status === "in-progress";
+	const tasks = data.tasks ?? [];
+	const visibleTasks = tasks.filter((t) => t.task_name !== CANCEL_MARKER);
+	const sortedTasks = sort
+		? [...visibleTasks].sort((a, b) => {
+				const dir = sort.direction === "asc" ? 1 : -1;
+				const av = taskSortValue(a, sort.column);
+				const bv = taskSortValue(b, sort.column);
+				if (typeof av === "string" && typeof bv === "string") {
+					return dir * av.localeCompare(bv);
+				}
+				return dir * ((av as number) - (bv as number));
+			})
+		: visibleTasks;
+	const handleSortToggle = (column: string) => {
+		setSort((prev) =>
+			prev?.column === column
+				? { column, direction: prev.direction === "asc" ? "desc" : "asc" }
+				: { column, direction: "asc" },
+		);
+	};
+	const counts = aggregate(tasks);
+	const taskName =
+		tasks.find((t) => t.task_name !== CANCEL_MARKER)?.task_name ?? "—";
+	const { startMs, startRaw, endMs, endRaw } = timeBounds(tasks);
+	const createdLabel = startRaw ?? "—";
+	const updatedLabel = endRaw ?? "—";
+	const durationEnd = status === "in-progress" ? Date.now() : endMs;
+	const durationLabel =
+		startMs !== null && durationEnd !== null
+			? formatDuration(durationEnd - startMs)
+			: "—";
+	const metrics: { label: string; value: string | number }[] = [
+		{ label: "Duration", value: durationLabel },
+		{ label: "Total", value: counts.total },
+		{ label: "Succeeded", value: counts.succeeded },
+		...(counts.failed > 0 ? [{ label: "Failed", value: counts.failed }] : []),
+		...(counts.pending > 0
+			? [{ label: "Pending", value: counts.pending }]
+			: []),
+		{ label: "Created", value: createdLabel },
+		{ label: "Updated", value: updatedLabel },
+	];
 	const failure =
 		status === "failed" || counts.failed > 0 ? findFailureMessage(tasks) : null;
 
 	return (
 		<div className="flex flex-col h-full">
-			<div className="flex items-center gap-3 px-4 h-12 border-b border-border-secondary bg-bg-secondary">
-				<Link
-					to="/async-operations"
-					className="text-text-link hover:underline flex items-center gap-1"
-				>
-					<ArrowLeft className="size-4" />
-					Operations
-				</Link>
-				<span className="text-text-secondary">/</span>
-				<span className="font-mono text-sm truncate" title={operationId}>
-					{operationId}
-				</span>
-				<div className="ml-auto flex items-center gap-2">
+			{isActive ? (
+				<div className="flex items-center justify-between bg-bg-secondary flex-none h-10 border-b border-border-secondary px-4">
 					<Button
 						variant="ghost"
+						danger
 						size="small"
-						onClick={() => refetch()}
-						disabled={isFetching}
+						className="px-0! hover:bg-bg-secondary!"
+						disabled={cancel.isPending}
+						onClick={() => setTerminateOpen(true)}
 					>
-						<RefreshCw
-							className={isFetching ? "animate-spin size-4" : "size-4"}
-						/>
-						Refresh
+						<Ban className="size-4" />
+						Terminate
 					</Button>
-					{isActive ? (
-						<Button
-							variant="secondary"
-							danger
-							size="small"
-							disabled={cancel.isPending}
-							onClick={() => {
-								if (
-									window.confirm(
-										"Cancel this async operation? Active tasks will be removed.",
-									)
-								) {
-									cancel.mutate(operationId);
-								}
-							}}
+				</div>
+			) : null}
+			<div className="flex flex-col px-4 py-3 border-b border-border-secondary">
+				<StatusBadge status={status} />
+				<h1
+					className="mt-1.5 text-lg font-semibold text-text-primary truncate"
+					title={taskName}
+				>
+					{taskName}
+				</h1>
+				<div className="mt-3 flex items-center gap-2 flex-wrap">
+					{metrics.map((m) => (
+						<Badge
+							key={m.label}
+							variant="outline"
+							className="border-transparent gap-1.5 font-normal bg-neutral-100 text-neutral-600"
 						>
-							<XCircle className="size-4" />
-							Cancel
-						</Button>
-					) : null}
+							<span className="opacity-70">{m.label}</span>
+							<span className="font-medium tabular-nums">{m.value}</span>
+						</Badge>
+					))}
 				</div>
-			</div>
-
-			<div className="flex flex-col gap-3 px-4 py-3 border-b border-border-secondary">
-				<div className="flex items-center gap-6">
-					<div className="flex items-center gap-2">
-						<span className="text-text-secondary text-sm">Status:</span>
-						<StatusBadge status={status} />
-					</div>
-					<div className="text-sm text-text-secondary tabular-nums">
-						{counts.succeeded}/{counts.total} succeeded
-						{counts.failed > 0 ? (
-							<span className="text-text-error-primary ml-2">
-								{counts.failed} failed
-							</span>
-						) : null}
-						{counts.pending > 0 ? (
-							<span className="ml-2">{counts.pending} pending</span>
-						) : null}
-					</div>
-				</div>
-				<ProgressBar status={status} counts={counts} />
 			</div>
 
 			{failure ? (
@@ -215,100 +392,79 @@ export function AsyncOperationDetail({ operationId }: { operationId: string }) {
 				</Alert>
 			) : null}
 
-			<div className="flex-1 overflow-auto p-4">
-				<Tabs value={tab} onValueChange={setTab}>
-					<TabsList>
-						<TabsTrigger value="tasks">Tasks ({tasks.length})</TabsTrigger>
-						<TabsTrigger value="raw">Raw JSON</TabsTrigger>
-					</TabsList>
-
-					<TabsContent value="tasks" className="mt-3">
-						{tasks.length === 0 ? (
-							<div className="text-text-secondary text-sm py-6 text-center">
-								No tasks recorded for this operation
-							</div>
-						) : (
-							<Table>
-								<TableHeader>
-									<TableRow>
-										<TableHead>Task instance</TableHead>
-										<TableHead>Task name</TableHead>
-										<TableHead>Success</TableHead>
-										<TableHead className="whitespace-nowrap">Started</TableHead>
-										<TableHead className="whitespace-nowrap">Done</TableHead>
-										<TableHead>Attempt</TableHead>
-									</TableRow>
-								</TableHeader>
-								<TableBody>
-									{tasks.map((t) => (
-										<TaskRow key={t.task_instance} task={t} />
-									))}
-								</TableBody>
-							</Table>
-						)}
-					</TabsContent>
-
-					<TabsContent value="raw" className="mt-3">
-						<JsonBlock value={data} />
-					</TabsContent>
-				</Tabs>
-			</div>
-		</div>
-	);
-}
-
-function TaskRow({ task }: { task: AsyncOperationTask }) {
-	const [expanded, setExpanded] = useState(false);
-	const successLabel =
-		task.success === true ? "yes" : task.success === false ? "no" : "—";
-	const successClass =
-		task.success === true
-			? "text-utility-green"
-			: task.success === false
-				? "text-utility-red"
-				: "text-text-secondary";
-
-	return (
-		<>
-			<TableRow
-				className="cursor-pointer"
-				onClick={() => setExpanded((v) => !v)}
-			>
-				<TableCell className="font-mono text-xs max-w-0 truncate">
-					{task.task_instance}
-				</TableCell>
-				<TableCell className="whitespace-nowrap text-xs">
-					{task.task_name}
-				</TableCell>
-				<TableCell className={successClass}>{successLabel}</TableCell>
-				<TableCell className="whitespace-nowrap text-text-secondary text-xs">
-					{formatDateTime(task.time_started ?? task.execution_time)}
-				</TableCell>
-				<TableCell className="whitespace-nowrap text-text-secondary text-xs">
-					{formatDateTime(task.time_done)}
-				</TableCell>
-				<TableCell className="text-text-secondary text-xs tabular-nums">
-					{task.attempt ?? "—"}
-				</TableCell>
-			</TableRow>
-			{expanded ? (
-				<tr className="bg-bg-secondary">
-					<td colSpan={6} className="p-3">
-						<div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-							<div>
-								<div className="text-xs text-text-secondary mb-1">
-									Input (task_data)
-								</div>
-								<JsonBlock value={task.task_data} />
-							</div>
-							<div>
-								<div className="text-xs text-text-secondary mb-1">Outcome</div>
-								<JsonBlock value={task.task_outcome} />
-							</div>
+			<div className="flex-1 overflow-auto">
+				<DataTable<AsyncOperationTask>
+					data={sortedTasks}
+					columns={TASK_COLUMNS}
+					rowKey={(t) => t.task_instance}
+					resizable
+					zebra={false}
+					sort={sort}
+					onSortToggle={handleSortToggle}
+					tableId="async-operation-tasks"
+					renderExpandedRow={(t) => (
+						<div className="h-80 w-full">
+							<ResizablePanelGroup direction="horizontal" className="size-full">
+								<ResizablePanel
+									defaultSize={50}
+									minSize={20}
+									className="flex flex-col overflow-hidden"
+								>
+									<div className="shrink-0 pl-7 pt-2 pb-1 text-sm text-text-secondary">
+										Input
+									</div>
+									<div className="flex-1 min-h-0 px-3">
+										<CodeEditor
+											readOnly
+											mode="json"
+											currentValue={JSON.stringify(
+												t.task_data ?? null,
+												null,
+												2,
+											)}
+										/>
+									</div>
+								</ResizablePanel>
+								<ResizableHandle />
+								<ResizablePanel
+									defaultSize={50}
+									minSize={20}
+									className="flex flex-col overflow-hidden"
+								>
+									<div className="shrink-0 pl-7 pt-2 pb-1 text-sm text-text-secondary">
+										Output
+									</div>
+									<div className="flex-1 min-h-0 px-3">
+										<CodeEditor
+											readOnly
+											mode="json"
+											currentValue={JSON.stringify(
+												t.task_outcome ?? null,
+												null,
+												2,
+											)}
+										/>
+									</div>
+								</ResizablePanel>
+							</ResizablePanelGroup>
 						</div>
-					</td>
-				</tr>
-			) : null}
-		</>
+					)}
+					emptyState={
+						<div className="flex items-center justify-center h-full text-text-secondary">
+							No tasks recorded for this operation
+						</div>
+					}
+				/>
+			</div>
+			<ConfirmDialog
+				open={terminateOpen}
+				onOpenChange={setTerminateOpen}
+				title="Terminate operation"
+				description="Active tasks will be removed. This cannot be undone."
+				confirmLabel="Terminate"
+				danger
+				onConfirm={() => cancel.mutate(operationId)}
+			/>
+		</div>
 	);
 }

--- a/src/components/AsyncOperations/page.tsx
+++ b/src/components/AsyncOperations/page.tsx
@@ -199,8 +199,8 @@ export function AsyncOperationsPage() {
 
 	return (
 		<div className="flex flex-col h-full">
-			<div className="flex items-center justify-between gap-3 px-4 h-12 border-b border-border-secondary bg-bg-primary">
-				<div className="flex items-center gap-3 flex-1 min-w-0">
+			<div className="flex items-center justify-between gap-2 px-4 py-3 border-b border-border-secondary bg-bg-primary">
+				<div className="flex items-center gap-2 flex-1 min-w-0">
 					<Select
 						value={query.statusFilter === "all" ? "" : query.statusFilter}
 						onValueChange={(v) =>

--- a/src/components/AsyncOperations/page.tsx
+++ b/src/components/AsyncOperations/page.tsx
@@ -1,14 +1,16 @@
 import {
-	Button,
-	Input,
+	Combobox,
 	Select,
 	SelectContent,
 	SelectItem,
 	SelectTrigger,
 	SelectValue,
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
 } from "@health-samurai/react-components";
-import { Link } from "@tanstack/react-router";
-import { RefreshCw } from "lucide-react";
+import { Link, useNavigate, useSearch } from "@tanstack/react-router";
+import { X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { DataTable } from "../data-table/data-table";
 import type { ColumnDef, SortState } from "../data-table/types";
@@ -20,9 +22,10 @@ import {
 	DEFAULT_LIST_QUERY,
 	type ListQuery,
 	type SortField,
+	type SortOrder,
 	STATUS_FILTER_OPTIONS,
+	STATUS_TEXT_COLOR,
 } from "./types";
-import { formatDateTime } from "./utils";
 
 const COLUMN_TO_SORT_FIELD: Record<string, SortField> = {
 	created: "created-at",
@@ -33,26 +36,46 @@ const SORT_FIELD_TO_COLUMN: Record<SortField, string> = {
 	"last-updated": "lastUpdated",
 };
 
-export function AsyncOperationsPage() {
-	const [query, setQuery] = useState<ListQuery>(DEFAULT_LIST_QUERY);
-	// Local input value, debounced into query.taskName so we don't refetch on every keystroke.
-	const [taskNameInput, setTaskNameInput] = useState("");
-	useEffect(() => {
-		const t = setTimeout(() => {
-			setQuery((prev) =>
-				prev.taskName === taskNameInput
-					? prev
-					: { ...prev, taskName: taskNameInput },
-			);
-		}, 300);
-		return () => clearTimeout(t);
-	}, [taskNameInput]);
+const parseTs = (s: string | null): number | null =>
+	s ? new Date(s).getTime() : null;
 
-	const { data, isLoading, refetch, isFetching } =
-		useAsyncOperationsList(query);
+function formatDuration(ms: number): string {
+	const seconds = Math.max(0, Math.floor(ms / 1000));
+	if (seconds < 60) return `${seconds}s`;
+	if (seconds < 3600) return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+	return `${Math.floor(seconds / 3600)}h ${Math.floor((seconds % 3600) / 60)}m`;
+}
+
+export function AsyncOperationsPage() {
+	const search = useSearch({ from: "/async-operations/" });
+	const navigate = useNavigate({ from: "/async-operations/" });
+
+	const [sort, setSort] = useState<{
+		sortField: SortField;
+		sortOrder: SortOrder;
+	}>({
+		sortField: DEFAULT_LIST_QUERY.sortField,
+		sortOrder: DEFAULT_LIST_QUERY.sortOrder,
+	});
+
+	const query: ListQuery = {
+		statusFilter: search.status ?? "all",
+		taskName: search.task ?? "",
+		sortField: sort.sortField,
+		sortOrder: sort.sortOrder,
+	};
+
+	const { data, isLoading } = useAsyncOperationsList(query);
 
 	const operations = data?.operations ?? [];
-	const total = data?.total ?? 0;
+	const taskNames = data?.["task-names"] ?? [];
+
+	const [now, setNow] = useState(() => Date.now());
+	useEffect(() => {
+		if (!operations.some((o) => o.status === "in-progress")) return;
+		const t = setInterval(() => setNow(Date.now()), 1000);
+		return () => clearInterval(t);
+	}, [operations]);
 
 	const tableSort: SortState = {
 		column: SORT_FIELD_TO_COLUMN[query.sortField],
@@ -62,10 +85,10 @@ export function AsyncOperationsPage() {
 	const handleSortToggle = (columnId: string) => {
 		const field = COLUMN_TO_SORT_FIELD[columnId];
 		if (!field) return;
-		setQuery((prev) =>
+		setSort((prev) =>
 			prev.sortField === field
 				? { ...prev, sortOrder: prev.sortOrder === "asc" ? "desc" : "asc" }
-				: { ...prev, sortField: field, sortOrder: "desc" },
+				: { sortField: field, sortOrder: "desc" },
 		);
 	};
 
@@ -89,44 +112,75 @@ export function AsyncOperationsPage() {
 			},
 		},
 		{
-			id: "task",
-			header: "Task",
-			maxSize: 300,
-			cell: (op) => op["task-name"] ?? "—",
-		},
-		{
 			id: "status",
 			header: "Status",
 			maxSize: 180,
 			cell: (op) => <StatusBadge status={op.status} />,
 		},
 		{
+			id: "task",
+			header: "Task",
+			maxSize: 300,
+			cell: (op) => op["task-name"] ?? "—",
+		},
+		{
+			id: "duration",
+			header: "Duration",
+			maxSize: 160,
+			cell: (op) => {
+				const start = parseTs(op["created-at"]);
+				const end =
+					op.status === "in-progress" ? now : parseTs(op["last-updated"]);
+				if (start === null || end === null) return "—";
+				return (
+					<span className="text-text-secondary tabular-nums">
+						{formatDuration(end - start)}
+					</span>
+				);
+			},
+		},
+		{
 			id: "tasks",
 			header: "Tasks",
 			maxSize: 180,
 			cell: (op) => (
-				<span
-					className="text-text-secondary tabular-nums"
-					title={`active=${op.active} succeeded=${op.succeeded} failed=${op.failed}`}
-				>
-					{op.succeeded}/{op.total}
-					{op.failed > 0 ? (
-						<span className="text-text-error-primary ml-1">
-							({op.failed} failed)
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<span className="text-text-secondary tabular-nums">
+							{op.succeeded}/{op.total}
 						</span>
-					) : null}
-				</span>
+					</TooltipTrigger>
+					<TooltipContent
+						side="bottom"
+						style={{ fontFamily: "var(--font-family-mono)" }}
+						className="bg-bg-primary text-text-primary border border-border-primary shadow-md font-medium"
+					>
+						<div className="flex flex-col gap-0.5">
+							<div className="flex justify-between gap-4">
+								<span className={STATUS_TEXT_COLOR["in-progress"]}>Active</span>
+								<span className="tabular-nums">{op.active}</span>
+							</div>
+							<div className="flex justify-between gap-4">
+								<span className={STATUS_TEXT_COLOR.completed}>Succeeded</span>
+								<span className="tabular-nums">{op.succeeded}</span>
+							</div>
+							<div className="flex justify-between gap-4">
+								<span className={STATUS_TEXT_COLOR.failed}>Failed</span>
+								<span className="tabular-nums">{op.failed}</span>
+							</div>
+						</div>
+					</TooltipContent>
+				</Tooltip>
 			),
 		},
 		{
 			id: "created",
 			header: "Created",
 			sortable: true,
-			defaultSize: 200,
 			maxSize: 320,
 			cell: (op) => (
 				<span className="text-text-secondary whitespace-nowrap">
-					{formatDateTime(op["created-at"])}
+					{op["created-at"]}
 				</span>
 			),
 		},
@@ -134,11 +188,10 @@ export function AsyncOperationsPage() {
 			id: "lastUpdated",
 			header: "Last updated",
 			sortable: true,
-			defaultSize: 200,
 			maxSize: 320,
 			cell: (op) => (
 				<span className="text-text-secondary whitespace-nowrap">
-					{formatDateTime(op["last-updated"])}
+					{op["last-updated"]}
 				</span>
 			),
 		},
@@ -146,15 +199,20 @@ export function AsyncOperationsPage() {
 
 	return (
 		<div className="flex flex-col h-full">
-			<div className="flex items-center justify-between gap-3 px-4 h-12 border-b border-border-secondary bg-bg-secondary">
+			<div className="flex items-center justify-between gap-3 px-4 h-12 border-b border-border-secondary bg-bg-primary">
 				<div className="flex items-center gap-3 flex-1 min-w-0">
 					<Select
-						value={query.statusFilter}
+						value={query.statusFilter === "all" ? "" : query.statusFilter}
 						onValueChange={(v) =>
-							setQuery((prev) => ({
-								...prev,
-								statusFilter: v as AsyncOperationStatus | "all",
-							}))
+							navigate({
+								search: (prev) => ({
+									...prev,
+									status:
+										v === "all" || v === ""
+											? undefined
+											: (v as AsyncOperationStatus),
+								}),
+							})
 						}
 					>
 						<SelectTrigger className="w-44 h-8">
@@ -162,33 +220,46 @@ export function AsyncOperationsPage() {
 						</SelectTrigger>
 						<SelectContent>
 							{STATUS_FILTER_OPTIONS.map((opt) => (
-								<SelectItem key={opt.value} value={opt.value}>
+								<SelectItem
+									key={opt.value}
+									value={opt.value}
+									className={
+										opt.value === "all"
+											? undefined
+											: STATUS_TEXT_COLOR[opt.value]
+									}
+								>
 									{opt.label}
 								</SelectItem>
 							))}
 						</SelectContent>
 					</Select>
-					<Input
-						className="h-8 max-w-72"
-						placeholder="Filter by task name..."
-						value={taskNameInput}
-						onChange={(e) => setTaskNameInput(e.target.value)}
+					<Combobox
+						options={taskNames.map((tn) => ({ value: tn, label: tn }))}
+						value={query.taskName}
+						onValueChange={(v) =>
+							navigate({
+								search: (prev) => ({ ...prev, task: v || undefined }),
+							})
+						}
+						placeholder="Task"
+						searchPlaceholder="Search task..."
+						emptyText="No tasks found."
+						className="w-56 h-8"
 					/>
-					<Button
-						variant="ghost"
-						size="small"
-						onClick={() => refetch()}
-						disabled={isFetching}
-					>
-						<RefreshCw
-							className={isFetching ? "animate-spin size-4" : "size-4"}
-						/>
-						Refresh
-					</Button>
+					{query.taskName ? (
+						<button
+							type="button"
+							onClick={() =>
+								navigate({ search: (prev) => ({ ...prev, task: undefined }) })
+							}
+							aria-label="Clear task filter"
+							className="-ml-2 flex items-center justify-center size-8 shrink-0 cursor-pointer text-text-tertiary hover:text-text-primary"
+						>
+							<X className="size-4" />
+						</button>
+					) : null}
 				</div>
-				<span className="text-text-secondary text-sm whitespace-nowrap">
-					{total} operation{total === 1 ? "" : "s"}
-				</span>
 			</div>
 
 			<div className="flex-1 overflow-auto">

--- a/src/components/AsyncOperations/status-badge.tsx
+++ b/src/components/AsyncOperations/status-badge.tsx
@@ -10,25 +10,16 @@ const STATUS_CLASSES: Record<AsyncOperationStatus, string> = {
 	"in-progress": "border-transparent bg-utility-blue/15 text-utility-blue",
 };
 
-const STATUS_BADGE_WIDTH = "w-24";
-
 export function StatusBadge({
 	status,
 }: {
 	status: AsyncOperationStatus | "not-found";
 }) {
 	if (status === "not-found") {
-		return (
-			<Badge variant="outline" className={STATUS_BADGE_WIDTH}>
-				Not found
-			</Badge>
-		);
+		return <Badge variant="outline">Not found</Badge>;
 	}
 	return (
-		<Badge
-			variant="outline"
-			className={`${STATUS_BADGE_WIDTH} ${STATUS_CLASSES[status]}`}
-		>
+		<Badge variant="outline" className={STATUS_CLASSES[status]}>
 			{STATUS_LABEL[status]}
 		</Badge>
 	);

--- a/src/components/AsyncOperations/status-badge.tsx
+++ b/src/components/AsyncOperations/status-badge.tsx
@@ -10,16 +10,25 @@ const STATUS_CLASSES: Record<AsyncOperationStatus, string> = {
 	"in-progress": "border-transparent bg-utility-blue/15 text-utility-blue",
 };
 
+const STATUS_BADGE_WIDTH = "w-24";
+
 export function StatusBadge({
 	status,
 }: {
 	status: AsyncOperationStatus | "not-found";
 }) {
 	if (status === "not-found") {
-		return <Badge variant="outline">Not found</Badge>;
+		return (
+			<Badge variant="outline" className={STATUS_BADGE_WIDTH}>
+				Not found
+			</Badge>
+		);
 	}
 	return (
-		<Badge variant="outline" className={STATUS_CLASSES[status]}>
+		<Badge
+			variant="outline"
+			className={`${STATUS_BADGE_WIDTH} ${STATUS_CLASSES[status]}`}
+		>
 			{STATUS_LABEL[status]}
 		</Badge>
 	);

--- a/src/components/AsyncOperations/types.ts
+++ b/src/components/AsyncOperations/types.ts
@@ -31,7 +31,16 @@ export interface AsyncOperationTask {
 	time_started?: string | null;
 	time_done?: string | null;
 	attempt?: number | null;
+	executed_by?: string | null;
+	priority?: number | null;
 	execution_time?: string | null;
+	picked?: boolean | null;
+	picked_by?: string | null;
+	last_heartbeat?: string | null;
+	last_success?: string | null;
+	last_failure?: string | null;
+	consecutive_failures?: number | null;
+	version?: number | null;
 }
 
 export interface AsyncOperationStatusResponse {

--- a/src/components/AsyncOperations/types.ts
+++ b/src/components/AsyncOperations/types.ts
@@ -19,6 +19,7 @@ export interface AsyncOperationSummary {
 export interface AsyncOperationsListResponse {
 	operations: AsyncOperationSummary[];
 	total: number;
+	"task-names": string[];
 }
 
 export interface AsyncOperationTask {
@@ -46,8 +47,8 @@ export const STATUS_FILTER_OPTIONS: {
 	{ value: "all", label: "All" },
 	{ value: "in-progress", label: "In progress" },
 	{ value: "completed", label: "Completed" },
-	{ value: "failed", label: "Failed" },
 	{ value: "cancelled", label: "Cancelled" },
+	{ value: "failed", label: "Failed" },
 ];
 
 export const STATUS_LABEL: Record<AsyncOperationStatus, string> = {
@@ -55,6 +56,13 @@ export const STATUS_LABEL: Record<AsyncOperationStatus, string> = {
 	completed: "Completed",
 	failed: "Failed",
 	cancelled: "Cancelled",
+};
+
+export const STATUS_TEXT_COLOR: Record<AsyncOperationStatus, string> = {
+	"in-progress": "text-utility-blue",
+	completed: "text-utility-green",
+	failed: "text-utility-red",
+	cancelled: "text-utility-yellow",
 };
 
 export type SortField = "created-at" | "last-updated";

--- a/src/components/data-table/data-table.tsx
+++ b/src/components/data-table/data-table.tsx
@@ -1,12 +1,6 @@
 "use no memo";
 
 import * as HSComp from "@health-samurai/react-components";
-import {
-	type ColumnSizingState,
-	getCoreRowModel,
-	type ColumnDef as TSColumnDef,
-	useReactTable,
-} from "@tanstack/react-table";
 import React from "react";
 import { useLocalStorage } from "../../hooks";
 import type { ColumnDef, DataTableProps, SortState } from "./types";
@@ -14,7 +8,7 @@ import type { ColumnDef, DataTableProps, SortState } from "./types";
 const DEFAULT_MIN_SIZE = 60;
 const DEFAULT_MAX_SIZE = 1000;
 const DEFAULT_SIZE = 150;
-const STORAGE_PREFIX = "data-table-sizing:";
+const STORAGE_PREFIX = "data-table-sizing:v2:";
 
 function sortedColumn(
 	sort: SortState | undefined,
@@ -28,21 +22,20 @@ function ColumnHead<T>({
 	column,
 	sort,
 	onSortToggle,
-	style,
+	wrapperStyle,
 	resizeHandle,
 	colId,
 }: {
 	column: ColumnDef<T>;
 	sort: SortState | undefined;
 	onSortToggle: ((column: string) => void) | undefined;
-	style?: React.CSSProperties;
+	wrapperStyle?: React.CSSProperties;
 	resizeHandle?: React.ReactNode;
 	colId?: string;
 }) {
 	const head = (
 		<HSComp.TableHead
 			className={resizeHandle ? "relative" : column.width}
-			style={style}
 			sortable={column.sortable}
 			sorted={sortedColumn(sort, column.id)}
 			data-col-id={colId}
@@ -52,8 +45,10 @@ function ColumnHead<T>({
 					: undefined
 			}
 		>
-			{resizeHandle ? (
-				<span className="block truncate">{column.header}</span>
+			{wrapperStyle ? (
+				<span className="block truncate" style={wrapperStyle}>
+					{column.header}
+				</span>
 			) : (
 				column.header
 			)}
@@ -78,13 +73,11 @@ function ColumnHead<T>({
 }
 
 function ResizeHandle({
-	onMouseDown,
-	onTouchStart,
+	onPointerDown,
 	isResizing,
 	columnId,
 }: {
-	onMouseDown: React.MouseEventHandler;
-	onTouchStart: React.TouchEventHandler;
+	onPointerDown: React.PointerEventHandler;
 	isResizing: boolean;
 	columnId: string;
 }) {
@@ -92,8 +85,7 @@ function ResizeHandle({
 		<button
 			type="button"
 			aria-label={`Resize ${columnId}`}
-			onMouseDown={onMouseDown}
-			onTouchStart={onTouchStart}
+			onPointerDown={onPointerDown}
 			onClick={(e) => e.stopPropagation()}
 			className={`group/resize absolute top-0 h-full w-3 cursor-col-resize select-none touch-none z-10 flex items-center justify-center ${
 				isResizing ? "z-20" : ""
@@ -288,118 +280,78 @@ function ResizableDataTable<T>({
 		);
 
 	const containerRef = React.useRef<HTMLDivElement>(null);
+	const colWidthsRef = React.useRef<Record<string, number>>({});
 
-	const [persistedSizing, setPersistedSizing] =
-		useLocalStorage<ColumnSizingState>({
-			key: `${STORAGE_PREFIX}${tableId ?? "_unkeyed"}`,
-			defaultValue: {},
-		});
-
-	const columnsById = React.useMemo(() => {
-		const map = new Map<string, ColumnDef<T>>();
-		for (const c of columns) map.set(c.id, c);
-		return map;
-	}, [columns]);
-
-	const tsColumns = React.useMemo<TSColumnDef<T>[]>(
-		() =>
-			columns.map((c) => ({
-				id: c.id,
-				size: c.defaultSize ?? DEFAULT_SIZE,
-				minSize: c.minSize ?? DEFAULT_MIN_SIZE,
-				maxSize: c.maxSize ?? DEFAULT_MAX_SIZE,
-				enableResizing: true,
-			})),
-		[columns],
-	);
-
-	const table = useReactTable({
-		data,
-		columns: tsColumns,
-		getCoreRowModel: getCoreRowModel(),
-		columnResizeMode: "onChange",
-		enableColumnResizing: true,
-		state: { columnSizing: persistedSizing },
-		onColumnSizingChange: (updater) => {
-			setPersistedSizing((prev) =>
-				typeof updater === "function" ? updater(prev) : updater,
-			);
-		},
+	const [persistedSizing, setPersistedSizing] = useLocalStorage<
+		Record<string, number>
+	>({
+		key: `${STORAGE_PREFIX}${tableId ?? "_unkeyed"}`,
+		defaultValue: {},
 	});
 
-	const needsMeasure = React.useMemo(
-		() =>
-			columns.filter(
-				(c) => c.defaultSize == null && !(c.id in persistedSizing),
-			),
-		[columns, persistedSizing],
-	);
-	const isMeasuring = needsMeasure.length > 0;
+	const [resizingId, setResizingId] = React.useState<string | null>(null);
 
 	React.useLayoutEffect(() => {
-		if (!isMeasuring) return;
 		const container = containerRef.current;
 		if (!container) return;
 		const ths = container.querySelectorAll<HTMLTableCellElement>(
 			"thead [data-col-id]",
 		);
-		const map = new Map<string, HTMLTableCellElement>();
 		ths.forEach((th) => {
 			const id = th.dataset.colId;
-			if (id) map.set(id, th);
+			if (id) colWidthsRef.current[id] = th.getBoundingClientRect().width;
 		});
-		const updates: ColumnSizingState = {};
-		for (const c of needsMeasure) {
-			const th = map.get(c.id);
-			if (!th) continue;
-			const natural = th.getBoundingClientRect().width;
-			updates[c.id] = Math.min(
-				Math.max(natural, c.minSize ?? DEFAULT_MIN_SIZE),
-				c.maxSize ?? DEFAULT_MAX_SIZE,
-			);
+	});
+
+	const wrapperStyle = (column: ColumnDef<T>): React.CSSProperties => {
+		const fixed = persistedSizing[column.id];
+		if (fixed != null) {
+			return { width: fixed, minWidth: fixed, maxWidth: fixed };
 		}
-		if (Object.keys(updates).length > 0) {
-			setPersistedSizing((prev) => ({ ...prev, ...updates }));
-		}
-	}, [isMeasuring, needsMeasure, setPersistedSizing]);
+		return {
+			minWidth: column.minSize ?? DEFAULT_MIN_SIZE,
+			maxWidth: column.maxSize ?? DEFAULT_MAX_SIZE,
+		};
+	};
 
-	const headerGroup = table.getHeaderGroups()[0];
-	if (!headerGroup) return null;
-
-	const resizingHeader = headerGroup.headers.find((h) =>
-		h.column.getIsResizing(),
-	);
-	const guideLeft =
-		!isMeasuring && resizingHeader
-			? (selectable ? 52 : 0) +
-				resizingHeader.getStart() +
-				resizingHeader.getSize()
-			: null;
-
-	const tableStyle: React.CSSProperties = isMeasuring
-		? { tableLayout: "auto", width: "100%" }
-		: {
-				tableLayout: "fixed",
-				width: "100%",
-				minWidth: table.getCenterTotalSize() + (selectable ? 52 : 0),
-			};
+	const startResize = (column: ColumnDef<T>) => (e: React.PointerEvent) => {
+		e.preventDefault();
+		e.stopPropagation();
+		const startX = e.clientX;
+		const startW =
+			persistedSizing[column.id] ??
+			colWidthsRef.current[column.id] ??
+			DEFAULT_SIZE;
+		const minS = column.minSize ?? DEFAULT_MIN_SIZE;
+		const maxS = column.maxSize ?? DEFAULT_MAX_SIZE;
+		setResizingId(column.id);
+		document.body.style.cursor = "col-resize";
+		document.body.style.userSelect = "none";
+		const onMove = (ev: PointerEvent) => {
+			const w = Math.min(Math.max(startW + (ev.clientX - startX), minS), maxS);
+			setPersistedSizing((prev) => ({ ...prev, [column.id]: w }));
+		};
+		const onUp = () => {
+			document.removeEventListener("pointermove", onMove);
+			document.removeEventListener("pointerup", onUp);
+			document.body.style.cursor = "";
+			document.body.style.userSelect = "";
+			setResizingId(null);
+		};
+		document.addEventListener("pointermove", onMove);
+		document.addEventListener("pointerup", onUp);
+	};
 
 	return (
 		<div
 			ref={containerRef}
 			className="relative [&_div[data-slot=table-container]]:overflow-visible [&_div[data-slot=table-container]]:h-auto"
 		>
-			{guideLeft !== null && (
-				<div
-					className="pointer-events-none absolute top-0 bottom-0 w-0.5 bg-border-link z-30"
-					style={{ left: guideLeft - 1 }}
-				/>
-			)}
 			<HSComp.Table
 				zebra={zebra}
 				stickyHeader
 				className="typo-code"
-				style={tableStyle}
+				style={{ tableLayout: "auto", width: "100%" }}
 			>
 				<HSComp.TableHeader>
 					<HSComp.TableRow className="group/header">
@@ -419,37 +371,24 @@ function ResizableDataTable<T>({
 								/>
 							</HSComp.TableHead>
 						)}
-						{headerGroup.headers.map((header) => {
-							const column = columnsById.get(header.column.id);
-							if (!column) return null;
-							const isLast =
-								header.column.getIndex() === headerGroup.headers.length - 1;
-							const headStyle: React.CSSProperties | undefined = isMeasuring
-								? { maxWidth: column.maxSize ?? DEFAULT_MAX_SIZE }
-								: isLast
-									? undefined
-									: { width: header.getSize() };
-							return (
-								<ColumnHead
-									key={column.id}
-									column={column}
-									sort={sort}
-									onSortToggle={onSortToggle}
-									style={headStyle}
-									colId={column.id}
-									resizeHandle={
-										isMeasuring || isLast ? null : (
-											<ResizeHandle
-												columnId={column.id}
-												onMouseDown={header.getResizeHandler()}
-												onTouchStart={header.getResizeHandler()}
-												isResizing={header.column.getIsResizing()}
-											/>
-										)
-									}
-								/>
-							);
-						})}
+						{columns.map((column) => (
+							<ColumnHead
+								key={column.id}
+								column={column}
+								sort={sort}
+								onSortToggle={onSortToggle}
+								colId={column.id}
+								wrapperStyle={wrapperStyle(column)}
+								resizeHandle={
+									<ResizeHandle
+										columnId={column.id}
+										isResizing={resizingId === column.id}
+										onPointerDown={startResize(column)}
+									/>
+								}
+							/>
+						))}
+						<HSComp.TableHead aria-hidden style={{ width: "100%" }} />
 					</HSComp.TableRow>
 				</HSComp.TableHeader>
 				<HSComp.TableBody
@@ -476,25 +415,17 @@ function ResizableDataTable<T>({
 										/>
 									</HSComp.TableCell>
 								)}
-								{headerGroup.headers.map((header, idx) => {
-									const column = columnsById.get(header.column.id);
-									if (!column) return null;
-									const isLast = idx === headerGroup.headers.length - 1;
-									const cellStyle: React.CSSProperties | undefined = isMeasuring
-										? { maxWidth: column.maxSize ?? DEFAULT_MAX_SIZE }
-										: isLast
-											? undefined
-											: { width: header.getSize() };
-									return (
-										<HSComp.TableCell
-											key={column.id}
-											className={`${column.className ?? ""} truncate`}
-											style={cellStyle}
-										>
+								{columns.map((column) => (
+									<HSComp.TableCell
+										key={column.id}
+										className={column.className}
+									>
+										<div className="truncate" style={wrapperStyle(column)}>
 											{column.cell(row)}
-										</HSComp.TableCell>
-									);
-								})}
+										</div>
+									</HSComp.TableCell>
+								))}
+								<HSComp.TableCell aria-hidden />
 							</HSComp.TableRow>
 						);
 					})}

--- a/src/components/data-table/data-table.tsx
+++ b/src/components/data-table/data-table.tsx
@@ -269,6 +269,7 @@ function ResizableDataTable<T>({
 	tableId,
 	zebra = true,
 	noRowHover,
+	renderExpandedRow,
 }: DataTableProps<T>) {
 	const { allSelected, someSelected, toggleAll, toggleOne } =
 		useSelectionHelpers(
@@ -290,6 +291,32 @@ function ResizableDataTable<T>({
 	});
 
 	const [resizingId, setResizingId] = React.useState<string | null>(null);
+	const [expandedKeys, setExpandedKeys] = React.useState<Set<string>>(
+		() => new Set(),
+	);
+	const toggleRow = (id: string) =>
+		setExpandedKeys((prev) => {
+			const next = new Set(prev);
+			if (next.has(id)) next.delete(id);
+			else next.add(id);
+			return next;
+		});
+	const expandable = !!renderExpandedRow;
+	const expandColSpan = columns.length + (selectable ? 1 : 0) + 1;
+	const [expandedWidth, setExpandedWidth] = React.useState<number | undefined>(
+		undefined,
+	);
+
+	React.useLayoutEffect(() => {
+		if (!expandable) return;
+		const scroller = containerRef.current?.parentElement;
+		if (!scroller) return;
+		const update = () => setExpandedWidth(scroller.clientWidth);
+		update();
+		const ro = new ResizeObserver(update);
+		ro.observe(scroller);
+		return () => ro.disconnect();
+	}, [expandable]);
 
 	React.useLayoutEffect(() => {
 		const container = containerRef.current;
@@ -397,36 +424,55 @@ function ResizableDataTable<T>({
 					{data.map((row, index) => {
 						const id = rowKey(row, index);
 						const isSelected = selectedIds?.has(id) ?? false;
+						const isExpanded = expandable && expandedKeys.has(id);
 						return (
-							<HSComp.TableRow
-								key={id || index}
-								zebra={zebra}
-								index={index}
-								selected={isSelected}
-							>
-								{selectable && (
-									<HSComp.TableCell style={{ width: 52 }}>
-										<HSComp.Checkbox
-											size="small"
-											className="border-border-primary"
-											checked={isSelected}
-											onCheckedChange={() => toggleOne(id)}
-											aria-label={`Select ${id}`}
-										/>
-									</HSComp.TableCell>
-								)}
-								{columns.map((column) => (
-									<HSComp.TableCell
-										key={column.id}
-										className={column.className}
-									>
-										<div className="truncate" style={wrapperStyle(column)}>
-											{column.cell(row)}
-										</div>
-									</HSComp.TableCell>
-								))}
-								<HSComp.TableCell aria-hidden />
-							</HSComp.TableRow>
+							<React.Fragment key={id || index}>
+								<HSComp.TableRow
+									zebra={zebra}
+									index={index}
+									selected={isSelected}
+									className={expandable ? "cursor-pointer" : undefined}
+									onClick={expandable ? () => toggleRow(id) : undefined}
+								>
+									{selectable && (
+										<HSComp.TableCell
+											style={{ width: 52 }}
+											onClick={(e) => e.stopPropagation()}
+										>
+											<HSComp.Checkbox
+												size="small"
+												className="border-border-primary"
+												checked={isSelected}
+												onCheckedChange={() => toggleOne(id)}
+												aria-label={`Select ${id}`}
+											/>
+										</HSComp.TableCell>
+									)}
+									{columns.map((column) => (
+										<HSComp.TableCell
+											key={column.id}
+											className={column.className}
+										>
+											<div className="truncate" style={wrapperStyle(column)}>
+												{column.cell(row)}
+											</div>
+										</HSComp.TableCell>
+									))}
+									<HSComp.TableCell aria-hidden />
+								</HSComp.TableRow>
+								{isExpanded && renderExpandedRow ? (
+									<HSComp.TableRow className="hover:bg-transparent!">
+										<HSComp.TableCell colSpan={expandColSpan} className="p-0">
+											<div
+												className="sticky left-0"
+												style={{ width: expandedWidth }}
+											>
+												{renderExpandedRow(row)}
+											</div>
+										</HSComp.TableCell>
+									</HSComp.TableRow>
+								) : null}
+							</React.Fragment>
 						);
 					})}
 				</HSComp.TableBody>

--- a/src/components/data-table/types.ts
+++ b/src/components/data-table/types.ts
@@ -50,6 +50,7 @@ export type DataTableProps<T> = {
 	tableId?: string;
 	zebra?: boolean;
 	noRowHover?: boolean;
+	renderExpandedRow?: (row: T) => React.ReactNode;
 };
 
 export type DataTableFooterProps = {

--- a/src/routes/async-operations.$operationId.tsx
+++ b/src/routes/async-operations.$operationId.tsx
@@ -3,6 +3,7 @@ import { AsyncOperationDetail } from "../components/AsyncOperations/detail";
 
 export const Route = createFileRoute("/async-operations/$operationId")({
 	component: RouteComponent,
+	loader: (cx) => ({ breadCrumb: cx.params.operationId }),
 });
 
 function RouteComponent() {

--- a/src/routes/async-operations.index.tsx
+++ b/src/routes/async-operations.index.tsx
@@ -1,6 +1,17 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { AsyncOperationsPage } from "../components/AsyncOperations/page";
+import type { AsyncOperationStatus } from "../components/AsyncOperations/types";
 
 export const Route = createFileRoute("/async-operations/")({
 	component: AsyncOperationsPage,
+	validateSearch: (search) => {
+		const res: { status?: AsyncOperationStatus | "all"; task?: string } = {};
+		if (typeof search.status === "string") {
+			res.status = search.status as AsyncOperationStatus | "all";
+		}
+		if (typeof search.task === "string") {
+			res.task = search.task;
+		}
+		return res;
+	},
 });


### PR DESCRIPTION
UI polish for the Async Operations screens.

## List screen
- white header; removed Refresh button and operation counter
- `count=5000`, Status column moved 2nd, raw ISO timestamps
- native fit-content DataTable (`table-layout:auto` + pointer resize, fixed localStorage sizing)
- Status filter (placeholder, colored menu items), Task dropdown (combobox + clear button), filter state in URL
- Tasks tooltip with per-status counts

## Detail screen
- breadcrumb via route `loader` instead of in-page crumbs
- header toolbar with **Terminate** action (`ConfirmDialog`, not native confirm)
- badge header: status, task name, metrics (duration, total, succeeded, created, updated)
- tasks rendered via resizable `DataTable` with sorting and expandable rows
- expanded row: Input/Output JSON in resizable `CodeEditor` panels
- Status column with icons (Succeeded / Failed / Running)
- columns for all task fields; `cancel-marker` sentinel filtered out
- raw ISO timestamps

## DataTable (shared)
- `renderExpandedRow` prop for toggle rows (sticky wrapper constrained to viewport width)
- `StatusBadge`: dropped fixed `w-24` width